### PR TITLE
test(swap): the swaps arkade.money makes, end to end against solverd

### DIFF
--- a/packages/swap/.env.regtest
+++ b/packages/swap/.env.regtest
@@ -4,7 +4,11 @@
 ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.14
 ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 
-ARKD_VTXO_TREE_EXPIRY=20
+# 240 blocks: the solverd suite chains every spend to the previous one's
+# preconfirmed output, and arkd expires a preconfirmed vtxo with its OLDEST
+# input, so a lineage born in the setup's early rounds dies 20 blocks on — mid
+# suite on a slow runner. 240 keeps block denomination past any suite's tip.
+ARKD_VTXO_TREE_EXPIRY=240
 ARKD_BOARDING_EXIT_DELAY=40
 ARKD_CHECKPOINT_EXIT_DELAY=20
 ARKD_UNILATERAL_EXIT_DELAY=20

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -88,7 +88,8 @@ funds an offer should keep cancelling within reach.
 4. **`restore`** — `restoreAssetSwaps` rebuilds lost records by scanning sent virtual txs for
    offer packets and binding each funding vtxo to its spend. Incremental: answered txids are
    remembered in the repository (`getScannedTxids`/`markTxidsScanned`) so nothing is fetched
-   twice.
+   twice. With `cover`, a restored deposit still at its covenant is registered with the wallet
+   again — see "After a restore" below.
 5. **`watch`** — `watchOfferSwaps` drives swap status from the wallet's own contract events, so a
    fill shows up without re-running a scan. Registration is what makes it possible: only a
    registered covenant is watched. See "Live status" below.
@@ -213,6 +214,28 @@ await wallet.send({
 });
 ```
 
+### Swap all
+
+The deposit a "Max" control prefills has to be an amount `wallet.send` accepts as-is, and for BTC
+that is `WalletBalance.maxSendable`, not `available`. Every asset the wallet receives — a fill's
+payout included — arrives on a dust carrier that `available` counts, and a send of the whole
+balance leaves the asset change with no output at or above dust to ride on, so `send` refuses it.
+`maxSendable` is `available` less one dust carrier whenever a spendable coin carries an asset, and
+equal to it otherwise. Quote with it, validate with it, fund with it:
+
+```ts
+const { maxSendable, availableAssets } = await wallet.getBalance();
+
+// swap all BTC
+const plan = await quoteOffer(market, { give, giveAmount: BigInt(maxSendable), ...QUOTE_OPTIONS });
+validatePlan(plan, BigInt(maxSendable), dust); // undefined = fundable
+await wallet.send({ address: o.address, amount: maxSendable, extensions: [o.extension] });
+
+// swap all of an asset: the whole balance goes, and the carrier it rode on goes with it
+const held = availableAssets.find((a) => a.assetId === assetId)!.amount;
+validatePlan(await quoteOffer(market, { give, giveAmount: held, ...QUOTE_OPTIONS }), held, dust);
+```
+
 The covenant co-signer ("emulator") key defaults to the SDK's per-network pin, resolved from the
 network the Ark server reports — never fetched from the emulator itself. Pass
 `params.emulatorPubkey` (33-byte compressed hex, the same contract as `Arkade.connect`'s option)
@@ -256,6 +279,31 @@ guess: a stored swap is skipped by every later scan, so a guess here would be pe
 
 `onUpdate` is a notification for UI reactivity, not a second store; every write goes through the
 repository.
+
+### After a restore
+
+A record `restoreAssetSwaps` rebuilds has no registration behind it: the deposit is on chain and
+the record is back, but nothing has told the wallet the script is its own. Left that way the
+deposit is neither gated nor counted, and a later fill is never noticed — the watcher only hears
+registered scripts, and the scan never revisits a funding txid it has answered. Two things close
+that gap:
+
+```ts
+// registers the covenant of every restored deposit still at its script, before returning
+const { restored } = await restoreAssetSwaps(indexer, txs, existing, {
+    serverPubkey,
+    cover: { wallet, arkServerUrl: ARK },
+});
+```
+
+and `watchOfferSwaps` itself, which on start registers the covenant of every live record in the
+repository (`pending`, `cancelling`, `recoverable`) — a no-op for offers this wallet created, and
+the missing registration for records restored without `cover` — and then reads each covered
+deposit off the indexer once: a spend that landed while the script was uncovered never becomes an
+event, and that one read is what classifies it. Both registrations are `ensureOfferContracts`,
+exported for a consumer that needs to run it on its own schedule. Registration is idempotent and
+best effort: a record that could not be covered is logged and tried again at the watcher's next
+start — the scan will not come back to it, since its funding txid is already answered.
 
 ## Cancelling: the refund path
 

--- a/packages/swap/src/coverage.ts
+++ b/packages/swap/src/coverage.ts
@@ -113,6 +113,26 @@ export async function promoteOfferContract(
 }
 
 /**
+ * Put `script` in the watched set for a deposit that has already landed — a
+ * record rebuilt by the restore scan, or one found unwatched at watcher start.
+ *
+ * {@link promoteOfferContract} without the issuance mark: the mark says "an
+ * address is out and waiting for its deposit", and here the deposit is the
+ * record itself. Marking it anyway would pin the script watched for the life
+ * of the process, because no record at the script can ever postdate a mark
+ * set after its funding — `addressOutstanding` would never clear.
+ *
+ * Throws like promotion does: nothing is at stake in the write, and a record
+ * left uncovered is what the caller must know about.
+ */
+export async function coverOfferContract(
+    manager: OfferContractRetirer,
+    script: string,
+): Promise<void> {
+    await serialize(script, () => manager.setContractWatchState(script, "watched"));
+}
+
+/**
  * Drop `script` from the watched set unless something there still needs it.
  * Identical offers share one script, so the check is per script, not per record.
  *

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -1,6 +1,7 @@
 export {
     createOffer,
     cancelOffer,
+    ensureOfferContracts,
     encodeOffer,
     decodeOffer,
     offerVtxoScript,

--- a/packages/swap/src/markets.ts
+++ b/packages/swap/src/markets.ts
@@ -226,7 +226,18 @@ export type PlanError =
     | "above-max"
     | "below-dust";
 
-/** Validate a plan against the user's balance and the server dust limit. */
+/**
+ * Validate a plan against the user's balance and the server dust limit.
+ *
+ * `giveBalance` is the ceiling on the deposit, so pass what a send can move,
+ * not what the wallet owns. For a BTC deposit that is the wallet's
+ * `WalletBalance.maxSendable`, not `available`: the two differ by one dust
+ * carrier once the wallet holds an asset, and a plan validated against
+ * `available` is refused by `send` at the whole-balance edge — the "swap
+ * all" of every wallet that has ever received an asset. For an asset deposit
+ * it is the asset's `availableAssets` entry: an asset can leave whole, since
+ * sending it frees the carrier it rode on.
+ */
 export const validatePlan = (
     plan: OfferPlan,
     giveBalance: bigint,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -40,7 +40,7 @@ import {
 
 import wantAssetProgram from "./swap-want-asset.program.json";
 import wantBtcProgram from "./swap-want-btc.program.json";
-import { promoteOfferContract, retireOfferContract } from "./coverage";
+import { coverOfferContract, promoteOfferContract, retireOfferContract } from "./coverage";
 import type { AssetSwapRepository } from "./repository";
 import { getAssetSwapsOrThrow, updateAssetSwap, updateAssetSwapBestEffort } from "./store";
 
@@ -469,6 +469,13 @@ export const OFFER_CONTRACT_KIND = "asset-swap-offer";
  * this states is the one the corridor needs: an offer address handed to a user
  * is a watched address, and {@link promoteOfferContract} is what keeps a
  * settlement racing this call from taking it back.
+ *
+ * `deposit` says which side of that invariant is being restored. `"issued"`
+ * is `createOffer`: an address is going out and nothing is funded yet, so the
+ * script is promoted with the issuance mark. `"landed"` is a deposit that is
+ * already there — a record the restore scan rebuilt, or one the watcher found
+ * uncovered — and takes {@link coverOfferContract}, which sets no mark: a mark
+ * set after the funding could never be cleared by it.
  */
 async function registerOfferContract(
     wallet: IWallet,
@@ -477,6 +484,7 @@ async function registerOfferContract(
     binding: Omit<Offer, "swapPkScript">,
     serverPubkey: Uint8Array,
     expectedPkScript: Uint8Array,
+    deposit: "issued" | "landed",
 ): Promise<void> {
     const { program, args, keys } = swapProgramBinding(binding, serverPubkey);
     const contractManager = await wallet.getContractManager();
@@ -501,7 +509,83 @@ async function registerOfferContract(
         label: OFFER_CONTRACT_LABEL,
         metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
     });
-    await promoteOfferContract(contractManager, hex.encode(expectedPkScript));
+    const script = hex.encode(expectedPkScript);
+    if (deposit === "issued") await promoteOfferContract(contractManager, script);
+    else await coverOfferContract(contractManager, script);
+}
+
+/**
+ * Register and watch the covenants of offers this wallet did not create in
+ * this store: records the restore scan rebuilt, or records found uncovered
+ * when the watcher starts.
+ *
+ * `createOffer` registers before it hands out an address, so an offer made
+ * here is watched from the moment its deposit lands. A restored record has no
+ * such moment: the deposit is on chain, the record is back, and nothing has
+ * told the wallet the script is its own. Left that way the deposit is not
+ * gated, not counted, and — the part a user sees — a fill is never noticed:
+ * {@link watchOfferSwaps} only hears about registered scripts, and the restore
+ * scan skips a funding txid it has already answered. This is the missing
+ * registration, done the way `createOffer` does it (same row, same escrow
+ * marker), minus the issuance mark.
+ *
+ * Idempotent: `createContract` is first-writer-wins and the watch state is a
+ * set. Safe to run on every watcher start.
+ *
+ * `swapAddress`, when the record has one, pins the server key the covenant
+ * was funded against; without it `opts.serverPubkey` is used — the key a
+ * restore scan classified the records with — and failing that the server's
+ * current key. An offer whose covenant rebuilds under none of them (a signer
+ * rotation since funding) is refused by name rather than registered at a
+ * script it never had. The refusal is per offer: the rest are still
+ * registered, and the error names every one that was not.
+ */
+export async function ensureOfferContracts(
+    wallet: IWallet,
+    arkServerUrl: string,
+    offers: readonly { offerHex: string; swapAddress?: string }[],
+    opts: { serverPubkey?: Uint8Array } = {},
+): Promise<void> {
+    if (offers.length === 0) return;
+    const info = await new RestArkProvider(arkServerUrl).getInfo();
+    const currentServerKey = opts.serverPubkey ?? hex.decode(toXOnlySignerHex(info.signerPubkey));
+    const network = info.network as NetworkName;
+
+    const failures: string[] = [];
+    for (const { offerHex, swapAddress } of offers) {
+        try {
+            const { swapPkScript, ...binding } = decodeOffer(hex.decode(offerHex));
+            const serverPubkey = swapAddress
+                ? ArkAddress.decode(swapAddress).serverPubKey
+                : currentServerKey;
+            const rebuilt = offerVtxoScript(binding, serverPubkey).pkScript;
+            if (hex.encode(rebuilt) !== hex.encode(swapPkScript)) {
+                throw new Error(
+                    "rebuilt covenant does not match the offer's swapPkScript — the server " +
+                        "signing key has likely rotated since funding; pass swapAddress (the " +
+                        "funded address) to pin the original key",
+                );
+            }
+            await registerOfferContract(
+                wallet,
+                arkServerUrl,
+                network,
+                binding,
+                serverPubkey,
+                swapPkScript,
+                "landed",
+            );
+        } catch (err) {
+            // the TLV opens with the swap script, so its first bytes are enough
+            // of a handle to find the record this names
+            failures.push(`offer ${offerHex.slice(0, 22)}…: ${(err as Error).message}`);
+        }
+    }
+    if (failures.length > 0) {
+        throw new Error(
+            `could not register ${failures.length} offer covenant(s): ${failures.join("; ")}`,
+        );
+    }
 }
 
 // ── User operations ─────────────────────────────────────────────────────────
@@ -637,6 +721,7 @@ export async function createOffer(
         binding,
         serverPubKey,
         script.pkScript,
+        "issued",
     );
 
     const payload = encodeOffer(offer);

--- a/packages/swap/src/payment/crossAsset.ts
+++ b/packages/swap/src/payment/crossAsset.ts
@@ -48,6 +48,8 @@ export interface CrossAssetRailDeps {
      *  `discoverMarkets`, not a bare registry fetch. */
     discover(): Promise<DiscoveredMarket[]>;
     quote(market: DiscoveredMarket, give: Side, wantAmount: bigint): Promise<OfferPlan>;
+    /** The ceiling on the deposit: the wallet's `maxSendable`, not its
+     *  `available` — see {@link validatePlan}. */
     btcBalance(): Promise<bigint>;
     dust(): Promise<bigint>;
     /** Before every irreversible step and once after the last. See

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -443,5 +443,10 @@ export async function restoreAssetSwaps(
  * Statuses under which a restored deposit still sits at its covenant, and so
  * is the wallet's to watch. `recoverable` too: a swept deposit is still the
  * user's money at that script (see `RETIRABLE` in coverage.ts).
+ *
+ * `cancelling` is deliberately absent: the restore scan classifies by chain
+ * state and never produces a `cancelling` record — only `NEEDS_COVERAGE` in
+ * watch.ts has it, and only because a cancel in flight may still be resolved
+ * by a spend the watcher later hears about.
  */
 const LIVE_DEPOSIT: readonly AssetSwapStatus[] = ["pending", "recoverable"];

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -18,8 +18,15 @@ import {
     RestIndexerProvider,
     Transaction,
     scriptFromTapLeafScript,
+    type IWallet,
 } from "@arkade-os/sdk";
-import { decodeOffer, Offer, OFFER_PACKET_TYPE, offerVtxoScript } from "./offer";
+import {
+    decodeOffer,
+    ensureOfferContracts,
+    Offer,
+    OFFER_PACKET_TYPE,
+    offerVtxoScript,
+} from "./offer";
 import { BTC_ASSET_ID, type AssetSwap, type AssetSwapStatus } from "./store";
 
 // ponytail: fixed request size; tune only if histories outgrow it
@@ -240,14 +247,35 @@ export function classifyDepositSpend(
  * `serverPubkey` must be the server key the covenants were funded against; a
  * key that has rotated since makes every affected swap unclassifiable rather
  * than misclassified.
+ *
+ * ## A restored deposit is the wallet's to watch again
+ *
+ * Pass `cover` and every record restored with its deposit still at the
+ * covenant — `pending`, or `recoverable` — has that covenant registered with
+ * the wallet before it is returned, exactly as `createOffer` registers it
+ * ({@link ensureOfferContracts}). Without it the record is back but the
+ * deposit is not: not gated, not counted, and a later fill goes unnoticed,
+ * because {@link watchOfferSwaps} only hears about registered scripts and this
+ * scan never revisits a funding txid it has answered. The scan itself does not
+ * need a wallet, which is why this is an option rather than a parameter.
+ *
+ * Best effort, and never a reason to lose the record: a registration that
+ * fails is logged and the record is still returned — the scan will not come
+ * back to it (its txid is answered), but {@link watchOfferSwaps} covers every
+ * live record at its next start and reconciles it against the chain then.
  */
 export async function restoreAssetSwaps(
     indexer: RestoreIndexer,
     txs: Tx[],
     existingIds: ReadonlySet<string>,
-    opts: { serverPubkey: Uint8Array; scanned?: ReadonlySet<string> },
+    opts: {
+        serverPubkey: Uint8Array;
+        scanned?: ReadonlySet<string>;
+        /** The wallet to register live restored covenants with. */
+        cover?: { wallet: IWallet; arkServerUrl: string };
+    },
 ): Promise<{ restored: AssetSwap[]; scannedTxids: string[] }> {
-    const { serverPubkey, scanned = new Set<string>() } = opts;
+    const { serverPubkey, scanned = new Set<string>(), cover } = opts;
     const candidates = unscannedSwapCandidates(txs, existingIds, scanned);
     if (candidates.length === 0) return { restored: [], scannedTxids: [] };
 
@@ -397,5 +425,23 @@ export async function restoreAssetSwaps(
                 : {}),
         });
     }
+    if (cover) {
+        const live = restored.filter((swap) => LIVE_DEPOSIT.includes(swap.status));
+        try {
+            // the key the records were classified with: a restored record has
+            // no swapAddress to pin it, and the current key is wrong after a
+            // rotation
+            await ensureOfferContracts(cover.wallet, cover.arkServerUrl, live, { serverPubkey });
+        } catch (err) {
+            console.warn("[swap] could not re-register every restored offer covenant", err);
+        }
+    }
     return { restored, scannedTxids: fetchedTxids.filter((id) => !unresolved.has(id)) };
 }
+
+/**
+ * Statuses under which a restored deposit still sits at its covenant, and so
+ * is the wallet's to watch. `recoverable` too: a swept deposit is still the
+ * user's money at that script (see `RETIRABLE` in coverage.ts).
+ */
+const LIVE_DEPOSIT: readonly AssetSwapStatus[] = ["pending", "recoverable"];

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -15,7 +15,7 @@
  * txid is the one `cancelOffer` recorded is a cancel, and anything else that
  * spends an offer deposit is a fill. The fallback, for a cancel this device did
  * not make (another device, or a wiped store), reads the covenant leaf off the
- * spending transaction ({@link classifySpend}).
+ * spending transaction ({@link classifyDepositSpend}).
  *
  * What this deliberately does not do:
  *
@@ -30,6 +30,12 @@
  * - **Keep watching a script it has finished with.** A persisted terminal
  *   status retires the contract to `retained`, once nothing at that script
  *   still needs coverage ({@link retireOfferContract}).
+ *
+ * Layout: the public surface comes first — {@link spendUpdate}, the pure
+ * transition, then {@link watchOfferSwaps}, which reads as the sequence it
+ * performs. Everything below it is module-private machinery, taking the
+ * watcher's dependencies as an explicit {@link WatchContext} rather than
+ * closing over them.
  */
 import { base64, hex } from "@scure/base";
 import {
@@ -38,9 +44,10 @@ import {
     RestIndexerProvider,
     Transaction,
     type ContractVtxoEvent,
+    type IContractManager,
     type IWallet,
 } from "@arkade-os/sdk";
-import { RETIRABLE, retireOfferContract } from "./coverage";
+import { RETIRABLE, retireOfferContract, type OfferContractRetirer } from "./coverage";
 import { decodeOffer, ensureOfferContracts, OFFER_CONTRACT_KIND } from "./offer";
 import type { AssetSwapRepository } from "./repository";
 import { classifyDepositSpend, spendTxidsOf, type RestoreIndexer, type SpendKind } from "./restore";
@@ -64,6 +71,23 @@ const TERMINAL: readonly AssetSwapStatus[] = ["fulfilled", "cancelled", "recover
  */
 const NEEDS_COVERAGE: readonly AssetSwapStatus[] = ["pending", "cancelling", "recoverable"];
 
+/** A running watcher. `idle()` exists because the writes are async: shutdown
+ * and tests both need to know when in-flight updates have settled. */
+export interface OfferSwapWatcher {
+    stop(): void;
+    idle(): Promise<void>;
+}
+
+export interface WatchOfferSwapsParams {
+    wallet: IWallet;
+    /** Same URL `createOffer`/`cancelOffer` take; used to read a spending tx
+     * when the exact classifier cannot answer. */
+    arkServerUrl: string;
+    repository: AssetSwapRepository;
+    /** Called after a change is persisted. A notification, not a store. */
+    onUpdate?: (swap: AssetSwap) => void;
+}
+
 /**
  * The record change a classified spend implies, or `undefined` when it implies
  * none — an already-resolved swap, or a spend nobody could classify.
@@ -86,23 +110,6 @@ export function spendUpdate(
         // mirrors restore.ts: a completion time is a fill's, not a cancel's
         ...(status === "fulfilled" && spend.at ? { completedAt: spend.at } : {}),
     };
-}
-
-/** A running watcher. `idle()` exists because the writes are async: shutdown
- * and tests both need to know when in-flight updates have settled. */
-export interface OfferSwapWatcher {
-    stop(): void;
-    idle(): Promise<void>;
-}
-
-export interface WatchOfferSwapsParams {
-    wallet: IWallet;
-    /** Same URL `createOffer`/`cancelOffer` take; used to read a spending tx
-     * when the exact classifier cannot answer. */
-    arkServerUrl: string;
-    repository: AssetSwapRepository;
-    /** Called after a change is persisted. A notification, not a store. */
-    onUpdate?: (swap: AssetSwap) => void;
 }
 
 /**
@@ -137,11 +144,16 @@ export async function watchOfferSwaps({
     onUpdate,
 }: WatchOfferSwapsParams): Promise<OfferSwapWatcher> {
     const manager = await wallet.getContractManager();
-    // Current server key at watcher start. TODO: persist the funding-time key
-    // with swap records; a signer rotation during a long session makes leaf
-    // classification return indeterminate rather than guessing.
-    const serverPubkey = ArkAddress.decode(await wallet.getAddress()).serverPubKey;
-    const indexer: RestoreIndexer = new RestIndexerProvider(arkServerUrl);
+    const context: WatchContext = {
+        manager,
+        indexer: new RestIndexerProvider(arkServerUrl),
+        repository,
+        // Current server key at watcher start. TODO: persist the funding-time
+        // key with swap records; a signer rotation during a long session makes
+        // leaf classification return indeterminate rather than guessing.
+        serverPubkey: ArkAddress.decode(await wallet.getAddress()).serverPubKey,
+        onUpdate,
+    };
 
     // events arrive independently but the update is read-modify-write over
     // the whole list, so two concurrent handlers would lose one of the writes
@@ -153,119 +165,69 @@ export async function watchOfferSwaps({
         });
     };
 
-    /** The two halves of a spend, as an event or the indexer reports them. */
-    type SpentDeposit = { txid: string; vout: number; arkTxId?: string; spentBy?: string };
-
-    const classify = async (swap: AssetSwap, vtxo: SpentDeposit, spentTxid: string) => {
-        // the exact answer: only the user can cancel, and cancelOffer records
-        // the txid it submitted
-        if (swap.spentTxid === spentTxid && swap.status === "cancelling") return "cancelled";
-        try {
-            // both halves of the spend: the checkpoint carries the deposit
-            // outpoint, the ark tx is the id the record and history name
-            const candidates = spendTxidsOf(vtxo);
-            if (candidates.length === 0) return "indeterminate";
-            const { txs } = await indexer.getVirtualTxs(candidates);
-            return classifyDepositSpend(
-                decodeOffer(hex.decode(swap.offerHex)),
-                serverPubkey,
-                txs.map((psbt) => Transaction.fromPSBT(base64.decode(psbt))),
-                { txid: vtxo.txid, vout: vtxo.vout },
-            );
-        } catch {
-            return "indeterminate" as const;
-        }
-    };
-
-    /**
-     * What a classified spend does to its record: written, announced, and the
-     * script retired once nothing live is left at it. One path for a spend an
-     * event delivers and for one the start-up reconcile finds on the indexer.
-     */
-    const resolveSpend = async (
-        swap: AssetSwap,
-        vtxo: SpentDeposit,
-        spentTxid: string,
-        at?: number,
-    ) => {
-        const kind: SpendKind = await classify(swap, vtxo, spentTxid);
-        const changes = spendUpdate(swap, { txid: spentTxid, kind, at });
-        if (!changes) return;
-
-        // notify only on a write that landed: `onUpdate` is documented as
-        // firing after the change is persisted, and a consumer that caches
-        // from it would otherwise run ahead of the store
-        const { persisted, swaps } = await updateAssetSwapBestEffort(repository, swap.id, changes);
-        // a lost write must not retire: the next restore scan still
-        // believes this deposit is live
-        if (!persisted) return;
-        onUpdate?.({ ...swap, ...changes });
-        // `swaps` is the post-update view, so the liveness check sees this
-        // record's new status without a third read
-        if (changes.status && RETIRABLE.includes(changes.status)) {
-            await retireOfferContract(manager, swaps, swap.swapPkScript);
-        }
-    };
-
-    const handleSpend = async (event: Extract<ContractVtxoEvent, { type: "vtxo_spent" }>) => {
-        if (event.contract.metadata?.kind !== OFFER_CONTRACT_KIND) return;
-
-        for (const vtxo of event.vtxos) {
-            const spentTxid = vtxo.arkTxId || vtxo.spentBy;
-            if (!spentTxid) continue;
-            // Identical offers share one script and are told apart by the
-            // deposit that funded them. Repository v1 has no indexed lookup, so
-            // this is O(history) per spend event; add a query API if offer
-            // event volume makes this hot.
-            const swap = (await getAssetSwaps(repository)).find(
-                (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === event.contractScript,
-            );
-            if (!swap) continue;
-            await resolveSpend(swap, vtxo, spentTxid, event.timestamp);
-        }
-    };
-
-    /**
-     * The fate of a deposit the sweep just covered, read off the indexer. A
-     * spend that happened while the script was uncovered never becomes an
-     * event: this is the one read that catches it. A deposit not indexed yet
-     * is left alone — its event will come, or the next start will look again.
-     */
-    const reconcile = async (swap: AssetSwap) => {
-        const { vtxos } = await indexer.getVtxos({ scripts: [swap.swapPkScript] });
-        const vtxo = vtxos.find((v) => v.txid === swap.fundingTxid);
-        if (!vtxo) return;
-        if (vtxo.virtualStatus.state === "swept") {
-            // mirrors restore.ts: a swept deposit is still the user's money at
-            // that script, so it keeps its script watched and is never retired
-            if (swap.status === "recoverable") return;
-            const changes = { status: "recoverable" as const };
-            const { persisted } = await updateAssetSwapBestEffort(repository, swap.id, changes);
-            if (persisted) onUpdate?.({ ...swap, ...changes });
-            return;
-        }
-        if (vtxo.virtualStatus.state !== "spent") return;
-        const spentTxid = vtxo.arkTxId || vtxo.spentBy;
-        if (!spentTxid) return;
-        // No timestamp available on this path: the indexer VTXO only carries
-        // `createdAt` (its own creation), not the spend's time. A reload caught
-        // here is persisted without `completedAt`; the consumer re-queries the
-        // spending transaction if it needs the fill time.
-        await resolveSpend(swap, vtxo, spentTxid);
-    };
-
     const unsubscribe = manager.onContractEvent((event) => {
         // An offer is an owned contract; a watched script has no `metadata`.
         if (!isContractVtxoEvent(event) || event.type !== "vtxo_spent") return;
-        enqueue(() => handleSpend(event));
+        enqueue(() => handleSpendEvent(context, event));
     });
 
     // After subscribing, never before: registration is what starts the
     // manager's own watch on a script, and an event it delivers during the
     // sweep must find a handler already attached.
-    const uncovered = (await getAssetSwaps(repository)).filter(
+    const uncovered = await liveOfferRecords(repository);
+    await coverLiveOffers(wallet, arkServerUrl, uncovered);
+    // Through the queue, like an event: a spend delivered mid-sweep and the
+    // reconcile of the same deposit must not write over each other. Not
+    // awaited — `idle()` is how a caller waits for it — so a slow indexer
+    // delays the reconcile, never the watcher.
+    for (const swap of uncovered) enqueue(() => reconcileQuietly(context, swap));
+    enqueue(() => retireUntouchedScripts(context, uncovered));
+
+    return {
+        stop: unsubscribe,
+        idle: () => queue,
+    };
+}
+
+// ── internals ────────────────────────────────────────────────────────────────
+
+/** The two halves of a spend, as an event or the indexer reports them. */
+type SpentDeposit = { txid: string; vout: number; arkTxId?: string; spentBy?: string };
+
+/** The contract-manager surface the helpers below use, and no more. */
+type OfferWatchManager = OfferContractRetirer & Pick<IContractManager, "getContracts">;
+
+/**
+ * What a running watcher hands its helpers: the dependencies they read, passed
+ * rather than closed over, so each step below is callable — and testable — on
+ * its own.
+ */
+interface WatchContext {
+    manager: OfferWatchManager;
+    indexer: RestoreIndexer;
+    repository: AssetSwapRepository;
+    /** Server key as of watcher start; the leaf classifier rebuilds against it. */
+    serverPubkey: Uint8Array;
+    onUpdate?: (swap: AssetSwap) => void;
+}
+
+/** The records whose covenant may still hold a deposit, so still need coverage. */
+async function liveOfferRecords(repository: AssetSwapRepository): Promise<AssetSwap[]> {
+    return (await getAssetSwaps(repository)).filter(
         (swap) => typeof swap.offerHex === "string" && NEEDS_COVERAGE.includes(swap.status),
     );
+}
+
+/**
+ * Register every live record's covenant. Best effort: a record left uncovered
+ * is logged and tried again at the next start, rather than failing the watcher
+ * that the other records still need.
+ */
+async function coverLiveOffers(
+    wallet: IWallet,
+    arkServerUrl: string,
+    uncovered: readonly AssetSwap[],
+): Promise<void> {
     try {
         await ensureOfferContracts(
             wallet,
@@ -278,36 +240,146 @@ export async function watchOfferSwaps({
     } catch (err) {
         console.warn("[swap] could not re-register every live offer covenant", err);
     }
-    // Through the queue, like an event: a spend delivered mid-sweep and the
-    // reconcile of the same deposit must not write over each other. Not
-    // awaited — `idle()` is how a caller waits for it — so a slow indexer
-    // delays the reconcile, never the watcher.
-    for (const swap of uncovered) {
-        enqueue(async () => {
-            try {
-                await reconcile(swap);
-            } catch (err) {
-                console.warn(`[swap] could not reconcile offer ${swap.id} after covering it`, err);
-            }
-        });
-    }
-    // A settlement that landed mid-sweep retired its script before the sweep
-    // put it back in the watched set, and nothing would retire it again:
-    // re-derive liveness from the records as they stand now, for the scripts
-    // the sweep touched and left watched. `retireOfferContract` leaves a live
-    // script alone; a row the reconcile already retired is not written twice.
-    enqueue(async () => {
-        const swaps = await getAssetSwaps(repository);
-        for (const script of new Set(uncovered.map((swap) => swap.swapPkScript))) {
-            const [row] = await manager.getContracts({ script });
-            if (!row) continue; // never registered (partial ensureOfferContracts failure)
-            if (row.watch === "retained") continue;
-            await retireOfferContract(manager, swaps, script);
-        }
-    });
+}
 
-    return {
-        stop: unsubscribe,
-        idle: () => queue,
-    };
+/** What became of a deposit, exactly where the record can say so and off the
+ * spending transaction's covenant leaf where it cannot. */
+async function spendKindOf(
+    { indexer, serverPubkey }: WatchContext,
+    swap: AssetSwap,
+    vtxo: SpentDeposit,
+    spentTxid: string,
+): Promise<SpendKind> {
+    // the exact answer: only the user can cancel, and cancelOffer records
+    // the txid it submitted
+    if (swap.spentTxid === spentTxid && swap.status === "cancelling") return "cancelled";
+    try {
+        // both halves of the spend: the checkpoint carries the deposit
+        // outpoint, the ark tx is the id the record and history name
+        const candidates = spendTxidsOf(vtxo);
+        if (candidates.length === 0) return "indeterminate";
+        const { txs } = await indexer.getVirtualTxs(candidates);
+        return classifyDepositSpend(
+            decodeOffer(hex.decode(swap.offerHex)),
+            serverPubkey,
+            txs.map((psbt) => Transaction.fromPSBT(base64.decode(psbt))),
+            { txid: vtxo.txid, vout: vtxo.vout },
+        );
+    } catch {
+        return "indeterminate";
+    }
+}
+
+/**
+ * What a classified spend does to its record: written, announced, and the
+ * script retired once nothing live is left at it. One path for a spend an
+ * event delivers and for one the start-up reconcile finds on the indexer.
+ */
+async function applySpend(
+    context: WatchContext,
+    swap: AssetSwap,
+    vtxo: SpentDeposit,
+    spentTxid: string,
+    at?: number,
+): Promise<void> {
+    const { manager, repository, onUpdate } = context;
+    const kind = await spendKindOf(context, swap, vtxo, spentTxid);
+    const changes = spendUpdate(swap, { txid: spentTxid, kind, at });
+    if (!changes) return;
+
+    // notify only on a write that landed: `onUpdate` is documented as
+    // firing after the change is persisted, and a consumer that caches
+    // from it would otherwise run ahead of the store
+    const { persisted, swaps } = await updateAssetSwapBestEffort(repository, swap.id, changes);
+    // a lost write must not retire: the next restore scan still
+    // believes this deposit is live
+    if (!persisted) return;
+    onUpdate?.({ ...swap, ...changes });
+    // `swaps` is the post-update view, so the liveness check sees this
+    // record's new status without a third read
+    if (changes.status && RETIRABLE.includes(changes.status)) {
+        await retireOfferContract(manager, swaps, swap.swapPkScript);
+    }
+}
+
+/** A `vtxo_spent` the manager delivered, resolved against the records it names. */
+async function handleSpendEvent(
+    context: WatchContext,
+    event: Extract<ContractVtxoEvent, { type: "vtxo_spent" }>,
+): Promise<void> {
+    if (event.contract.metadata?.kind !== OFFER_CONTRACT_KIND) return;
+
+    for (const vtxo of event.vtxos) {
+        const spentTxid = vtxo.arkTxId || vtxo.spentBy;
+        if (!spentTxid) continue;
+        // Identical offers share one script and are told apart by the
+        // deposit that funded them. Repository v1 has no indexed lookup, so
+        // this is O(history) per spend event; add a query API if offer
+        // event volume makes this hot.
+        const swap = (await getAssetSwaps(context.repository)).find(
+            (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === event.contractScript,
+        );
+        if (!swap) continue;
+        await applySpend(context, swap, vtxo, spentTxid, event.timestamp);
+    }
+}
+
+/**
+ * The fate of a deposit the sweep just covered, read off the indexer. A
+ * spend that happened while the script was uncovered never becomes an
+ * event: this is the one read that catches it. A deposit not indexed yet
+ * is left alone — its event will come, or the next start will look again.
+ */
+async function reconcileDeposit(context: WatchContext, swap: AssetSwap): Promise<void> {
+    const { indexer, repository, onUpdate } = context;
+    const { vtxos } = await indexer.getVtxos({ scripts: [swap.swapPkScript] });
+    const vtxo = vtxos.find((v) => v.txid === swap.fundingTxid);
+    if (!vtxo) return;
+    if (vtxo.virtualStatus.state === "swept") {
+        // mirrors restore.ts: a swept deposit is still the user's money at
+        // that script, so it keeps its script watched and is never retired
+        if (swap.status === "recoverable") return;
+        const changes = { status: "recoverable" as const };
+        const { persisted } = await updateAssetSwapBestEffort(repository, swap.id, changes);
+        if (persisted) onUpdate?.({ ...swap, ...changes });
+        return;
+    }
+    if (vtxo.virtualStatus.state !== "spent") return;
+    const spentTxid = vtxo.arkTxId || vtxo.spentBy;
+    if (!spentTxid) return;
+    // No timestamp available on this path: the indexer VTXO only carries
+    // `createdAt` (its own creation), not the spend's time. A reload caught
+    // here is persisted without `completedAt`; the consumer re-queries the
+    // spending transaction if it needs the fill time.
+    await applySpend(context, swap, vtxo, spentTxid);
+}
+
+/** {@link reconcileDeposit}, logged rather than thrown: one unreachable indexer
+ * must not stop the records behind it in the queue. */
+async function reconcileQuietly(context: WatchContext, swap: AssetSwap): Promise<void> {
+    try {
+        await reconcileDeposit(context, swap);
+    } catch (err) {
+        console.warn(`[swap] could not reconcile offer ${swap.id} after covering it`, err);
+    }
+}
+
+/**
+ * A settlement that landed mid-sweep retired its script before the sweep put it
+ * back in the watched set, and nothing would retire it again: re-derive
+ * liveness from the records as they stand now, for the scripts the sweep
+ * touched and left watched. `retireOfferContract` leaves a live script alone; a
+ * row the reconcile already retired is not written twice.
+ */
+async function retireUntouchedScripts(
+    { manager, repository }: WatchContext,
+    uncovered: readonly AssetSwap[],
+): Promise<void> {
+    const swaps = await getAssetSwaps(repository);
+    for (const script of new Set(uncovered.map((swap) => swap.swapPkScript))) {
+        const [row] = await manager.getContracts({ script });
+        if (!row) continue; // never registered (partial ensureOfferContracts failure)
+        if (row.watch === "retained") continue;
+        await retireOfferContract(manager, swaps, script);
+    }
 }

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -37,11 +37,10 @@ import {
     RestIndexerProvider,
     Transaction,
     type ContractEvent,
-    type ContractVtxo,
     type IWallet,
 } from "@arkade-os/sdk";
 import { RETIRABLE, retireOfferContract } from "./coverage";
-import { decodeOffer, OFFER_CONTRACT_KIND } from "./offer";
+import { decodeOffer, ensureOfferContracts, OFFER_CONTRACT_KIND } from "./offer";
 import type { AssetSwapRepository } from "./repository";
 import { classifyDepositSpend, spendTxidsOf, type RestoreIndexer, type SpendKind } from "./restore";
 import {
@@ -54,6 +53,15 @@ import {
 /** Statuses a spend cannot move: the swap is already resolved.
  * @see RETIRABLE — a different question, and not the same set. */
 const TERMINAL: readonly AssetSwapStatus[] = ["fulfilled", "cancelled", "recoverable"];
+
+/**
+ * Records whose deposit may still be at the covenant, and whose script this
+ * watcher therefore needs registered: everything a spend could still move,
+ * plus `recoverable`, which keeps its script watched (see `RETIRABLE`).
+ * `cancelling` is in: the cancel may have failed to broadcast, and a record
+ * stuck there is exactly one the watcher has to be able to hear about.
+ */
+const NEEDS_COVERAGE: readonly AssetSwapStatus[] = ["pending", "cancelling", "recoverable"];
 
 /**
  * The record change a classified spend implies, or `undefined` when it implies
@@ -106,6 +114,20 @@ export interface WatchOfferSwapsParams {
  * This depends on the wallet's contract event transport. In Node, callers must
  * provide an `EventSource` implementation or use a runtime where it is enabled;
  * otherwise live updates do not arrive and restore remains the fallback.
+ *
+ * **Starting the watcher re-covers what it is asked to watch, and reconciles
+ * it.** Every record in the repository whose deposit may still be at its
+ * covenant gets that covenant registered ({@link ensureOfferContracts}) — a
+ * no-op for offers this wallet created, and the missing registration for
+ * records the restore scan rebuilt on a wallet that never made them. Only a
+ * registered script produces the events this watcher runs on. Registration
+ * alone is not enough, though: a deposit spent *before* its script was
+ * covered produces no event — the manager hydrates it already spent and the
+ * watch baseline starts past it — so each covered record is then read off the
+ * indexer once and a spend found there is classified exactly as an event
+ * would be. The sweep is best effort and runs after the subscription is in
+ * place, so a spend landing mid-sweep is still delivered; a record it could
+ * not cover is logged and is tried again at the next start.
  */
 export async function watchOfferSwaps({
     wallet,
@@ -130,7 +152,10 @@ export async function watchOfferSwaps({
         });
     };
 
-    const classify = async (swap: AssetSwap, vtxo: ContractVtxo, spentTxid: string) => {
+    /** The two halves of a spend, as an event or the indexer reports them. */
+    type SpentDeposit = { txid: string; vout: number; arkTxId?: string; spentBy?: string };
+
+    const classify = async (swap: AssetSwap, vtxo: SpentDeposit, spentTxid: string) => {
         // the exact answer: only the user can cancel, and cancelOffer records
         // the txid it submitted
         if (swap.spentTxid === spentTxid && swap.status === "cancelling") return "cancelled";
@@ -151,6 +176,36 @@ export async function watchOfferSwaps({
         }
     };
 
+    /**
+     * What a classified spend does to its record: written, announced, and the
+     * script retired once nothing live is left at it. One path for a spend an
+     * event delivers and for one the start-up reconcile finds on the indexer.
+     */
+    const resolveSpend = async (
+        swap: AssetSwap,
+        vtxo: SpentDeposit,
+        spentTxid: string,
+        at?: number,
+    ) => {
+        const kind: SpendKind = await classify(swap, vtxo, spentTxid);
+        const changes = spendUpdate(swap, { txid: spentTxid, kind, at });
+        if (!changes) return;
+
+        // notify only on a write that landed: `onUpdate` is documented as
+        // firing after the change is persisted, and a consumer that caches
+        // from it would otherwise run ahead of the store
+        const { persisted, swaps } = await updateAssetSwapBestEffort(repository, swap.id, changes);
+        // a lost write must not retire: the next restore scan still
+        // believes this deposit is live
+        if (!persisted) return;
+        onUpdate?.({ ...swap, ...changes });
+        // `swaps` is the post-update view, so the liveness check sees this
+        // record's new status without a third read
+        if (changes.status && RETIRABLE.includes(changes.status)) {
+            await retireOfferContract(manager, swaps, swap.swapPkScript);
+        }
+    };
+
     const handleSpend = async (event: Extract<ContractEvent, { type: "vtxo_spent" }>) => {
         if (event.contract.metadata?.kind !== OFFER_CONTRACT_KIND) return;
 
@@ -165,34 +220,83 @@ export async function watchOfferSwaps({
                 (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === event.contractScript,
             );
             if (!swap) continue;
-
-            const kind: SpendKind = await classify(swap, vtxo, spentTxid);
-            const changes = spendUpdate(swap, { txid: spentTxid, kind, at: event.timestamp });
-            if (!changes) continue;
-
-            // notify only on a write that landed: `onUpdate` is documented as
-            // firing after the change is persisted, and a consumer that caches
-            // from it would otherwise run ahead of the store
-            const { persisted, swaps } = await updateAssetSwapBestEffort(
-                repository,
-                swap.id,
-                changes,
-            );
-            // a lost write must not retire: the next restore scan still
-            // believes this deposit is live
-            if (!persisted) continue;
-            onUpdate?.({ ...swap, ...changes });
-            // `swaps` is the post-update view, so the liveness check sees this
-            // record's new status without a third read
-            if (changes.status && RETIRABLE.includes(changes.status)) {
-                await retireOfferContract(manager, swaps, event.contractScript);
-            }
+            await resolveSpend(swap, vtxo, spentTxid, event.timestamp);
         }
+    };
+
+    /**
+     * The fate of a deposit the sweep just covered, read off the indexer. A
+     * spend that happened while the script was uncovered never becomes an
+     * event: this is the one read that catches it. A deposit not indexed yet
+     * is left alone — its event will come, or the next start will look again.
+     */
+    const reconcile = async (swap: AssetSwap) => {
+        const { vtxos } = await indexer.getVtxos({ scripts: [swap.swapPkScript] });
+        const vtxo = vtxos.find((v) => v.txid === swap.fundingTxid);
+        if (!vtxo) return;
+        if (vtxo.virtualStatus.state === "swept") {
+            // mirrors restore.ts: a swept deposit is still the user's money at
+            // that script, so it keeps its script watched and is never retired
+            if (swap.status === "recoverable") return;
+            const changes = { status: "recoverable" as const };
+            const { persisted } = await updateAssetSwapBestEffort(repository, swap.id, changes);
+            if (persisted) onUpdate?.({ ...swap, ...changes });
+            return;
+        }
+        if (vtxo.virtualStatus.state !== "spent") return;
+        const spentTxid = vtxo.arkTxId || vtxo.spentBy;
+        if (!spentTxid) return;
+        await resolveSpend(swap, vtxo, spentTxid);
     };
 
     const unsubscribe = manager.onContractEvent((event) => {
         if (event.type !== "vtxo_spent") return;
         enqueue(() => handleSpend(event));
+    });
+
+    // After subscribing, never before: registration is what starts the
+    // manager's own watch on a script, and an event it delivers during the
+    // sweep must find a handler already attached.
+    const uncovered = (await getAssetSwaps(repository)).filter(
+        (swap) => typeof swap.offerHex === "string" && NEEDS_COVERAGE.includes(swap.status),
+    );
+    try {
+        await ensureOfferContracts(
+            wallet,
+            arkServerUrl,
+            uncovered.map((swap) => ({
+                offerHex: swap.offerHex,
+                ...(swap.swapAddress ? { swapAddress: swap.swapAddress } : {}),
+            })),
+        );
+    } catch (err) {
+        console.warn("[swap] could not re-register every live offer covenant", err);
+    }
+    // Through the queue, like an event: a spend delivered mid-sweep and the
+    // reconcile of the same deposit must not write over each other. Not
+    // awaited — `idle()` is how a caller waits for it — so a slow indexer
+    // delays the reconcile, never the watcher.
+    for (const swap of uncovered) {
+        enqueue(async () => {
+            try {
+                await reconcile(swap);
+            } catch (err) {
+                console.warn(`[swap] could not reconcile offer ${swap.id} after covering it`, err);
+            }
+        });
+    }
+    // A settlement that landed mid-sweep retired its script before the sweep
+    // put it back in the watched set, and nothing would retire it again:
+    // re-derive liveness from the records as they stand now, for the scripts
+    // the sweep touched and left watched. `retireOfferContract` leaves a live
+    // script alone; a row the reconcile already retired is not written twice.
+    enqueue(async () => {
+        const swaps = await getAssetSwaps(repository);
+        for (const script of new Set(uncovered.map((swap) => swap.swapPkScript))) {
+            const [row] = await manager.getContracts({ script });
+            if (row?.watch === "retained") continue;
+            await retireOfferContract(manager, swaps, script);
+        }
     });
 
     return {

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -246,6 +246,10 @@ export async function watchOfferSwaps({
         if (vtxo.virtualStatus.state !== "spent") return;
         const spentTxid = vtxo.arkTxId || vtxo.spentBy;
         if (!spentTxid) return;
+        // No timestamp available on this path: the indexer VTXO only carries
+        // `createdAt` (its own creation), not the spend's time. A reload caught
+        // here is persisted without `completedAt`; the consumer re-queries the
+        // spending transaction if it needs the fill time.
         await resolveSpend(swap, vtxo, spentTxid);
     };
 
@@ -294,7 +298,8 @@ export async function watchOfferSwaps({
         const swaps = await getAssetSwaps(repository);
         for (const script of new Set(uncovered.map((swap) => swap.swapPkScript))) {
             const [row] = await manager.getContracts({ script });
-            if (row?.watch === "retained") continue;
+            if (!row) continue; // never registered (partial ensureOfferContracts failure)
+            if (row.watch === "retained") continue;
             await retireOfferContract(manager, swaps, script);
         }
     });

--- a/packages/swap/test/coverage.test.ts
+++ b/packages/swap/test/coverage.test.ts
@@ -82,6 +82,9 @@ describe("offer contract coverage", () => {
 // A deposit that already landed — a restored record — is covered without the
 // issuance mark: the mark answers "has this address been funded", and here the
 // answer is the record itself, older than any mark set now could be.
+// AI-generated, and to be redone: written by Claude, kept for the coverage it
+// gives the fix rather than for its shape. Rewrite by hand before reading it as
+// the specification.
 describe("coverOfferContract", () => {
     const LANDED = "51" + "bb".repeat(32);
 

--- a/packages/swap/test/coverage.test.ts
+++ b/packages/swap/test/coverage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { promoteOfferContract, retireOfferContract } from "../src/coverage";
+import { coverOfferContract, promoteOfferContract, retireOfferContract } from "../src/coverage";
 import type { AssetSwap } from "../src/store";
 
 const SCRIPT = "51" + "aa".repeat(32);
@@ -76,5 +76,36 @@ describe("offer contract coverage", () => {
         await Promise.all([retire, promote]);
 
         expect(row).toBe("watched");
+    });
+});
+
+// A deposit that already landed — a restored record — is covered without the
+// issuance mark: the mark answers "has this address been funded", and here the
+// answer is the record itself, older than any mark set now could be.
+describe("coverOfferContract", () => {
+    const LANDED = "51" + "bb".repeat(32);
+
+    it("watches the script and lets a settled record retire it at once", async () => {
+        const { setContractWatchState } = manager();
+        await coverOfferContract({ setContractWatchState }, LANDED);
+        // predates any mark: with one set, this record would never clear it
+        await retireOfferContract(
+            { setContractWatchState },
+            [swap({ swapPkScript: LANDED, createdAt: 0 })],
+            LANDED,
+        );
+
+        expect(setContractWatchState.mock.calls).toEqual([
+            [LANDED, "watched"],
+            [LANDED, "retained"],
+        ]);
+    });
+
+    it("surfaces a failed write, like promotion does", async () => {
+        const { setContractWatchState } = manager();
+        setContractWatchState.mockRejectedValueOnce(new Error("repository unavailable"));
+        await expect(coverOfferContract({ setContractWatchState }, LANDED)).rejects.toThrow(
+            "repository unavailable",
+        );
     });
 });

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -629,6 +629,10 @@ describe("the swap, against solverd (regtest)", () => {
         const history = await historyWith(wallet, txids);
         const { restored } = await restoreAssetSwaps(indexer, history, new Set(), {
             serverPubkey,
+            // re-cover the deposits still at their covenant, as createOffer
+            // registered them on the live wallet: without this the restored
+            // wallet cannot see its own escrowed assets
+            cover: { wallet, arkServerUrl: ARK_URL },
         });
         for (const swap of restored) await addAssetSwap(repository, swap);
         return { wallet, repository, restored };
@@ -687,22 +691,25 @@ describe("the swap, against solverd (regtest)", () => {
         );
     }, 180_000);
 
-    it("swap ALL BTC -> RGT: the balance the wallet reports available funds the offer, and it fills", async () => {
+    it("swap ALL BTC -> RGT: the balance the wallet reports sendable funds the offer, and it fills", async () => {
         // the case arkade.money's Max button hits: a wallet that has received
-        // an asset offers every sat the wallet says it can spend
+        // an asset offers every sat the wallet says it can send — which is
+        // `maxSendable`, not `available`: the two differ by the dust carrier
+        // the held asset's change must ride on
         const held = await rgtHeld(maker);
         expect(held).toBeGreaterThan(BigInt(0));
-        const { available } = await maker.getBalance();
-        const plan = btcToRgt(available);
-        expect(validatePlan(plan, BigInt(available), dust)).toBeUndefined();
+        const { available, maxSendable } = await maker.getBalance();
+        expect(maxSendable).toBeLessThan(available);
+        const plan = btcToRgt(maxSendable);
+        expect(validatePlan(plan, BigInt(maxSendable), dust)).toBeUndefined();
 
         let published: Awaited<ReturnType<typeof publish>>;
         try {
             published = await publish(maker, plan, makerRepository);
         } catch (err) {
             throw new Error(
-                `funding the offer with the wallet's own available balance (${available} sats, ` +
-                    `${held} RGT held) was refused: ${err instanceof Error ? err.message : err}`,
+                `funding the offer with the wallet's own sendable balance (${maxSendable} sats of ` +
+                    `${available} available, ${held} RGT held) was refused: ${err instanceof Error ? err.message : err}`,
             );
         }
         const { fundingTxid, script } = published;
@@ -790,13 +797,11 @@ describe("the swap, against solverd (regtest)", () => {
                 offerHex: untaken.swap.offerHex,
             });
 
-            // the escrowed deposit is the restored wallet's asset: a wallet
-            // that re-registered the covenant owns it — gated, not spendable,
-            // but still counted in the total the user sees. On master nothing
-            // re-covers the covenant after a restore, so the restored wallet
-            // cannot see the escrowed asset at all: it reads as vanished until
-            // the cancel brings it back. That gap is what this case shows —
-            // the live maker, which never lost the registration, still owns it
+            // the escrowed deposit is the restored wallet's asset: the
+            // restore re-registered the covenant (restoreAssetSwaps' `cover`),
+            // so the deposit is owned — gated, not spendable, but counted in
+            // the total the user sees, exactly as the live maker (which never
+            // lost the registration) owns it
             const makerOwned = assetAmount((await maker.getBalance()).assets, rgt);
             expect(assetAmount((await restored.wallet.getBalance()).assets, rgt)).toBe(makerOwned);
 

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -6,10 +6,17 @@
  *
  * This is the package's persistence contract exercised end to end: offerHex +
  * fundingTxid is all a maker must keep — everything else comes back from the
- * indexer. The fill path is NOT covered here: it needs a taker holding the
- * want-asset (no solver runs in this stack) and is scoped separately.
+ * indexer.
+ *
+ * The second block is the fill, against the stack's own solverd: every swap
+ * shape a wallet can put through it, in both directions, and what the wallet
+ * sees of each before and after a restore or a reload. The regtest `solver`
+ * profile funds solverd, mints a regtest asset (RGT) and registers a BTC/RGT
+ * market on a mock feed, so an offer priced off the solver's own card is
+ * taken within seconds of funding, and one priced away from the feed is
+ * looked at and declined — which is how a deposit is made to stay pending.
  */
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { execSync } from "child_process";
 import { hex } from "@scure/base";
 import {
@@ -21,23 +28,34 @@ import {
     RestIndexerProvider,
     SingleKey,
     Wallet,
+    type Asset,
 } from "@arkade-os/sdk";
+import { planOffer, type Market, type OfferPlan } from "@arkade-os/solver-discovery";
 import {
     addAssetSwap,
+    BTC_ASSET_ID,
     cancelOffer,
     createOffer,
     decodeOffer,
     getAssetSwaps,
     InMemoryAssetSwapRepository,
+    QUOTE_OPTIONS,
     restoreAssetSwaps,
+    validatePlan,
     watchOfferSwaps,
     type AssetSwap,
+    type AssetSwapRepository,
+    type OfferSwapWatcher,
     type Tx,
 } from "../../src";
 
 const ARK_URL = "http://localhost:7070";
 // mempool serves the Esplora REST API under `/api`; the root path is the HTML UI
 const ESPLORA_API_URL = "http://localhost:3000/api";
+/** solverd's HTTP gateway: the regtest stack remaps the container's 7171 here. */
+const SOLVER_URL = "http://localhost:7091";
+/** The mock feed the solver's regtest market prices from, on its published port. */
+const PRICEFEED_URL = "http://localhost:8088";
 const arkdExec = "docker exec -t arkd";
 
 const FAUCET_SATS = 30_000;
@@ -335,6 +353,637 @@ describe("maker-side swap loop (regtest)", () => {
             expect(rows.find((c) => c.script === secondScript)?.watch).toBe("retained");
         } finally {
             watcher.stop();
+        }
+    }, 180_000);
+});
+
+// ---------------------------------------------------------------------------
+// The fill, against solverd
+// ---------------------------------------------------------------------------
+
+/** The wallet's own storage — what a restore loses and a reload keeps. */
+interface WalletRepos {
+    walletRepository: InMemoryWalletRepository;
+    contractRepository: InMemoryContractRepository;
+}
+
+const newRepos = (): WalletRepos => ({
+    walletRepository: new InMemoryWalletRepository(),
+    contractRepository: new InMemoryContractRepository(),
+});
+
+/**
+ * A wallet on the given repositories, fresh ones by default. Called twice
+ * with one key and fresh repositories it yields the restore case: same funds
+ * on chain, nothing remembered locally. Called again on the SAME repositories
+ * it yields the reload case: an app refresh, everything remembered.
+ */
+const createWallet = async (keyHex: string, repos: WalletRepos = newRepos()): Promise<Wallet> =>
+    Wallet.create({
+        identity: SingleKey.fromHex(keyHex),
+        arkServerUrl: ARK_URL,
+        onchainProvider: new EsploraProvider(ESPLORA_API_URL, {
+            forcePolling: true,
+            pollingInterval: 2000,
+        }),
+        storage: repos,
+        settlementConfig: false,
+    });
+
+/** Fund `wallet` offchain from the arkd CLI wallet, a fresh note each time. */
+const faucet = async (wallet: Wallet, sats: number): Promise<void> => {
+    const before = (await wallet.getBalance()).available;
+    const note = execCommand(`${arkdExec} arkd note --amount ${Math.max(200_000, sats * 2)}`);
+    execCommand(`${arkdExec} ark redeem-notes -n ${note} --password secret`);
+    const address = await wallet.getAddress();
+    execCommand(`${arkdExec} ark send --to ${address} --amount ${sats} --password secret`);
+    await waitFor(async () => (await wallet.getBalance()).available >= before + sats);
+};
+
+const assetAmount = (assets: readonly Asset[], assetId: string): bigint =>
+    assets.find((a) => a.assetId === assetId)?.amount ?? BigInt(0);
+
+/** The deposit `txid` at `script`, as the indexer sees it, or undefined. */
+const vtxoAt = async (script: string, txid: string) =>
+    (await indexer.getVtxos({ scripts: [script] })).vtxos.find((v) => v.txid === txid);
+
+/**
+ * The wallet's own history in the shape the restore scan reads — the mapping a
+ * consumer applies to `getTransactionHistory()` (arkade.money's
+ * `arkTransactionToTx`): the ark txid is the funding tx's identity, the type
+ * is lower-cased, and the time is unix seconds.
+ */
+const historyOf = async (wallet: Wallet): Promise<Tx[]> =>
+    (await wallet.getTransactionHistory()).map((tx) => ({
+        type: tx.type.toLowerCase(),
+        redeemTxid: tx.key.arkTxid,
+        roundTxid: tx.key.commitmentTxid,
+        boardingTxid: tx.key.boardingTxid,
+        createdAt: Math.floor(tx.createdAt / 1000),
+    }));
+
+/** The history once it names every txid in `txids` — a fresh wallet syncs it. */
+const historyWith = async (wallet: Wallet, txids: string[]): Promise<Tx[]> => {
+    let history: Tx[] = [];
+    await waitFor(
+        async () => {
+            history = await historyOf(wallet);
+            return txids.every((id) => history.some((tx) => tx.redeemTxid === id));
+        },
+        { timeout: 60_000 },
+    );
+    return history;
+};
+
+const getJson = async (url: string, what: string): Promise<any> => {
+    const res = await fetch(url);
+    if (!res.ok) {
+        throw new Error(
+            `${what}: ${url} -> HTTP ${res.status} — is the regtest \`solver\` profile up, and ` +
+                "its SOLVER_IMAGE new enough to serve it?",
+        );
+    }
+    return res.json();
+};
+
+/**
+ * The solver's own card, and its feed's current value — what a wallet's
+ * discovery hands the quote. The card names the feed by its docker-network
+ * host; from here it is the mock feed's published port, same path.
+ */
+const solverMarket = async (): Promise<{ market: Market; feedValue: number }> => {
+    const card = (await getJson(`${SOLVER_URL}/v1/card?name=regtest`, "solver card")) as {
+        markets: Market[];
+    };
+    const found = card.markets.find((m) => m.base_asset.id === BTC_ASSET_ID);
+    if (!found?.price_feed || !found.price_feed_schema) {
+        throw new Error(
+            "solverd advertises no BTC market with a feed — is the `solver` profile up?",
+        );
+    }
+    const body = await getJson(
+        `${PRICEFEED_URL}${new URL(found.price_feed).pathname}`,
+        "the solver's price feed",
+    );
+    const value = found.price_feed_schema.price_path
+        .split("/")
+        .filter(Boolean)
+        .reduce<unknown>((node, key) => (node as Record<string, unknown>)?.[key], body);
+    return { market: found, feedValue: Number(value) };
+};
+
+describe("the swap, against solverd (regtest)", () => {
+    const SOLVER_FAUCET_SATS = 20_000;
+    /** How long a fill may take once the funding tx is on the stream. */
+    const FILL_TIMEOUT = 90_000;
+    /** How long the solver gets to look at an offer it will decline. */
+    const DECLINE_GRACE_MS = 4_000;
+    /**
+     * The sats solverd puts under an asset payout: its own constant (330, in
+     * `FulfillOffer`), not the server's dust — the two agree on this stack,
+     * but the arithmetic below names the one it actually depends on.
+     */
+    const SOLVER_CARRIER = 330;
+
+    const keyHex = SingleKey.fromRandomBytes().toHex();
+    const makerRepos = newRepos();
+    let maker: Wallet;
+    let makerRepository: AssetSwapRepository;
+    let makerWatcher: OfferSwapWatcher;
+    let serverPubkey: Uint8Array;
+    let dust: bigint;
+    let market: Market;
+    let feedValue: number;
+    let rgt: string;
+
+    const btcToRgt = (sats: number | bigint): OfferPlan =>
+        planOffer({ market, give: "base", feedValue, giveAmount: BigInt(sats), ...QUOTE_OPTIONS });
+    const rgtToBtc = (units: bigint): OfferPlan =>
+        planOffer({ market, give: "quote", feedValue, giveAmount: units, ...QUOTE_OPTIONS });
+
+    /** A want the solver will look at and decline: twice the fair amount. */
+    const wrongPrice = (plan: OfferPlan): bigint => plan.receive.atomic * BigInt(2);
+
+    const rgtHeld = async (wallet: Wallet) =>
+        assetAmount((await wallet.getBalance()).availableAssets, rgt);
+
+    /** Sats for the next deposit, whatever the earlier cases left behind. */
+    const ensureSats = async (min: number) => {
+        if ((await maker.getBalance()).available < min) await faucet(maker, SOLVER_FAUCET_SATS);
+    };
+
+    /**
+     * What arkade.money's `createSwap` does with a plan: derive the offer
+     * keyed on the receive side, fund it with the deposit side (sats, or the
+     * asset on a dust carrier), and record it by its funding txid.
+     * `wantAmount` overrides the plan's — how a test publishes an offer no
+     * solver will take.
+     */
+    const publish = async (
+        wallet: Wallet,
+        plan: OfferPlan,
+        repository: AssetSwapRepository,
+        wantAmount = plan.receive.atomic,
+    ) => {
+        const wantsBtc = plan.receive.asset.id === BTC_ASSET_ID;
+        const depositsBtc = plan.deposit.asset.id === BTC_ASSET_ID;
+        const offer = await createOffer(wallet, ARK_URL, {
+            wantAmount,
+            ...(wantsBtc
+                ? { offerAsset: asset.AssetId.fromString(plan.deposit.asset.id) }
+                : { wantAsset: asset.AssetId.fromString(plan.receive.asset.id) }),
+        });
+        const fundingTxid = await wallet.send({
+            address: offer.address,
+            ...(depositsBtc
+                ? { amount: Number(plan.deposit.atomic) }
+                : { assets: [{ assetId: plan.deposit.asset.id, amount: plan.deposit.atomic }] }),
+            extensions: [offer.extension],
+        });
+        const swap: AssetSwap = {
+            id: fundingTxid,
+            fromAsset: plan.deposit.asset.id,
+            toAsset: plan.receive.asset.id,
+            fromAmount: plan.deposit.atomic.toString(),
+            toAmount: wantAmount.toString(),
+            swapAddress: offer.address,
+            swapPkScript: hex.encode(offer.swapPkScript),
+            offerHex: offer.offerHex,
+            fundingTxid,
+            status: "pending",
+            createdAt: Date.now(),
+        };
+        await addAssetSwap(repository, swap);
+        const script = hex.encode(offer.swapPkScript);
+        await waitFor(async () => Boolean(await vtxoAt(script, fundingTxid)));
+        return { offer, fundingTxid, swap, script };
+    };
+
+    const statusOf = async (repository: AssetSwapRepository, id: string) =>
+        (await getAssetSwaps(repository)).find((s) => s.id === id);
+
+    /**
+     * The watcher-driven resolution: no scan anywhere, the event carries it.
+     * On a miss, says what the record reads against what the chain says of
+     * its deposit — the two disagreeing is the finding.
+     */
+    const untilStatus = async (
+        watcher: OfferSwapWatcher,
+        repository: AssetSwapRepository,
+        id: string,
+        script: string,
+        status: AssetSwap["status"],
+    ) => {
+        try {
+            await waitFor(
+                async () => {
+                    await watcher.idle();
+                    return (await statusOf(repository, id))?.status === status;
+                },
+                { timeout: FILL_TIMEOUT },
+            );
+        } catch {
+            const record = await statusOf(repository, id);
+            const deposit = await vtxoAt(script, id);
+            throw new Error(
+                `record ${id} reads "${record?.status}" ${FILL_TIMEOUT} ms on, expected ` +
+                    `"${status}" — its deposit is ${deposit?.virtualStatus.state ?? "unknown"} on chain`,
+            );
+        }
+    };
+
+    /** The solver had its look and passed: still pending, still unspent. */
+    const stillPending = async (repository: AssetSwapRepository, script: string, id: string) => {
+        await new Promise((r) => setTimeout(r, DECLINE_GRACE_MS));
+        await makerWatcher.idle();
+        expect((await statusOf(repository, id))?.status).toBe("pending");
+        expect((await vtxoAt(script, id))?.virtualStatus.state).not.toBe("spent");
+    };
+
+    /**
+     * A wallet rebuilt from its key alone, with every record the chain still
+     * carries for it: the restore scan over its own history, and the records
+     * stored. What arkade.money does on "restore wallet".
+     */
+    const restoreFromKey = async (txids: string[]) => {
+        const wallet = await createWallet(keyHex);
+        const repository = new InMemoryAssetSwapRepository();
+        const history = await historyWith(wallet, txids);
+        const { restored } = await restoreAssetSwaps(indexer, history, new Set(), {
+            serverPubkey,
+        });
+        for (const swap of restored) await addAssetSwap(repository, swap);
+        return { wallet, repository, restored };
+    };
+
+    beforeAll(async () => {
+        // the solver-init step registers the market after the stack reports
+        // up; wait for it here rather than in the shared setup
+        await waitFor(
+            async () => {
+                const res = await fetch(`${SOLVER_URL}/v1/markets`).catch(() => undefined);
+                const body = res?.ok ? await res.json() : undefined;
+                return Array.isArray(body?.markets) && body.markets.length > 0;
+            },
+            { timeout: 90_000, interval: 2_000 },
+        );
+        ({ market, feedValue } = await solverMarket());
+        rgt = market.quote_asset.id;
+
+        maker = await createWallet(keyHex, makerRepos);
+        await faucet(maker, SOLVER_FAUCET_SATS);
+        serverPubkey = ArkAddress.decode(await maker.getAddress()).serverPubKey;
+        dust = maker.dustAmount;
+        makerRepository = new InMemoryAssetSwapRepository();
+        makerWatcher = await watchOfferSwaps({
+            wallet: maker,
+            arkServerUrl: ARK_URL,
+            repository: makerRepository,
+        });
+    }, 180_000);
+
+    afterAll(async () => {
+        makerWatcher?.stop();
+        await maker?.dispose().catch(() => {});
+    });
+
+    it("BTC -> RGT leaving change: quoted off the card, validated, funded, and filled", async () => {
+        const plan = btcToRgt(10_000);
+        expect(plan.deposit.atomic).toBe(BigInt(10_000));
+        expect(plan.receive.atomic).toBeGreaterThan(BigInt(0));
+        const { available } = await maker.getBalance();
+        expect(validatePlan(plan, BigInt(available), dust)).toBeUndefined();
+
+        const { fundingTxid, script } = await publish(maker, plan, makerRepository);
+        await untilStatus(makerWatcher, makerRepository, fundingTxid, script, "fulfilled");
+        const filled = await statusOf(makerRepository, fundingTxid);
+        expect(filled?.spentTxid).toBeTruthy();
+        expect(filled?.completedAt).toBeGreaterThan(0);
+        expect((await vtxoAt(script, fundingTxid))?.virtualStatus.state).toBe("spent");
+
+        // the asset is in the wallet, spendable, on the solver's carrier; the
+        // change from the funding is still here too
+        await waitFor(async () => (await rgtHeld(maker)) >= plan.receive.atomic);
+        expect((await maker.getBalance()).available).toBe(
+            SOLVER_FAUCET_SATS - 10_000 + SOLVER_CARRIER,
+        );
+    }, 180_000);
+
+    it("swap ALL BTC -> RGT: the balance the wallet reports available funds the offer, and it fills", async () => {
+        // the case arkade.money's Max button hits: a wallet that has received
+        // an asset offers every sat the wallet says it can spend
+        const held = await rgtHeld(maker);
+        expect(held).toBeGreaterThan(BigInt(0));
+        const { available } = await maker.getBalance();
+        const plan = btcToRgt(available);
+        expect(validatePlan(plan, BigInt(available), dust)).toBeUndefined();
+
+        let published: Awaited<ReturnType<typeof publish>>;
+        try {
+            published = await publish(maker, plan, makerRepository);
+        } catch (err) {
+            throw new Error(
+                `funding the offer with the wallet's own available balance (${available} sats, ` +
+                    `${held} RGT held) was refused: ${err instanceof Error ? err.message : err}`,
+            );
+        }
+        const { fundingTxid, script } = published;
+        await untilStatus(makerWatcher, makerRepository, fundingTxid, script, "fulfilled");
+        // the asset it held stayed, and the asset it bought arrived
+        await waitFor(async () => (await rgtHeld(maker)) === held + plan.receive.atomic);
+    }, 180_000);
+
+    it("RGT -> BTC leaving asset change: part of the balance goes, the solver pays sats, the rest stays", async () => {
+        await ensureSats(Number(dust));
+        const held = await rgtHeld(maker);
+        const units = BigInt(2_000);
+        expect(held).toBeGreaterThan(units);
+        const plan = rgtToBtc(units);
+        expect(plan.deposit.atomic).toBe(units);
+        expect(validatePlan(plan, held, dust)).toBeUndefined();
+        const satsBefore = (await maker.getBalance()).available;
+
+        const { fundingTxid, script } = await publish(maker, plan, makerRepository);
+        await untilStatus(makerWatcher, makerRepository, fundingTxid, script, "fulfilled");
+
+        // the asset change rode the funding's change output and is spendable
+        // again; the sats the solver paid are here, net of the carrier the
+        // asset rode out on
+        await waitFor(async () => {
+            const balance = await maker.getBalance();
+            return (
+                assetAmount(balance.availableAssets, rgt) === held - units &&
+                balance.available >= satsBefore - Number(dust) + Number(plan.receive.atomic)
+            );
+        });
+        expect((await maker.getBalance()).available).toBe(
+            satsBefore - Number(dust) + Number(plan.receive.atomic),
+        );
+    }, 180_000);
+
+    it("RGT -> BTC at the WRONG price stays pending, and cancels", async () => {
+        await ensureSats(Number(dust));
+        const held = await rgtHeld(maker);
+        const plan = rgtToBtc(BigInt(1_000));
+        // wanting twice the fair sats: the solver looks, declines, and the
+        // deposit stays where the maker put it
+        const { fundingTxid, script, swap } = await publish(
+            maker,
+            plan,
+            makerRepository,
+            wrongPrice(plan),
+        );
+        await stillPending(makerRepository, script, fundingTxid);
+        // escrowed as an asset meanwhile: owned, not spendable
+        expect(await rgtHeld(maker)).toBe(held - plan.deposit.atomic);
+
+        await cancelOffer(maker, ARK_URL, swap.offerHex, {
+            repository: makerRepository,
+            fundingTxid,
+            swapAddress: swap.swapAddress,
+        });
+        expect((await statusOf(makerRepository, fundingTxid))?.status).toBe("cancelled");
+        await waitFor(async () => (await rgtHeld(maker)) === held);
+    }, 180_000);
+
+    it("RGT -> BTC at the WRONG price, restored from the key alone, then cancelled from the restored wallet", async () => {
+        await ensureSats(Number(dust));
+        const held = await rgtHeld(maker);
+        const plan = rgtToBtc(BigInt(1_000));
+        const untaken = await publish(maker, plan, makerRepository, wrongPrice(plan));
+        await stillPending(makerRepository, untaken.script, untaken.fundingTxid);
+
+        // the wallet comes back with its key alone: the record is rebuilt
+        // from chain data, and the offer is still the wallet's to delete
+        const restored = await restoreFromKey([untaken.fundingTxid]);
+        try {
+            const record = restored.restored.find((s) => s.id === untaken.fundingTxid);
+            expect(record).toMatchObject({
+                status: "pending",
+                fromAsset: rgt,
+                fromAmount: plan.deposit.atomic.toString(),
+                toAsset: BTC_ASSET_ID,
+                toAmount: wrongPrice(plan).toString(),
+                offerHex: untaken.swap.offerHex,
+            });
+
+            // deleted from the restored wallet, with what a restored record
+            // has: the offer bytes and the funding txid, no address
+            await cancelOffer(restored.wallet, ARK_URL, record!.offerHex, {
+                repository: restored.repository,
+                fundingTxid: untaken.fundingTxid,
+            });
+            expect((await statusOf(restored.repository, untaken.fundingTxid))?.status).toBe(
+                "cancelled",
+            );
+            // the asset is home, in the restored wallet and the live one alike
+            await waitFor(async () => (await rgtHeld(restored.wallet)) === held);
+            await waitFor(async () => (await rgtHeld(maker)) === held);
+            // and the live wallet's watcher reads the same cancel off the leaf
+            await untilStatus(
+                makerWatcher,
+                makerRepository,
+                untaken.fundingTxid,
+                untaken.script,
+                "cancelled",
+            );
+        } finally {
+            await restored.wallet.dispose().catch(() => {});
+        }
+    }, 240_000);
+
+    it("RGT -> BTC restored before the solver takes it: the restored wallet sees the fill", async () => {
+        // Stage "published, restored, then taken": solverd matches offers off
+        // arkd's live tx stream, so pausing its container holds the funding
+        // tx on the stream until the restored wallet is watching.
+        //
+        // The pause has to stay short. arkd pings its stream clients and
+        // closes one that stays silent for ~50 s, and solverd reconnects to a
+        // stream that replays nothing — so the restored wallet is brought up
+        // and synced BEFORE the pause, and the paused window holds only the
+        // funding and the incremental sync that follows it.
+        await ensureSats(Number(dust));
+        const plan = rgtToBtc(BigInt(1_500));
+        const restoredRepository = new InMemoryAssetSwapRepository();
+        const restoredWallet = await createWallet(keyHex);
+        await historyOf(restoredWallet);
+        const satsBefore = (await restoredWallet.getBalance()).available;
+        let restoredWatcher: OfferSwapWatcher | undefined;
+        execCommand("docker pause solver");
+        const pausedAt = Date.now();
+        try {
+            const { fundingTxid, script } = await publish(maker, plan, makerRepository);
+
+            const history = await historyWith(restoredWallet, [fundingTxid]);
+            const { restored } = await restoreAssetSwaps(indexer, history, new Set(), {
+                serverPubkey,
+            });
+            const record = restored.find((s) => s.id === fundingTxid);
+            expect(record?.status).toBe("pending");
+            await addAssetSwap(restoredRepository, record!);
+            restoredWatcher = await watchOfferSwaps({
+                wallet: restoredWallet,
+                arkServerUrl: ARK_URL,
+                repository: restoredRepository,
+            });
+
+            execCommand("docker unpause solver");
+            const pausedMs = Date.now() - pausedAt;
+
+            // the solver takes it: the chain says so
+            try {
+                await waitFor(
+                    async () =>
+                        (await vtxoAt(script, fundingTxid))?.virtualStatus.state === "spent",
+                    { timeout: FILL_TIMEOUT },
+                );
+            } catch (err) {
+                throw new Error(
+                    `no fill after unpausing the solver (paused ${pausedMs} ms; past ~50 s arkd ` +
+                        `drops a silent stream client and solverd replays nothing): ${err}`,
+                );
+            }
+            // a scan from nothing reads it fulfilled, off the leaf
+            const rescanned = await restoreAssetSwaps(indexer, history, new Set(), {
+                serverPubkey,
+            });
+            expect(rescanned.restored.find((s) => s.id === fundingTxid)?.status).toBe("fulfilled");
+            // and so must the restored wallet's own record, through its watcher
+            await untilStatus(
+                restoredWatcher,
+                restoredRepository,
+                fundingTxid,
+                script,
+                "fulfilled",
+            );
+            const filled = await statusOf(restoredRepository, fundingTxid);
+            expect(filled?.completedAt).toBeGreaterThan(0);
+            expect(filled?.spentTxid).toBeTruthy();
+            // the sats landed in the restored wallet — same key, same address.
+            // Net of the dust the asset rode out on
+            await waitFor(async () => {
+                const balance = await restoredWallet.getBalance();
+                return balance.available >= satsBefore - Number(dust) + Number(plan.receive.atomic);
+            });
+            // and the live wallet's watcher saw the same fill
+            await untilStatus(makerWatcher, makerRepository, fundingTxid, script, "fulfilled");
+        } finally {
+            try {
+                execCommand("docker unpause solver");
+            } catch {
+                // already running
+            }
+            restoredWatcher?.stop();
+            await restoredWallet.dispose().catch(() => {});
+        }
+    }, 240_000);
+
+    it("swap ALL RGT -> BTC: the whole asset balance goes, and the solver pays sats", async () => {
+        await ensureSats(Number(dust));
+        const held = await rgtHeld(maker);
+        expect(held).toBeGreaterThan(BigInt(0));
+        const plan = rgtToBtc(held);
+        expect(plan.deposit.atomic).toBe(held);
+        expect(validatePlan(plan, held, dust)).toBeUndefined();
+        const satsBefore = (await maker.getBalance()).available;
+
+        const { fundingTxid, script } = await publish(maker, plan, makerRepository);
+        await untilStatus(makerWatcher, makerRepository, fundingTxid, script, "fulfilled");
+
+        await waitFor(async () => {
+            const balance = await maker.getBalance();
+            return (
+                assetAmount(balance.availableAssets, rgt) === BigInt(0) &&
+                balance.available >= satsBefore - Number(dust) + Number(plan.receive.atomic)
+            );
+        });
+        expect(assetAmount((await maker.getBalance()).assets, rgt)).toBe(BigInt(0));
+    }, 180_000);
+
+    it("reload on the same storage: a fill that landed while nothing watched is picked up, a pending offer still cancels", async () => {
+        // An app refresh, not a restore: the wallet's repositories and the
+        // swap store survive, only the Wallet instance and its watcher are
+        // new. The fill lands in between — nothing is watching — so the new
+        // watcher has to pick it up on its own. No restore scan anywhere.
+        await ensureSats(2 * 1_000 + Number(dust));
+        makerWatcher.stop();
+        const plan = btcToRgt(1_000);
+        const { fundingTxid, script } = await publish(maker, plan, makerRepository);
+        await waitFor(
+            async () => (await vtxoAt(script, fundingTxid))?.virtualStatus.state === "spent",
+            {
+                timeout: FILL_TIMEOUT,
+            },
+        );
+        expect((await statusOf(makerRepository, fundingTxid))?.status).toBe("pending");
+        await maker.dispose();
+
+        maker = await createWallet(keyHex, makerRepos);
+        makerWatcher = await watchOfferSwaps({
+            wallet: maker,
+            arkServerUrl: ARK_URL,
+            repository: makerRepository,
+        });
+        await untilStatus(makerWatcher, makerRepository, fundingTxid, script, "fulfilled");
+        expect((await statusOf(makerRepository, fundingTxid))?.spentTxid).toBeTruthy();
+        await waitFor(async () => (await rgtHeld(maker)) >= plan.receive.atomic);
+
+        // and the other half of a reload: an offer published before it is
+        // still the wallet's to cancel after it
+        const untaken = await publish(maker, plan, makerRepository, wrongPrice(plan));
+        await stillPending(makerRepository, untaken.script, untaken.fundingTxid);
+        makerWatcher.stop();
+        await maker.dispose();
+        maker = await createWallet(keyHex, makerRepos);
+        makerWatcher = await watchOfferSwaps({
+            wallet: maker,
+            arkServerUrl: ARK_URL,
+            repository: makerRepository,
+        });
+        await makerWatcher.idle();
+        expect((await statusOf(makerRepository, untaken.fundingTxid))?.status).toBe("pending");
+        await cancelOffer(maker, ARK_URL, untaken.swap.offerHex, {
+            repository: makerRepository,
+            fundingTxid: untaken.fundingTxid,
+            swapAddress: untaken.swap.swapAddress,
+        });
+        expect((await statusOf(makerRepository, untaken.fundingTxid))?.status).toBe("cancelled");
+    }, 240_000);
+
+    it("restored from the key alone, every record reads the status the live wallet holds", async () => {
+        // the state machine after a restore is the chain's answer: fills read
+        // fulfilled, cancels read cancelled, each with the spend that did it,
+        // and nothing reads pending whose deposit is gone
+        const live = await getAssetSwaps(makerRepository);
+        expect(live.length).toBeGreaterThan(0);
+
+        const restored = await restoreFromKey(live.map((s) => s.fundingTxid));
+        try {
+            const byId = new Map(restored.restored.map((s) => [s.id, s]));
+            expect([...byId.keys()].sort()).toEqual(live.map((s) => s.id).sort());
+            for (const swap of live) {
+                const back = byId.get(swap.id);
+                expect(back).toMatchObject({
+                    fromAsset: swap.fromAsset,
+                    toAsset: swap.toAsset,
+                    fromAmount: swap.fromAmount,
+                    toAmount: swap.toAmount,
+                    offerHex: swap.offerHex,
+                });
+                if (swap.status === "fulfilled") expect(back?.completedAt).toBeGreaterThan(0);
+            }
+            // the live wallet's records against the chain's: a live record
+            // still pending whose deposit is spent is a status that went stale
+            const stale = live
+                .filter((s) => s.status === "pending")
+                .filter((s) => byId.get(s.id)?.status !== "pending")
+                .map((s) => `${s.id} reads pending, the chain reads ${byId.get(s.id)?.status}`);
+            expect(stale).toEqual([]);
+            expect(live.map((s) => [s.id, s.status, s.spentTxid])).toEqual(
+                live.map((s) => [s.id, byId.get(s.id)?.status, byId.get(s.id)?.spentTxid]),
+            );
+        } finally {
+            await restored.wallet.dispose().catch(() => {});
         }
     }, 180_000);
 });

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -513,6 +513,24 @@ describe("the swap, against solverd (regtest)", () => {
     };
 
     /**
+     * RGT for the next asset deposit. The maker's asset balance is shared
+     * across these cases, and a restore case runs a second wallet on the same
+     * key that can spend or strand the shared coins, so a case that needs RGT
+     * buys it fresh here with a fair BTC -> RGT swap rather than counting on a
+     * carry-over. Buying at a price the solver takes, this never hits the
+     * swap-all hazard: the deposit is a bounded BTC amount, not the balance.
+     */
+    const ensureRgt = async (minUnits: number) => {
+        if ((await rgtHeld(maker)) >= BigInt(minUnits)) return;
+        const give = minUnits * 2;
+        await ensureSats(give + 4 * Number(dust));
+        const plan = btcToRgt(give);
+        const { fundingTxid, script } = await publish(maker, plan, makerRepository);
+        await untilStatus(makerWatcher, makerRepository, fundingTxid, script, "fulfilled");
+        await waitFor(async () => (await rgtHeld(maker)) >= BigInt(minUnits));
+    };
+
+    /**
      * What arkade.money's `createSwap` does with a plan: derive the offer
      * keyed on the receive side, fund it with the deposit side (sats, or the
      * asset on a dust carrier), and record it by its funding txid.
@@ -802,6 +820,10 @@ describe("the swap, against solverd (regtest)", () => {
         // stream that replays nothing — so the restored wallet is brought up
         // and synced BEFORE the pause, and the paused window holds only the
         // funding and the incremental sync that follows it.
+        //
+        // The RGT is bought before the pause: the top-up itself is a swap, and
+        // the solver has to be running to take it.
+        await ensureRgt(1_500);
         await ensureSats(Number(dust));
         const plan = rgtToBtc(BigInt(1_500));
         const restoredRepository = new InMemoryAssetSwapRepository();
@@ -879,6 +901,9 @@ describe("the swap, against solverd (regtest)", () => {
     }, 240_000);
 
     it("swap ALL RGT -> BTC: the whole asset balance goes, and the solver pays sats", async () => {
+        // sending the whole asset frees the carriers it rode on, so this
+        // direction has no swap-all hazard and is expected to go through
+        await ensureRgt(4_000);
         await ensureSats(Number(dust));
         const held = await rgtHeld(maker);
         expect(held).toBeGreaterThan(BigInt(0));

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -15,6 +15,15 @@
  * market on a mock feed, so an offer priced off the solver's own card is
  * taken within seconds of funding, and one priced away from the feed is
  * looked at and declined — which is how a deposit is made to stay pending.
+ *
+ * ## AI-generated, and to be redone
+ *
+ * This suite was written by Claude, not by hand. It is kept because it runs
+ * green against the real stack and pins the behaviour the fixes in this change
+ * depend on — not because its shape is the one this package wants. Treat it as
+ * scaffolding: the fixtures, the waits and the case split are all expected to
+ * change when it is rewritten. Do not read it as the specification, and do not
+ * extend it by adding another AI-written case to the pile.
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { execSync } from "child_process";

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -1010,7 +1010,13 @@ describe("the swap, against solverd (regtest)", () => {
         const live = await getAssetSwaps(makerRepository);
         expect(live.length).toBeGreaterThan(0);
 
-        const restored = await restoreFromKey(live.map((s) => s.fundingTxid));
+        // await the spends as well as the fundings: the restored wallet's
+        // history names both before the scan runs, so a fulfilled or cancelled
+        // deposit is read off the chain on this pass, completedAt included,
+        // rather than left for a retry the assertions would not see
+        const restored = await restoreFromKey(
+            live.flatMap((s) => (s.spentTxid ? [s.fundingTxid, s.spentTxid] : [s.fundingTxid])),
+        );
         try {
             const byId = new Map(restored.restored.map((s) => [s.id, s]));
             expect([...byId.keys()].sort()).toEqual(live.map((s) => s.id).sort());

--- a/packages/swap/test/e2e/swap.test.ts
+++ b/packages/swap/test/e2e/swap.test.ts
@@ -742,7 +742,10 @@ describe("the swap, against solverd (regtest)", () => {
     it("RGT -> BTC at the WRONG price stays pending, and cancels", async () => {
         await ensureSats(Number(dust));
         const held = await rgtHeld(maker);
-        const plan = rgtToBtc(BigInt(1_000));
+        // a deposit whose doubled want (2_200) is no earlier offer's want, so
+        // the covenant script is this case's alone — identical offers share an
+        // address, and a reused script would tangle these deposits together
+        const plan = rgtToBtc(BigInt(1_100));
         // wanting twice the fair sats: the solver looks, declines, and the
         // deposit stays where the maker put it
         const { fundingTxid, script, swap } = await publish(
@@ -767,7 +770,9 @@ describe("the swap, against solverd (regtest)", () => {
     it("RGT -> BTC at the WRONG price, restored from the key alone, then cancelled from the restored wallet", async () => {
         await ensureSats(Number(dust));
         const held = await rgtHeld(maker);
-        const plan = rgtToBtc(BigInt(1_000));
+        // want 2_600, distinct from every other case's, so this deposit has
+        // its own covenant script
+        const plan = rgtToBtc(BigInt(1_300));
         const untaken = await publish(maker, plan, makerRepository, wrongPrice(plan));
         await stillPending(makerRepository, untaken.script, untaken.fundingTxid);
 
@@ -784,6 +789,16 @@ describe("the swap, against solverd (regtest)", () => {
                 toAmount: wrongPrice(plan).toString(),
                 offerHex: untaken.swap.offerHex,
             });
+
+            // the escrowed deposit is the restored wallet's asset: a wallet
+            // that re-registered the covenant owns it — gated, not spendable,
+            // but still counted in the total the user sees. On master nothing
+            // re-covers the covenant after a restore, so the restored wallet
+            // cannot see the escrowed asset at all: it reads as vanished until
+            // the cancel brings it back. That gap is what this case shows —
+            // the live maker, which never lost the registration, still owns it
+            const makerOwned = assetAmount((await maker.getBalance()).assets, rgt);
+            expect(assetAmount((await restored.wallet.getBalance()).assets, rgt)).toBe(makerOwned);
 
             // deleted from the restored wallet, with what a restored record
             // has: the offer bytes and the funding txid, no address
@@ -922,7 +937,15 @@ describe("the swap, against solverd (regtest)", () => {
                 balance.available >= satsBefore - Number(dust) + Number(plan.receive.atomic)
             );
         });
-        expect(assetAmount((await maker.getBalance()).assets, rgt)).toBe(BigInt(0));
+        // every spendable unit went and the sats came back. `assets` (total)
+        // can still hold RGT stranded in an earlier case's un-cancellable
+        // escrow — that is those cases' defect, not this one's, so this reads
+        // the spendable balance, which is what "swap all" moves
+        const balance = await maker.getBalance();
+        expect(assetAmount(balance.availableAssets, rgt)).toBe(BigInt(0));
+        expect(balance.available).toBeGreaterThanOrEqual(
+            satsBefore - Number(dust) + Number(plan.receive.atomic),
+        );
     }, 180_000);
 
     it("reload on the same storage: a fill that landed while nothing watched is picked up, a pending offer still cancels", async () => {

--- a/packages/swap/test/register.test.ts
+++ b/packages/swap/test/register.test.ts
@@ -347,6 +347,9 @@ describe("an offer at a script an earlier offer retired", () => {
 
 // ── Re-covering an offer this store did not create ────────────────────────────
 
+// AI-generated, and to be redone: written by Claude, kept for the coverage it
+// gives the fix rather than for its shape. Rewrite by hand before reading it as
+// the specification.
 describe("ensureOfferContracts", () => {
     const serverKey = hex.decode(
         "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",

--- a/packages/swap/test/register.test.ts
+++ b/packages/swap/test/register.test.ts
@@ -14,7 +14,16 @@ import {
     type RelativeTimelock,
     type OnchainProvider,
 } from "@arkade-os/sdk";
-import { createOffer, decodeOffer, OFFER_CONTRACT_KIND, OFFER_CONTRACT_LABEL } from "../src/offer";
+import {
+    createOffer,
+    decodeOffer,
+    encodeOffer,
+    ensureOfferContracts,
+    offerVtxoScript,
+    OFFER_CONTRACT_KIND,
+    OFFER_CONTRACT_LABEL,
+} from "../src/offer";
+import { retireOfferContract } from "../src/coverage";
 
 // the covenant derivation, Arkade.connect, ArkadeContract and register() are
 // all real here — only the network seam (the three Rest* providers) and the
@@ -333,5 +342,128 @@ describe("an offer at a script an earlier offer retired", () => {
 
         const row = (await contractRepository.getContracts()).find((c) => c.script === script);
         expect(row?.watch).toBe("watched");
+    });
+});
+
+// ── Re-covering an offer this store did not create ────────────────────────────
+
+describe("ensureOfferContracts", () => {
+    const serverKey = hex.decode(
+        "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+    );
+    /** An offer at a script none of the `create()` calls above ever promoted,
+     * so the issuance mark (module state, keyed by script) cannot leak in. */
+    const unmarkedOffer = async () => {
+        const created = await create();
+        const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(created.offerHex));
+        const rebound = { ...binding, wantAmount: BigInt(777_777) };
+        const script = offerVtxoScript(rebound, serverKey);
+        return {
+            offerHex: hex.encode(encodeOffer({ ...rebound, swapPkScript: script.pkScript })),
+            script: hex.encode(script.pkScript),
+        };
+    };
+
+    it("writes the row createOffer would, and watches it", async () => {
+        const { offerHex, script } = await unmarkedOffer();
+        state.created = [];
+        state.watched = [];
+
+        await ensureOfferContracts(wallet, "http://ark", [{ offerHex }]);
+
+        expect(state.created).toHaveLength(1);
+        expect(state.created[0]).toMatchObject({
+            type: "arkade",
+            script,
+            label: OFFER_CONTRACT_LABEL,
+            metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
+        });
+        expect(state.watched).toEqual([[script, "watched"]]);
+    });
+
+    it("sets no issuance mark, so a settled record can retire the script", async () => {
+        // createOffer's mark says an address is out waiting for its deposit;
+        // here the deposit is the record itself, and a mark set after the
+        // funding would never be cleared by it
+        const { offerHex, script } = await unmarkedOffer();
+        await ensureOfferContracts(wallet, "http://ark", [{ offerHex }]);
+        state.watched = [];
+
+        await retireOfferContract(
+            contractManager,
+            [
+                {
+                    id: "ab".repeat(32),
+                    fromAsset: "btc",
+                    toAsset: testAsset.toString(),
+                    fromAmount: "10000",
+                    toAmount: "777777",
+                    swapAddress: "",
+                    swapPkScript: script,
+                    offerHex,
+                    fundingTxid: "ab".repeat(32),
+                    status: "fulfilled",
+                    createdAt: 0,
+                },
+            ],
+            script,
+        );
+        expect(state.watched).toEqual([[script, "retained"]]);
+    });
+
+    it("refuses an offer the current server key no longer rebuilds, and registers the rest", async () => {
+        // a signer rotation since funding: the TLV pins the funded script, the
+        // rebuild under today's key disagrees, and registering at the rebuilt
+        // script would watch an address the deposit never sat at
+        const good = await unmarkedOffer();
+        const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(good.offerHex));
+        const rotatedKey = schnorr.getPublicKey(hex.decode("7".repeat(64)));
+        const rotated = offerVtxoScript(binding, rotatedKey);
+        const stale = hex.encode(encodeOffer({ ...binding, swapPkScript: rotated.pkScript }));
+        state.created = [];
+
+        await expect(
+            ensureOfferContracts(wallet, "http://ark", [{ offerHex: stale }, good]),
+        ).rejects.toThrow(/could not register 1 offer covenant\(s\).*rotated/);
+        expect(state.created.map((row) => row.script)).toEqual([good.script]);
+    });
+
+    it("takes the funded address as the key to rebuild with", async () => {
+        // the pin cancelOffer honours: a record that kept its swapAddress keeps
+        // working across a rotation, because the key comes from the address
+        const good = await unmarkedOffer();
+        const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(good.offerHex));
+        const rotatedKey = schnorr.getPublicKey(hex.decode("7".repeat(64)));
+        const rotated = offerVtxoScript(binding, rotatedKey);
+        const stale = hex.encode(encodeOffer({ ...binding, swapPkScript: rotated.pkScript }));
+        const fundedAddress = rotated.address("tark", rotatedKey).encode();
+        state.created = [];
+
+        await ensureOfferContracts(wallet, "http://ark", [
+            { offerHex: stale, swapAddress: fundedAddress },
+        ]);
+        expect(state.created.map((row) => row.script)).toEqual([hex.encode(rotated.pkScript)]);
+    });
+
+    it("falls back to the caller's key for a record with no address to pin", async () => {
+        // what the restore scan hands over: the key it classified with, which
+        // is the funded one after a rotation while the server's is not
+        const good = await unmarkedOffer();
+        const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(good.offerHex));
+        const rotatedKey = schnorr.getPublicKey(hex.decode("7".repeat(64)));
+        const rotated = offerVtxoScript(binding, rotatedKey);
+        const stale = hex.encode(encodeOffer({ ...binding, swapPkScript: rotated.pkScript }));
+        state.created = [];
+
+        await ensureOfferContracts(wallet, "http://ark", [{ offerHex: stale }], {
+            serverPubkey: rotatedKey,
+        });
+        expect(state.created.map((row) => row.script)).toEqual([hex.encode(rotated.pkScript)]);
+    });
+
+    it("reads nothing off the server for an empty list", async () => {
+        state.created = [];
+        await ensureOfferContracts(wallet, "http://ark", []);
+        expect(state.created).toEqual([]);
     });
 });

--- a/packages/swap/test/restore.test.ts
+++ b/packages/swap/test/restore.test.ts
@@ -397,6 +397,9 @@ describe("restoreAssetSwaps", () => {
         }
     });
 
+    // AI-generated, and to be redone: written by Claude, kept for the coverage
+    // it gives the fix rather than for its shape. Rewrite by hand before
+    // reading it as the specification.
     describe("with `cover`, a live restored deposit is the wallet's to watch again", () => {
         // the wallet seam `ensureOfferContracts` writes through, and the server
         // read it derives the row's address from

--- a/packages/swap/test/restore.test.ts
+++ b/packages/swap/test/restore.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { base64, hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
-import { asset, Extension, Transaction, UnknownPacket } from "@arkade-os/sdk";
+import {
+    asset,
+    CSVMultisigTapscript,
+    Extension,
+    RestArkProvider,
+    Transaction,
+    UnknownPacket,
+} from "@arkade-os/sdk";
 import { encodeOffer, offerVtxoScript, Offer, OFFER_PACKET_TYPE } from "../src/offer";
 import {
     classifyDepositSpend,
@@ -388,6 +395,163 @@ describe("restoreAssetSwaps", () => {
             expect(restored.status).toBe(status);
             expect(restored.spentTxid).toBeUndefined();
         }
+    });
+
+    describe("with `cover`, a live restored deposit is the wallet's to watch again", () => {
+        // the wallet seam `ensureOfferContracts` writes through, and the server
+        // read it derives the row's address from
+        const coverage = () => {
+            const createContract = vi.fn(async (params: Record<string, unknown>) => ({
+                ...params,
+                state: "active",
+                createdAt: 0,
+            }));
+            const setContractWatchState = vi.fn(async (_s: string, _w: string) => {});
+            const wallet = {
+                getContractManager: async () => ({ createContract, setContractWatchState }),
+            } as any;
+            const info = vi.spyOn(RestArkProvider.prototype, "getInfo").mockResolvedValue({
+                signerPubkey: "02" + hex.encode(SERVER_KEY),
+                checkpointTapscript: hex.encode(
+                    CSVMultisigTapscript.encode({
+                        timelock: { type: "blocks", value: 10n },
+                        pubkeys: [SERVER_KEY],
+                    }).script,
+                ),
+                network: "regtest",
+            } as any);
+            return { wallet, createContract, setContractWatchState, info };
+        };
+
+        it("registers the covenant of a pending deposit, and not of a filled one", async () => {
+            const pending = makeOffer("want-asset", BigInt(992));
+            const filled = makeOffer("want-asset", BigInt(993));
+            const fundingPending = fundingPsbt(pending);
+            const fundingFilled = fundingPsbt(filled);
+            const fill = spendPsbt([
+                { offer: filled, deposit: { txid: fundingFilled.txid, vout: 0 }, via: "fulfill" },
+            ]);
+            const indexer = makeIndexer(
+                [fundingPending, fundingFilled, fill],
+                [
+                    depositVtxo(pending, fundingPending.txid),
+                    spentVtxo(filled, fundingFilled.txid, fill.txid),
+                ],
+            );
+            const { wallet, createContract, setContractWatchState, info } = coverage();
+            try {
+                const { restored } = await restoreAssetSwaps(
+                    indexer,
+                    [walletTx(fundingPending.txid, "sent"), walletTx(fundingFilled.txid, "sent")],
+                    new Set(),
+                    { serverPubkey: SERVER_KEY, cover: { wallet, arkServerUrl: "http://ark" } },
+                );
+                expect(restored.map((s) => s.status).sort()).toEqual(["fulfilled", "pending"]);
+
+                // the same row createOffer writes: script-keyed, escrowed
+                expect(createContract).toHaveBeenCalledTimes(1);
+                expect(createContract.mock.calls[0][0]).toMatchObject({
+                    type: "arkade",
+                    script: scriptOf(pending),
+                    metadata: { genericallySpendable: false, kind: "asset-swap-offer" },
+                });
+                expect(setContractWatchState.mock.calls).toEqual([[scriptOf(pending), "watched"]]);
+            } finally {
+                info.mockRestore();
+            }
+        });
+
+        it("hands the registration the key it classified with, not the server's current one", async () => {
+            // after a signer rotation the caller passes the funding-time key;
+            // a restored record has no swapAddress to pin it, so without the
+            // hand-off the rebuild under today's key refuses every record
+            const offer = makeOffer("want-asset", BigInt(992));
+            const funding = fundingPsbt(offer);
+            const { wallet, createContract, info } = coverage();
+            info.mockResolvedValue({
+                signerPubkey: "02" + hex.encode(key("44")),
+                checkpointTapscript: hex.encode(
+                    CSVMultisigTapscript.encode({
+                        timelock: { type: "blocks", value: 10n },
+                        pubkeys: [key("44")],
+                    }).script,
+                ),
+                network: "regtest",
+            } as any);
+            try {
+                await restoreAssetSwaps(
+                    makeIndexer([funding], [depositVtxo(offer, funding.txid)]),
+                    [walletTx(funding.txid, "sent")],
+                    new Set(),
+                    { serverPubkey: SERVER_KEY, cover: { wallet, arkServerUrl: "http://ark" } },
+                );
+                expect(createContract).toHaveBeenCalledTimes(1);
+                expect(createContract.mock.calls[0][0]).toMatchObject({ script: scriptOf(offer) });
+            } finally {
+                info.mockRestore();
+            }
+        });
+
+        it("covers a swept deposit too — still the user's money at that script", async () => {
+            const offer = makeOffer("want-asset", BigInt(992));
+            const funding = fundingPsbt(offer);
+            const vtxo = depositVtxo(offer, funding.txid, { virtualStatus: { state: "swept" } });
+            const { wallet, createContract, info } = coverage();
+            try {
+                const { restored } = await restoreAssetSwaps(
+                    makeIndexer([funding], [vtxo]),
+                    [walletTx(funding.txid, "sent")],
+                    new Set(),
+                    { serverPubkey: SERVER_KEY, cover: { wallet, arkServerUrl: "http://ark" } },
+                );
+                expect(restored[0].status).toBe("recoverable");
+                expect(createContract).toHaveBeenCalledTimes(1);
+            } finally {
+                info.mockRestore();
+            }
+        });
+
+        it("returns the record and marks the txid scanned when the registration fails", async () => {
+            // best effort: the record is the user's way to cancel; losing it to
+            // an offline server would be worse than a deposit unwatched until
+            // the watcher's next start covers it
+            const offer = makeOffer("want-asset", BigInt(992));
+            const funding = fundingPsbt(offer);
+            const { wallet, info } = coverage();
+            info.mockRejectedValue(new Error("server down"));
+            const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+            try {
+                const { restored, scannedTxids } = await restoreAssetSwaps(
+                    makeIndexer([funding], [depositVtxo(offer, funding.txid)]),
+                    [walletTx(funding.txid, "sent")],
+                    new Set(),
+                    { serverPubkey: SERVER_KEY, cover: { wallet, arkServerUrl: "http://ark" } },
+                );
+                expect(restored).toHaveLength(1);
+                expect(scannedTxids).toEqual([funding.txid]);
+                expect(warn).toHaveBeenCalledWith(
+                    expect.stringContaining("could not re-register"),
+                    expect.anything(),
+                );
+            } finally {
+                info.mockRestore();
+                warn.mockRestore();
+            }
+        });
+
+        it("touches no wallet without it", async () => {
+            const offer = makeOffer("want-asset", BigInt(992));
+            const funding = fundingPsbt(offer);
+            const { info } = coverage();
+            try {
+                await scan(makeIndexer([funding], [depositVtxo(offer, funding.txid)]), [
+                    walletTx(funding.txid, "sent"),
+                ]);
+                expect(info).not.toHaveBeenCalled();
+            } finally {
+                info.mockRestore();
+            }
+        });
     });
 
     it("leaves a spend it cannot classify unscanned, rather than guessing", async () => {

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { base64, hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
-import { asset, ArkAddress, Transaction } from "@arkade-os/sdk";
-import { encodeOffer, offerVtxoScript, OFFER_CONTRACT_KIND, type Offer } from "../src/offer";
+import { asset, ArkAddress, CSVMultisigTapscript, Transaction } from "@arkade-os/sdk";
+import {
+    encodeOffer,
+    offerVtxoScript,
+    OFFER_CONTRACT_KIND,
+    OFFER_CONTRACT_LABEL,
+    type Offer,
+} from "../src/offer";
 import { InMemoryAssetSwapRepository } from "../src/repository";
 import { addAssetSwap, getAssetSwaps, type AssetSwap } from "../src/store";
 import { retireSettledOfferContracts } from "../src/coverage";
@@ -62,7 +68,19 @@ const makeWallet = (getVirtualTxs: (txids: string[]) => Promise<{ txs: string[] 
     const callbacks = new Set<(event: any) => void>();
     // a real ark address, so ArkAddress.decode recovers SERVER_KEY from it
     const address = new ArkAddress(SERVER_KEY, key("66"), "tark").encode();
-    const setContractWatchState = vi.fn(async (_script: string, _watch: string) => {});
+    // the row's watch state, as the manager would report it back: the last
+    // write wins, and a script never written is watched (the default)
+    const watchOf = new Map<string, string>();
+    const setContractWatchState = vi.fn(async (script: string, watch: string) => {
+        watchOf.set(script, watch);
+    });
+    // what the start-up sweep registers: `ensureOfferContracts` goes through
+    // the real ArkadeContract.register, which lands here
+    const createContract = vi.fn(async (params: Record<string, unknown>) => ({
+        ...params,
+        state: "active",
+        createdAt: 0,
+    }));
     const wallet = {
         getAddress: async () => address,
         getContractManager: async () => ({
@@ -71,12 +89,17 @@ const makeWallet = (getVirtualTxs: (txids: string[]) => Promise<{ txs: string[] 
                 return () => callbacks.delete(cb);
             },
             setContractWatchState,
+            createContract,
+            getContracts: async ({ script }: { script: string }) => [
+                { script, watch: watchOf.get(script) ?? "watched" },
+            ],
         }),
     } as any;
     return {
         wallet,
         getVirtualTxs,
         setContractWatchState,
+        createContract,
         emit: (event: any) => callbacks.forEach((cb) => cb(event)),
         listeners: () => callbacks.size,
     };
@@ -91,20 +114,52 @@ const spentEvent = (offer: Offer, spentTxid: string, overrides: Record<string, u
     ...overrides,
 });
 
-// the watcher builds its own RestIndexerProvider from arkServerUrl; intercept
-// the one call it makes rather than reaching through the constructor
+/** What the start-up sweep reads off the server: the signer key the offers
+ * above were built against, and a network to derive the row's address on. */
+const serverInfo = () => ({
+    signerPubkey: "02" + hex.encode(SERVER_KEY),
+    checkpointTapscript: hex.encode(
+        CSVMultisigTapscript.encode({
+            timelock: { type: "blocks", value: 10n },
+            pubkeys: [SERVER_KEY],
+        }).script,
+    ),
+    network: "regtest",
+    unilateralExitDelay: 4096n,
+});
+
+// the watcher builds its own RestIndexerProvider from arkServerUrl, and the
+// start-up sweep its own RestArkProvider; intercept the calls they make rather
+// than reaching through the constructors
+type Harness = ReturnType<typeof makeWallet>;
+
 const withIndexer = async (
     fetcher: (txids: string[]) => Promise<{ txs: string[] }>,
-    run: (harness: ReturnType<typeof makeWallet>) => Promise<void>,
+    run: (harness: Harness) => Promise<void>,
+    hooks: {
+        /** The server the sweep reads; sees the harness so it can emit mid-sweep. */
+        info?: (harness: Harness) => Promise<Record<string, unknown>>;
+        /** What the reconcile finds at the script; nothing indexed by default. */
+        vtxos?: () => Promise<{ vtxos: Record<string, unknown>[] }>;
+    } = {},
 ) => {
     const sdk = await import("@arkade-os/sdk");
+    const harness = makeWallet(fetcher);
     const spy = vi
         .spyOn(sdk.RestIndexerProvider.prototype, "getVirtualTxs")
         .mockImplementation(fetcher as any);
+    const vtxosSpy = vi
+        .spyOn(sdk.RestIndexerProvider.prototype, "getVtxos")
+        .mockImplementation((hooks.vtxos ?? (async () => ({ vtxos: [] }))) as any);
+    const infoSpy = vi
+        .spyOn(sdk.RestArkProvider.prototype, "getInfo")
+        .mockImplementation((() => (hooks.info ?? (async () => serverInfo()))(harness)) as any);
     try {
-        await run(makeWallet(fetcher));
+        await run(harness);
     } finally {
         spy.mockRestore();
+        vtxosSpy.mockRestore();
+        infoSpy.mockRestore();
     }
 };
 
@@ -317,6 +372,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up sweep's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -349,6 +406,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up sweep's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -382,6 +441,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up sweep's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -409,6 +470,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up sweep's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -436,6 +499,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up sweep's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -445,6 +510,300 @@ describe("watchOfferSwaps", () => {
             },
         );
         vi.restoreAllMocks();
+    });
+
+    it("registers the covenant of every live record at start, and of no settled one", async () => {
+        // The restored-wallet case: records are back, their deposits are on
+        // chain, and nothing has told the wallet the scripts are its own. The
+        // watcher hears only registered scripts, so it registers what it is
+        // asked to watch — the same row createOffer writes, escrow marker and
+        // all — and leaves the settled records alone.
+        const pending = makeOffer("want-asset");
+        const stuck: Offer = { ...pending, wantAmount: BigInt(993) };
+        stuck.swapPkScript = offerVtxoScript(stuck, SERVER_KEY).pkScript;
+        const done: Offer = { ...pending, wantAmount: BigInt(994) };
+        done.swapPkScript = offerVtxoScript(done, SERVER_KEY).pkScript;
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(pending));
+        await addAssetSwap(
+            repository,
+            swapFor(stuck, {
+                id: "cd".repeat(32),
+                fundingTxid: "cd".repeat(32),
+                status: "cancelling",
+            }),
+        );
+        await addAssetSwap(
+            repository,
+            swapFor(done, {
+                id: "ef".repeat(32),
+                fundingTxid: "ef".repeat(32),
+                status: "fulfilled",
+            }),
+        );
+
+        await withIndexer(
+            async () => ({ txs: [] }),
+            async ({ wallet, createContract, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                watcher.stop();
+
+                const registered = createContract.mock.calls.map(([row]) => row);
+                expect(registered.map((row) => row.script).sort()).toEqual(
+                    [hex.encode(pending.swapPkScript), hex.encode(stuck.swapPkScript)].sort(),
+                );
+                for (const row of registered) {
+                    expect(row.type).toBe("arkade");
+                    expect(row.label).toBe(OFFER_CONTRACT_LABEL);
+                    expect(row.metadata).toEqual({
+                        genericallySpendable: false,
+                        kind: OFFER_CONTRACT_KIND,
+                    });
+                }
+                // watched, without the issuance mark: a fill can retire it
+                expect(setContractWatchState.mock.calls.sort()).toEqual(
+                    [
+                        [hex.encode(pending.swapPkScript), "watched"],
+                        [hex.encode(stuck.swapPkScript), "watched"],
+                    ].sort(),
+                );
+            },
+        );
+    });
+
+    it("still resolves a fill after the fill retires a script the sweep covered", async () => {
+        // the mark `createOffer` sets would pin the script watched here; the
+        // sweep sets none, so the spend event's retire goes through
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "fulfilled" }]);
+                expect(setContractWatchState.mock.calls).toEqual([
+                    [hex.encode(offer.swapPkScript), "watched"],
+                    [hex.encode(offer.swapPkScript), "retained"],
+                ]);
+            },
+        );
+    });
+
+    it("starts, and keeps classifying, when the sweep cannot reach the server", async () => {
+        // best effort: an offline server at start costs coverage of restored
+        // records until the next start, never the watcher itself
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, createContract }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                expect(createContract).not.toHaveBeenCalled();
+                expect(warn).toHaveBeenCalledWith(
+                    expect.stringContaining("could not re-register"),
+                    expect.anything(),
+                );
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "fulfilled" }]);
+            },
+            {
+                info: async () => {
+                    throw new Error("server down");
+                },
+            },
+        );
+        vi.restoreAllMocks();
+    });
+
+    it("resolves a deposit spent before the sweep covered it, off the indexer", async () => {
+        // The event this record will never get: the fill landed while the
+        // script was uncovered (the wallet was restored, then closed), so the
+        // manager hydrates the deposit already spent and no vtxo_spent fires.
+        // The sweep reads the deposit's fate once and classifies it as an
+        // event would — the fill leaf — then retires the settled script.
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+        const updates: AssetSwap[] = [];
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                    onUpdate: (swap) => updates.push(swap),
+                });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([
+                    { status: "fulfilled", spentTxid: fill.txid },
+                ]);
+                expect(updates.map((u) => u.status)).toEqual(["fulfilled"]);
+                expect(setContractWatchState.mock.calls).toEqual([
+                    [hex.encode(offer.swapPkScript), "watched"],
+                    [hex.encode(offer.swapPkScript), "retained"],
+                ]);
+            },
+            {
+                vtxos: async () => ({
+                    vtxos: [
+                        {
+                            txid: FUNDING_TXID,
+                            vout: 0,
+                            script: hex.encode(offer.swapPkScript),
+                            virtualStatus: { state: "spent" },
+                            arkTxId: fill.txid,
+                        },
+                    ],
+                }),
+            },
+        );
+    });
+
+    it("marks a deposit swept before the sweep covered it recoverable, and keeps its script", async () => {
+        const offer = makeOffer();
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [] }),
+            async ({ wallet, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "recoverable" }]);
+                // swept money is still the user's money at that script
+                expect(setContractWatchState.mock.calls).toEqual([
+                    [hex.encode(offer.swapPkScript), "watched"],
+                ]);
+            },
+            {
+                vtxos: async () => ({
+                    vtxos: [
+                        {
+                            txid: FUNDING_TXID,
+                            vout: 0,
+                            script: hex.encode(offer.swapPkScript),
+                            virtualStatus: { state: "swept" },
+                        },
+                    ],
+                }),
+            },
+        );
+    });
+
+    it("leaves a covered deposit that is still unspent pending", async () => {
+        const offer = makeOffer();
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [] }),
+            async ({ wallet, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "pending" }]);
+                expect(setContractWatchState.mock.calls).toEqual([
+                    [hex.encode(offer.swapPkScript), "watched"],
+                ]);
+            },
+            {
+                vtxos: async () => ({
+                    vtxos: [
+                        {
+                            txid: FUNDING_TXID,
+                            vout: 0,
+                            script: hex.encode(offer.swapPkScript),
+                            virtualStatus: { state: "settled" },
+                        },
+                    ],
+                }),
+            },
+        );
+    });
+
+    it("retires a script whose fill landed mid-sweep, after the sweep re-watched it", async () => {
+        // The race: the sweep read its records (pending), a spend event lands
+        // and retires the script while the sweep is still talking to the
+        // server, then the sweep's own "watched" write comes last. Nothing
+        // would ever retire it again, so the sweep re-derives liveness for
+        // the scripts it touched once it is done.
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "fulfilled" }]);
+                const script = hex.encode(offer.swapPkScript);
+                // the sweep's "watched" did land after the event's retire —
+                // and the last word is "retained" again
+                const calls = setContractWatchState.mock.calls;
+                expect(calls).toContainEqual([script, "watched"]);
+                expect(calls[calls.length - 1]).toEqual([script, "retained"]);
+                expect(calls.indexOf(calls.find((c) => c[1] === "watched")!)).toBeLessThan(
+                    calls.length - 1,
+                );
+            },
+            {
+                // the event arrives while the sweep is reading the server
+                info: async ({ emit }) => {
+                    emit(spentEvent(offer, fill.txid));
+                    return serverInfo();
+                },
+            },
+        );
     });
 
     it("stops delivering after stop()", async () => {

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -787,14 +787,15 @@ describe("watchOfferSwaps", () => {
 
                 expect(await getAssetSwaps(repository)).toMatchObject([{ status: "fulfilled" }]);
                 const script = hex.encode(offer.swapPkScript);
-                // the sweep's "watched" did land after the event's retire —
-                // and the last word is "retained" again
+                // the sweep's cover is what re-watched the script, outracing
+                // the mid-sweep fill's retire; the sweep's own liveness
+                // re-derive has the last word: "retained" again
                 const calls = setContractWatchState.mock.calls;
-                expect(calls).toContainEqual([script, "watched"]);
+                const firstWatched = calls.findIndex((c) => c[1] === "watched");
+                const firstRetained = calls.findIndex((c) => c[1] === "retained");
+                expect(firstWatched).toBeGreaterThanOrEqual(0);
+                expect(firstRetained).toBeGreaterThan(firstWatched);
                 expect(calls[calls.length - 1]).toEqual([script, "retained"]);
-                expect(calls.indexOf(calls.find((c) => c[1] === "watched")!)).toBeLessThan(
-                    calls.length - 1,
-                );
             },
             {
                 // the event arrives while the sweep is reading the server

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -512,6 +512,11 @@ describe("watchOfferSwaps", () => {
         vi.restoreAllMocks();
     });
 
+    // ── AI-generated, and to be redone ──────────────────────────────────────
+    // The start-up sweep cases below were written by Claude, not by hand. They
+    // are kept for the coverage they give the fix, not for their shape; rewrite
+    // them by hand before reading them as the specification.
+
     it("registers the covenant of every live record at start, and of no settled one", async () => {
         // The restored-wallet case: records are back, their deposits are on
         // chain, and nothing has told the wallet the scripts are its own. The

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -397,6 +397,10 @@ const balance = await wallet.getBalance()
 console.log('Total Balance:', balance.total)
 console.log('Boarding Total:', balance.boarding.total)
 console.log('Offchain Available:', balance.available)
+// the most one send can move out while the wallet's assets stay: what a
+// "send max" or "swap all" control prefills. One dust carrier under
+// `available` once any spendable coin carries an asset
+console.log('Max sendable:', balance.maxSendable)
 console.log('Offchain Settled:', balance.settled)
 console.log('Offchain Preconfirmed:', balance.preconfirmed)
 console.log('Gated by a contract:', balance.gated) // swap escrow, chiefly

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -168,6 +168,12 @@ import { createAssetPacket, selectCoinsWithAsset } from "./wallet/asset";
 import { TxTree, TxTreeNode } from "./tree/txTree";
 import { SignerSession, TreeNonces, TreePartialSigs } from "./tree/signingSession";
 import { DustChangeError, Ramps } from "./wallet/ramps";
+import {
+    AssetChangeCarrierError,
+    SelectedVtxosCannotCarryAssetChangeError,
+    SendAboveMaxSendableError,
+    type AssetChangeCarrierFacts,
+} from "./wallet/sendErrors";
 import { HDDescriptorProvider } from "./wallet/hdDescriptorProvider";
 import { isVtxoExpiringSoon, VtxoManager } from "./wallet/vtxo-manager";
 import type {
@@ -616,6 +622,10 @@ export {
     OnchainWallet,
     Ramps,
     DustChangeError,
+    AssetChangeCarrierError,
+    SendAboveMaxSendableError,
+    SelectedVtxosCannotCarryAssetChangeError,
+    type AssetChangeCarrierFacts,
     VtxoManager,
     classifyContractSigner,
     classifyAgainstSignerSet,

--- a/packages/ts-sdk/src/wallet/balance.ts
+++ b/packages/ts-sdk/src/wallet/balance.ts
@@ -10,7 +10,27 @@ import { canRecoverOnchain, canSpendOffchain, hasTerminalSpend } from "./vtxo";
 export interface OffchainBalance {
     settled: number;
     preconfirmed: number;
+    /**
+     * What generic selection may pick: `settled + preconfirmed - gated -
+     * intentLocked`. Not what one `send` can move out — see {@link maxSendable}.
+     */
     available: number;
+    /**
+     * The largest amount one `send` to a single recipient is sure to accept
+     * while every asset the wallet holds stays behind: {@link available}, less
+     * one dust carrier once any spendable coin carries an asset
+     * (`availableAssets` non-empty). Asset change has to land on a change
+     * output at or above dust, so a send of `available` itself is refused
+     * whenever the coins it selects carry assets — and after the first asset
+     * receive that is every wallet, since assets arrive on a dust carrier that
+     * `available` counts. A ceiling, not a tight bound: an amount the plain
+     * coins alone cover goes through above it, but only this figure holds
+     * whatever coins selection picks. Zero when less than dust could leave —
+     * a send pads its recipient to dust before selecting, so nothing below
+     * dust ever leaves on its own — and so zero when the carriers are all
+     * there is.
+     */
+    maxSendable: number;
     /**
      * Spendable-but-for-the-gate funds: VTXOs under a contract
      * {@link BalanceCapabilities.isGenericallySpendable} refuses — a VHTLC
@@ -63,6 +83,12 @@ export interface OffchainBalance {
  */
 export interface BalanceCapabilities {
     now: TimeHeight;
+    /**
+     * The server's dust floor — what a change output has to hold to carry
+     * asset change, and so the reserve {@link OffchainBalance.maxSendable}
+     * keeps back.
+     */
+    dust: bigint;
     /** Past-cutoff deprecated-signer funds awaiting recovery. */
     isPendingRecovery: (vtxo: NormalizedExtendedVirtualCoin) => boolean;
     /** The generic-spending gate. @see isContractGenericallySpendable */
@@ -77,8 +103,10 @@ export interface BalanceCapabilities {
  * Owned vs spendable is the whole shape here. `settled`/`preconfirmed`/`total`
  * and `assets` count everything the wallet owns — escrowed funds are still the
  * user's funds. `available` and `availableAssets` count only what generic
- * spending would actually pick, so nothing reported as available can be refused
- * by `send`.
+ * spending would actually pick. `maxSendable` is the one figure a `send` amount
+ * can be taken from as-is: `available` overstates it by one dust carrier
+ * whenever the spendable coins carry assets, because the asset change those
+ * coins produce needs a change output at or above dust to land on.
  *
  * Terminally spent VTXOs are skipped outright: no capability predicate claims
  * them, and they must not reach the asset rollup. An unrolled one is not spent,
@@ -89,7 +117,7 @@ export function computeOffchainBalance(
     vtxos: readonly NormalizedExtendedVirtualCoin[],
     caps: BalanceCapabilities,
 ): OffchainBalance {
-    const { now, isPendingRecovery, isGenericallySpendable, isUnlocked } = caps;
+    const { now, dust, isPendingRecovery, isGenericallySpendable, isUnlocked } = caps;
 
     let settled = 0;
     let preconfirmed = 0;
@@ -164,10 +192,22 @@ export function computeOffchainBalance(
     const toAssets = (from: Map<string, bigint>): Asset[] =>
         Array.from(from.entries()).map(([assetId, amount]) => ({ assetId, amount }));
 
+    // One carrier covers every asset: `send` consolidates all asset change onto
+    // its single change output, so the reserve is a dust floor, not a per-asset
+    // sum. Keyed on `spendable` rather than `owned` — assets held only on gated
+    // or locked coins are never selected and produce no change to carry.
+    const carrierReserve = spendable.size > 0 ? Number(dust) : 0;
+    const ceiling = available - carrierReserve;
+    // Below dust nothing leaves alone: `send` pads its recipient to dust
+    // before selecting, so a ceiling under dust is a send that cannot be
+    // covered, not a small one.
+    const maxSendable = ceiling >= Number(dust) ? ceiling : 0;
+
     return {
         settled,
         preconfirmed,
         available,
+        maxSendable,
         gated,
         intentLocked,
         recoverable,

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -393,10 +393,33 @@ export interface WalletBalance {
     preconfirmed: number;
     /**
      * Immediately spendable offchain balance — what generic selection would
-     * pick, so nothing counted here can be refused by `send`:
-     * `settled + preconfirmed - gated - intentLocked`.
+     * pick: `settled + preconfirmed - gated - intentLocked`.
+     *
+     * Not the ceiling on one `send`: that is {@link maxSendable}. The two
+     * differ by one dust carrier whenever a spendable coin carries an asset.
      */
     available: number;
+
+    /**
+     * The largest amount a single `send` to one recipient is sure to accept
+     * while every asset the wallet holds stays behind — the figure a "send
+     * max" or "swap all" control should prefill, and the balance to validate
+     * such an amount against.
+     *
+     * Equal to {@link available} until the wallet holds an asset on a spendable
+     * coin, then `available` less the dust floor: asset change has to land on a
+     * change output at or above dust, so a send of `available` itself is
+     * refused once the coins it selects carry assets. Assets arrive on a dust
+     * carrier that `available` counts, so after the first asset receive this is
+     * the figure that holds. A ceiling rather than a tight bound — an amount
+     * the plain coins alone cover still goes through above it — and zero when
+     * less than dust could leave, since `send` pads its recipient to dust
+     * before selecting. Several sub-dust recipients pad to dust each, which
+     * this single figure does not model. Sending the assets along with the
+     * sats frees the reserve, which is why {@link availableAssets} stays the
+     * ceiling on the asset side.
+     */
+    maxSendable: number;
     /**
      * Spendable-but-for-the-gate funds: VTXOs under a contract the
      * generic-spending gate refuses — a VHTLC lockup, an unmarked `arkade`

--- a/packages/ts-sdk/src/wallet/sendErrors.ts
+++ b/packages/ts-sdk/src/wallet/sendErrors.ts
@@ -1,0 +1,118 @@
+/**
+ * Refusals from `Wallet.send` when asset change has nowhere to land.
+ *
+ * An asset rides a BTC carrier: the sats are the output, the asset is an
+ * annotation on it. `send` consolidates every asset the inputs carried but the
+ * recipients did not take onto its **one** change output, so that output has to
+ * hold at least the dust floor — an asset change output below dust is a change
+ * output the server will not accept.
+ *
+ * That makes "send all the sats" and "keep the assets" incompatible past a
+ * point, and the point is one dust below the spendable balance. Before these
+ * errors existed the refusal surfaced as `Insufficient funds` from coin
+ * selection, against a balance that plainly covered the amount, which is the
+ * least useful thing it could have said.
+ *
+ * Two ways to arrive, two remedies, so two errors — narrow to
+ * {@link AssetChangeCarrierError} for "the assets had no carrier" regardless of
+ * which:
+ *
+ * - {@link SendAboveMaxSendableError} — generic selection, and the wallet has
+ *   no spare coin left to fund the carrier. Recoverable by the caller: send
+ *   `maxSendable` instead, or include the assets in the send and free the
+ *   reserve entirely.
+ * - {@link SelectedVtxosCannotCarryAssetChangeError} — the caller pinned the
+ *   inputs with `selectedVtxos`, so `send` may not reach for a coin it was not
+ *   given. There is no ceiling to report; the remedy is to name more inputs.
+ */
+
+/** What both refusals carry: the change that would be left, and the floor it
+ * failed to reach. */
+export interface AssetChangeCarrierFacts {
+    /** Sats of BTC change the send would leave for the assets to ride. */
+    changeAmount: number;
+    /** Distinct assets needing that one change output. */
+    assetChangeCount: number;
+    /** The floor a change output must reach to carry them. */
+    dustAmount: bigint;
+}
+
+/**
+ * A send whose asset change could not be given a carrier at or above dust.
+ *
+ * Abstract on purpose: every instance is one of the two subclasses, which
+ * differ in whether a ceiling can be named. Catch this to handle both.
+ */
+export abstract class AssetChangeCarrierError extends Error {
+    /** Sats of BTC change the send would leave for the assets to ride. */
+    readonly changeAmount: number;
+    /** Distinct assets needing that one change output. */
+    readonly assetChangeCount: number;
+    /** The floor a change output must reach to carry them. */
+    readonly dustAmount: bigint;
+
+    protected constructor(
+        message: string,
+        facts: AssetChangeCarrierFacts,
+        options?: { cause?: unknown },
+    ) {
+        super(message, options);
+        this.changeAmount = facts.changeAmount;
+        this.assetChangeCount = facts.assetChangeCount;
+        this.dustAmount = facts.dustAmount;
+    }
+}
+
+/**
+ * Thrown when generic selection has no spare sat left to fund the carrier the
+ * asset change needs — the "send all" of a wallet that holds an asset.
+ *
+ * {@link maxSendable} is the same figure `WalletBalance.maxSendable` reports,
+ * computed from the same spendable set, so a caller that prefilled a "send max"
+ * control from the balance and raced a receive can re-read it from the refusal
+ * rather than parsing the message.
+ */
+export class SendAboveMaxSendableError extends AssetChangeCarrierError {
+    override readonly name = "SendAboveMaxSendableError";
+
+    /**
+     * The largest send that still leaves the assets a carrier — equal to
+     * `WalletBalance.maxSendable`, and zero when less than dust could leave.
+     */
+    readonly maxSendable: number;
+
+    constructor(
+        facts: AssetChangeCarrierFacts & { maxSendable: number },
+        options?: { cause?: unknown },
+    ) {
+        super(
+            `send: ${facts.changeAmount} sats of change cannot carry ${facts.assetChangeCount} asset ` +
+                `change(s), needs ${facts.dustAmount} — send at most ${facts.maxSendable} sats ` +
+                `(WalletBalance.maxSendable) to keep the assets, or send them too`,
+            facts,
+            options,
+        );
+        this.maxSendable = facts.maxSendable;
+    }
+}
+
+/**
+ * Thrown when the caller pinned the inputs with `selectedVtxos` and those
+ * inputs leave too little change to carry the asset change.
+ *
+ * No ceiling is reported: the wallet may hold coins that would fund the
+ * carrier, but this path may not reach for one the caller did not name. The
+ * remedy is to name more inputs, not to lower the amount.
+ */
+export class SelectedVtxosCannotCarryAssetChangeError extends AssetChangeCarrierError {
+    override readonly name = "SelectedVtxosCannotCarryAssetChangeError";
+
+    constructor(facts: AssetChangeCarrierFacts, options?: { cause?: unknown }) {
+        super(
+            `send({ selectedVtxos }): ${facts.changeAmount} sats of change cannot carry ` +
+                `${facts.assetChangeCount} asset change(s), needs ${facts.dustAmount}`,
+            facts,
+            options,
+        );
+    }
+}

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1663,6 +1663,9 @@ export class WalletMessageHandler
         // No chain tip: this is an offline-first read.
         const offchain = computeOffchainBalance(allVtxos, {
             now: { timestamp: new Date() },
+            // Without a wallet `repoSnapshot` is empty, so no reserve ever
+            // applies and the fallback is never read against a real coin.
+            dust: this.readonlyWallet?.dustAmount ?? 0n,
             isPendingRecovery: (vtxo) => pendingOutpoints.has(`${vtxo.txid}:${vtxo.vout}`),
             isGenericallySpendable: (vtxo) => !gated.has(vtxo.script),
             isUnlocked: (vtxo) => unlocked.has(`${vtxo.txid}:${vtxo.vout}`),
@@ -1677,6 +1680,7 @@ export class WalletMessageHandler
             settled: offchain.settled,
             preconfirmed: offchain.preconfirmed,
             available: offchain.available,
+            maxSendable: offchain.maxSendable,
             gated: offchain.gated,
             intentLocked: offchain.intentLocked,
             recoverable: offchain.recoverable,

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -1231,8 +1231,9 @@ export class ReadonlyWallet implements IReadonlyWallet {
 
         // `settled`/`preconfirmed`/`total` and the `assets` rollup count every VTXO
         // the wallet owns, including escrowed and intent-locked ones; `available`
-        // and `availableAssets` count only what generic spending would pick, so
-        // nothing reported as available can be refused by `send`.
+        // and `availableAssets` count only what generic spending would pick.
+        // `maxSendable` is the send ceiling: one dust carrier under `available`
+        // while a spendable coin carries an asset (see computeOffchainBalance).
         const totalBoarding = confirmed + unconfirmed;
         const offchain = computeOffchainBalance(
             vtxos,
@@ -1248,6 +1249,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
             settled: offchain.settled,
             preconfirmed: offchain.preconfirmed,
             available: offchain.available,
+            maxSendable: offchain.maxSendable,
             gated: offchain.gated,
             intentLocked: offchain.intentLocked,
             recoverable: offchain.recoverable,
@@ -1434,6 +1436,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         );
         return {
             now: { timestamp: new Date() },
+            dust: this.dustAmount,
             isPendingRecovery: (vtxo) => pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`),
             isGenericallySpendable: (vtxo) => !gated.has(vtxo.script),
             isUnlocked: (vtxo) => unlocked.has(`${vtxo.txid}:${vtxo.vout}`),
@@ -5663,10 +5666,25 @@ export class Wallet
             const availableCoins = virtualCoins.filter(
                 (c) => !selectedCoins.find((sc) => sc.txid === c.txid && sc.vout === c.vout),
             );
-            const { inputs: extraCoins } = selectVirtualCoins(
-                availableCoins,
-                Number(this.dustAmount) - changeAmount,
-            );
+            const shortfall = Number(this.dustAmount) - changeAmount;
+            const spare = availableCoins.reduce((sum, c) => sum + c.value, 0);
+            if (spare < shortfall) {
+                // Every spendable sat is already an input or spoken for by the
+                // recipients, so nothing can fund the carrier the asset change
+                // needs. This is the "send all" of a wallet that holds assets,
+                // and `selectVirtualCoins` would report it as "Insufficient
+                // funds" against a balance that plainly covers the amount —
+                // name the actual ceiling instead. `totalBtcSelected + spare`
+                // is every spendable sat, so the ceiling is the balance's
+                // `maxSendable`.
+                const ceiling = Math.max(0, totalBtcSelected + spare - Number(this.dustAmount));
+                throw new Error(
+                    `send: ${changeAmount} sats of change cannot carry ${assetChanges.size} asset ` +
+                        `change(s), needs ${this.dustAmount} — send at most ${ceiling} sats ` +
+                        `(WalletBalance.maxSendable) to keep the assets, or send them too`,
+                );
+            }
+            const { inputs: extraCoins } = selectVirtualCoins(availableCoins, shortfall);
 
             for (const coin of extraCoins) {
                 if (coin.assets) {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -5676,8 +5676,11 @@ export class Wallet
                 // funds" against a balance that plainly covers the amount —
                 // name the actual ceiling instead. `totalBtcSelected + spare`
                 // is every spendable sat, so the ceiling is the balance's
-                // `maxSendable`.
-                const ceiling = Math.max(0, totalBtcSelected + spare - Number(this.dustAmount));
+                // `maxSendable` — the same floor as there: below dust nothing
+                // leaves alone (a recipient is padded to dust), so a ceiling
+                // under dust is zero, not a small send.
+                const rawCeiling = Math.max(0, totalBtcSelected + spare - Number(this.dustAmount));
+                const ceiling = rawCeiling >= Number(this.dustAmount) ? rawCeiling : 0;
                 throw new Error(
                     `send: ${changeAmount} sats of change cannot carry ${assetChanges.size} asset ` +
                         `change(s), needs ${this.dustAmount} — send at most ${ceiling} sats ` +

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -192,6 +192,7 @@ import {
     DescriptorSigningProviderMissingError,
     MissingSigningDescriptorError,
 } from "./signingErrors";
+import { SelectedVtxosCannotCarryAssetChangeError, SendAboveMaxSendableError } from "./sendErrors";
 
 export const getArkadeServerUrl = ({ arkServerUrl }: { arkServerUrl?: string }) =>
     arkServerUrl || DEFAULT_ARKADE_SERVER_URL;
@@ -5664,10 +5665,11 @@ export class Wallet
             if (selectedVtxos) {
                 // Asset change needs a change output at or above dust, and this path
                 // may not reach for a coin the caller did not name.
-                throw new Error(
-                    `send({ selectedVtxos }): ${changeAmount} sats of change cannot carry ` +
-                        `${assetChanges.size} asset change(s), needs ${this.dustAmount}`,
-                );
+                throw new SelectedVtxosCannotCarryAssetChangeError({
+                    changeAmount,
+                    assetChangeCount: assetChanges.size,
+                    dustAmount: this.dustAmount,
+                });
             }
             const availableCoins = virtualCoins.filter(
                 (c) => !selectedCoins.find((sc) => sc.txid === c.txid && sc.vout === c.vout),
@@ -5687,11 +5689,12 @@ export class Wallet
                 // under dust is zero, not a small send.
                 const rawCeiling = Math.max(0, totalBtcSelected + spare - Number(this.dustAmount));
                 const ceiling = rawCeiling >= Number(this.dustAmount) ? rawCeiling : 0;
-                throw new Error(
-                    `send: ${changeAmount} sats of change cannot carry ${assetChanges.size} asset ` +
-                        `change(s), needs ${this.dustAmount} — send at most ${ceiling} sats ` +
-                        `(WalletBalance.maxSendable) to keep the assets, or send them too`,
-                );
+                throw new SendAboveMaxSendableError({
+                    changeAmount,
+                    assetChangeCount: assetChanges.size,
+                    dustAmount: this.dustAmount,
+                    maxSendable: ceiling,
+                });
             }
             const { inputs: extraCoins } = selectVirtualCoins(availableCoins, shortfall);
 

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -499,12 +499,12 @@ describe("send keeps a carrier for asset change", () => {
         }),
     ];
 
-    const makeWallet = async () => {
+    const makeWallet = async (overrideCoins: ReturnType<typeof coins> = coins()) => {
         const wallet = await Wallet.create({
             identity: mockIdentity,
             arkServerUrl: "http://localhost:7070",
         });
-        vi.spyOn(wallet, "getSpendableVtxos").mockResolvedValue(coins() as never);
+        vi.spyOn(wallet, "getSpendableVtxos").mockResolvedValue(overrideCoins as never);
         return wallet;
     };
 
@@ -531,6 +531,27 @@ describe("send keeps a carrier for asset change", () => {
         // change under a 1000 floor, and no spare coin to top it up.
         await expect(wallet.send({ address: ADDR, amount: 40_500 })).rejects.toThrow(
             /200 sats of change cannot carry 1 asset change\(s\), needs 1000 — send at most 39700 sats/,
+        );
+    });
+
+    it("reports zero, agreeing with maxSendable, when between one and two dust would leave", async () => {
+        // available is 1_500 on a single asset carrier: nothing but the
+        // carrier to spend, so a send of one dust consumes it whole, and the
+        // asset change is stranded exactly as "swap all" is. maxSendable's
+        // floor bites here: 1_500 - 1_000 = 500 < dust, so the ceiling is 0,
+        // not 500 — `send` pads its recipient to dust, so anything under dust
+        // cannot leave alone.
+        const wallet = await makeWallet([
+            createMockExtendedVtxo({
+                txid: "3".repeat(64),
+                vout: 0,
+                value: 1_500,
+                virtualStatus: { state: "settled" },
+                assets: [{ assetId: ASSET, amount: 5n }],
+            }) as never,
+        ]);
+        await expect(wallet.send({ address: ADDR, amount: 1_000 })).rejects.toThrow(
+            /500 sats of change cannot carry 1 asset change\(s\), needs 1000 — send at most 0 sats \(WalletBalance\.maxSendable\)/,
         );
     });
 

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -460,6 +460,9 @@ describe("send with caller-selected vtxos", () => {
  * of every wallet that has ever received an asset, since assets arrive on a
  * dust carrier the balance counts.
  */
+// AI-generated, and to be redone: written by Claude, kept for the coverage it
+// gives the fix rather than for its shape. Rewrite by hand before reading it as
+// the specification.
 describe("send keeps a carrier for asset change", () => {
     const ASSET = "a".repeat(64);
     const ADDR = encodeAddr(SERVER_XONLY, "tark");

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { hex } from "@scure/base";
 import { Script } from "@scure/btc-signer";
-import { Wallet, SingleKey, type Recipient } from "../src";
+import {
+    AssetChangeCarrierError,
+    SelectedVtxosCannotCarryAssetChangeError,
+    SendAboveMaxSendableError,
+    SingleKey,
+    Wallet,
+    type Recipient,
+} from "../src";
 import { VtxoScript } from "../src/script/base";
 import { ArkAddress } from "../src/script/address";
 import {
@@ -565,6 +572,42 @@ describe("send keeps a carrier for asset change", () => {
         // that the carrier was found and the send got past coin selection.
         expect(String(err)).not.toMatch(/cannot carry/);
         expect(String(err)).not.toMatch(/Insufficient funds/);
+    });
+
+    // The ceiling is the reason this refusal exists, so a caller has to be able
+    // to read it back without parsing the sentence it appears in — a "send max"
+    // control that raced a receive re-prefills from the error itself.
+    it("carries the ceiling as a field, not only in the message", async () => {
+        const wallet = await makeWallet();
+        const err = await wallet.send({ address: ADDR, amount: 40_700 }).catch((e: unknown) => e);
+
+        expect(err).toBeInstanceOf(SendAboveMaxSendableError);
+        expect(err).toBeInstanceOf(AssetChangeCarrierError);
+        const refusal = err as SendAboveMaxSendableError;
+        expect(refusal.name).toBe("SendAboveMaxSendableError");
+        expect(refusal.maxSendable).toBe(39_700);
+        expect(refusal.changeAmount).toBe(0);
+        expect(refusal.assetChangeCount).toBe(1);
+        expect(refusal.dustAmount).toBe(1_000n);
+    });
+
+    // Distinct remedy, distinct type: the wallet may hold a coin that would
+    // fund the carrier, but this path may not reach for one the caller did not
+    // name, so there is no ceiling to report and lowering the amount is the
+    // wrong advice.
+    it("refuses caller-pinned inputs under a different type, with no ceiling", async () => {
+        const wallet = await makeWallet();
+        const err = await wallet
+            .send({
+                recipients: [{ address: ADDR, amount: 40_700 }],
+                selectedVtxos: coins() as never,
+            })
+            .catch((e: unknown) => e);
+
+        expect(err).toBeInstanceOf(SelectedVtxosCannotCarryAssetChangeError);
+        expect(err).toBeInstanceOf(AssetChangeCarrierError);
+        expect(err).not.toBeInstanceOf(SendAboveMaxSendableError);
+        expect(err).not.toHaveProperty("maxSendable");
     });
 });
 

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -9,6 +9,7 @@ import {
     validateRecipients,
     type RecipientAddressContext,
 } from "../src/wallet/utils";
+import { createMockExtendedVtxo } from "./contracts/helpers";
 
 // Mock fetch
 const { mockFetch } = vi.hoisted(() => ({
@@ -448,6 +449,98 @@ describe("send with caller-selected vtxos", () => {
                 selectedVtxos: [coin(2000, [{ assetId: ASSET_A, amount: 100n }])],
             }),
         ).rejects.toThrow(/cannot carry 1 asset change\(s\), needs 1000/);
+    });
+});
+
+/**
+ * Generic selection with a wallet that holds assets: the balance figure and
+ * the send path agree. `maxSendable` goes through; `available` is refused —
+ * and refused with the ceiling named, not as "Insufficient funds" against a
+ * balance that plainly covers the amount. This is the "swap all" / "send max"
+ * of every wallet that has ever received an asset, since assets arrive on a
+ * dust carrier the balance counts.
+ */
+describe("send keeps a carrier for asset change", () => {
+    const ASSET = "a".repeat(64);
+    const ADDR = encodeAddr(SERVER_XONLY, "tark");
+    const mockIdentity = SingleKey.fromHex(
+        "ce66c68f8875c0c98a502c666303dc183a21600130013c06f9d1edf60207abf2",
+    );
+    const mockArkInfo = {
+        signerPubkey: SERVER_KEY_HEX,
+        forfeitPubkey: SERVER_KEY_HEX,
+        batchExpiry: BigInt(144),
+        unilateralExitDelay: BigInt(144),
+        boardingExitDelay: BigInt(144),
+        roundInterval: BigInt(144),
+        network: "mutinynet",
+        dust: BigInt(1000),
+        forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+        checkpointTapscript:
+            "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
+    };
+
+    // 40k on a plain coin, 700 on a carrier an asset arrived on. Selection is
+    // expiry-then-amount, so the plain coin goes first and the carrier is
+    // reached only when the amount outgrows it.
+    const coins = () => [
+        createMockExtendedVtxo({
+            txid: "1".repeat(64),
+            vout: 0,
+            value: 40_000,
+            virtualStatus: { state: "settled" },
+        }),
+        createMockExtendedVtxo({
+            txid: "2".repeat(64),
+            vout: 0,
+            value: 700,
+            virtualStatus: { state: "settled" },
+            assets: [{ assetId: ASSET, amount: 5n }],
+        }),
+    ];
+
+    const makeWallet = async () => {
+        const wallet = await Wallet.create({
+            identity: mockIdentity,
+            arkServerUrl: "http://localhost:7070",
+        });
+        vi.spyOn(wallet, "getSpendableVtxos").mockResolvedValue(coins() as never);
+        return wallet;
+    };
+
+    beforeEach(() => {
+        mockFetch.mockReset();
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve(mockArkInfo),
+        });
+    });
+
+    it("refuses a send of the whole balance and names the ceiling", async () => {
+        const wallet = await makeWallet();
+        // 40_700 is `available`; every sat is an input, so the asset change
+        // has nothing left to ride on. The ceiling is `available - dust`.
+        await expect(wallet.send({ address: ADDR, amount: 40_700 })).rejects.toThrow(
+            /0 sats of change cannot carry 1 asset change\(s\), needs 1000 — send at most 39700 sats \(WalletBalance\.maxSendable\)/,
+        );
+    });
+
+    it("names the ceiling when the change is short of dust, not only when it is zero", async () => {
+        const wallet = await makeWallet();
+        // 40_500 outgrows the plain coin, so the carrier is picked too: 200 of
+        // change under a 1000 floor, and no spare coin to top it up.
+        await expect(wallet.send({ address: ADDR, amount: 40_500 })).rejects.toThrow(
+            /200 sats of change cannot carry 1 asset change\(s\), needs 1000 — send at most 39700 sats/,
+        );
+    });
+
+    it("lets a send of `maxSendable` through the accounting", async () => {
+        const wallet = await makeWallet();
+        const err = await wallet.send({ address: ADDR, amount: 39_700 }).catch((e: unknown) => e);
+        // It fails later, at the submit this mock cannot serve. What matters is
+        // that the carrier was found and the send got past coin selection.
+        expect(String(err)).not.toMatch(/cannot carry/);
+        expect(String(err)).not.toMatch(/Insufficient funds/);
     });
 });
 

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -22,6 +22,8 @@ import {
 } from "../src";
 import type { ArkInfo } from "../src/providers/ark";
 import { InMemoryIntentRepository } from "../src/repositories/inMemory/intentRepository";
+import { computeOffchainBalance } from "../src/wallet/balance";
+import { normalizeVtxo } from "../src/wallet/vtxo";
 import {
     DEFAULT_MESSAGE_TAG,
     WalletMessageHandler,
@@ -547,6 +549,97 @@ describe("getBalance", () => {
         expect(amount(balance.availableAssets)).toBe(12n); // 7 + 5
         // The escrowed asset amount, without a new balance bucket.
         expect(amount(balance.assets) - amount(balance.availableAssets)).toBe(10n);
+    });
+
+    it("keeps one dust carrier under available in maxSendable while spendable coins carry assets", async () => {
+        // Both spendable coins (own 40k, marked 10k) carry the asset, so a send
+        // of `available` would leave asset change with nothing to ride on. The
+        // reserve is the server's dust (1000 here), once — not per asset, not
+        // per coin.
+        const { wallet } = await seededWallet();
+        const balance = await wallet.getBalance();
+
+        expect(balance.available).toBe(50_000);
+        expect(balance.maxSendable).toBe(49_000);
+        expectSplit(balance);
+    });
+});
+
+/**
+ * The reserve, isolated from the wallet: which coins count, and what happens
+ * when the carriers are all there is.
+ */
+describe("computeOffchainBalance.maxSendable", () => {
+    const OWN = "51200000000000000000000000000000000000000000000000000000000000000010";
+    const OTHER = "51200000000000000000000000000000000000000000000000000000000000000011";
+    const DUST = 1000n;
+
+    const compute = (
+        coins: ReturnType<typeof vtxo>[],
+        caps: Partial<Parameters<typeof computeOffchainBalance>[1]> = {},
+    ) =>
+        computeOffchainBalance(coins.map(normalizeVtxo), {
+            now: { timestamp: new Date() },
+            dust: DUST,
+            isPendingRecovery: () => false,
+            isGenericallySpendable: () => true,
+            isUnlocked: () => true,
+            ...caps,
+        });
+
+    it("equals available while no spendable coin carries an asset", () => {
+        const balance = compute([vtxo(OWN, 40_000), vtxo(OTHER, 2_500)]);
+        expect(balance.available).toBe(42_500);
+        expect(balance.maxSendable).toBe(42_500);
+    });
+
+    it("reserves exactly one dust floor however many assets and carriers there are", () => {
+        // Three carriers, two assets: `send` puts every asset change on its one
+        // change output, so the floor is paid once.
+        const balance = compute([
+            vtxo(OWN, 40_000),
+            vtxo(OTHER, 330, [{ assetId: ASSET_ID, amount: 5n }]),
+            vtxo(OWN.replace(/10$/, "12"), 330, [{ assetId: ASSET_ID, amount: 1n }]),
+            vtxo(OWN.replace(/10$/, "13"), 330, [{ assetId: "bb".repeat(32), amount: 9n }]),
+        ]);
+        expect(balance.available).toBe(40_990);
+        expect(balance.maxSendable).toBe(39_990);
+    });
+
+    it("is zero when the carriers are all the wallet has", () => {
+        const balance = compute([vtxo(OWN, 330, [{ assetId: ASSET_ID, amount: 5n }])]);
+        expect(balance.available).toBe(330);
+        expect(balance.maxSendable).toBe(0);
+    });
+
+    it("is zero when less than dust could leave", () => {
+        // `send` pads its recipient to dust before selecting, so a wallet of
+        // 700 plain sats under a 1000 floor cannot send 700 — or anything
+        expect(compute([vtxo(OWN, 700)]).maxSendable).toBe(0);
+        // and one carrier of 1500 leaves 500 under the reserve: the change
+        // would be short of dust however small the send
+        expect(compute([vtxo(OWN, 1_500, [{ assetId: ASSET_ID, amount: 5n }])]).maxSendable).toBe(
+            0,
+        );
+        // exactly dust left is exactly sendable
+        expect(compute([vtxo(OWN, 2_000, [{ assetId: ASSET_ID, amount: 5n }])]).maxSendable).toBe(
+            1_000,
+        );
+        expect(compute([vtxo(OWN, 1_000)]).maxSendable).toBe(1_000);
+    });
+
+    it("ignores assets that sit only on coins generic selection never picks", () => {
+        // A gated coin and an intent-locked coin both hold the asset; neither
+        // is an input a send could take, so neither produces change to carry.
+        const gated = vtxo(OTHER, 10_000, [{ assetId: ASSET_ID, amount: 5n }]);
+        const locked = vtxo(OWN.replace(/10$/, "14"), 10_000, [{ assetId: ASSET_ID, amount: 5n }]);
+        const balance = compute([vtxo(OWN, 40_000), gated, locked], {
+            isGenericallySpendable: (v) => v.script !== OTHER,
+            isUnlocked: (v) => v.txid !== locked.txid,
+        });
+        expect(balance.available).toBe(40_000);
+        expect(balance.availableAssets).toEqual([]);
+        expect(balance.maxSendable).toBe(40_000);
     });
 });
 

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -569,6 +569,9 @@ describe("getBalance", () => {
  * The reserve, isolated from the wallet: which coins count, and what happens
  * when the carriers are all there is.
  */
+// AI-generated, and to be redone: written by Claude, kept for the coverage it
+// gives the fix rather than for its shape. Rewrite by hand before reading it as
+// the specification.
 describe("computeOffchainBalance.maxSendable", () => {
     const OWN = "51200000000000000000000000000000000000000000000000000000000000000010";
     const OTHER = "51200000000000000000000000000000000000000000000000000000000000000011";

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -2035,6 +2035,8 @@ describe("WalletMessageHandler repo-backed reads", () => {
             payload: {
                 settled: 30000,
                 available: 30000,
+                // no asset on any spendable coin: nothing held back
+                maxSendable: 30000,
             },
         });
     });
@@ -2077,6 +2079,8 @@ describe("WalletMessageHandler repo-backed reads", () => {
                 settled: 30000,
                 total: 30000,
                 available: 10000,
+                // the spendable coin carries an asset: one dust (546) carrier held back
+                maxSendable: 9454,
                 gated: 20000,
                 intentLocked: 0,
                 assets: [{ assetId: "cc".repeat(32), amount: 7n }],


### PR DESCRIPTION
## Goal

End-to-end coverage for the swap flows arkade.money runs and this SDK never exercised against a solver: swap all in both directions, asset -> BTC, a wrong-priced offer that stays pending and is cancelled, and the record status after a wallet restore or reload. One file changes: `packages/swap/test/e2e/swap.test.ts`, which gains a second block that runs through the regtest stack's own solverd (BTC/RGT market, 1 sat = 1 RGT, fee 0).

Update (c321a429): the fix is now on this branch, so the suite is green end to end. Two product defects, two fixes:

- **ts-sdk** gains `WalletBalance.maxSendable` — `available` less one dust carrier whenever a spendable coin carries an asset (floored at zero). `send` names that ceiling when asset change would be stranded instead of reporting a misleading bare "Insufficient funds". This is the "swap all" hazard arkade.money's Max button hits.
- **swap** re-covers offer covenants after a restore: `ensureOfferContracts` registers a landed deposit's covenant, `restoreAssetSwaps` takes a `cover` option (handing the registration its funding-time server key, correct across rotations), and `watchOfferSwaps` sweeps live records at start-up — re-registering covenants for non-terminal records and reconciling each deposit against the chain, so a fill that landed while nothing watched is picked up. The same reconcile re-runs on `connection_reset`.

The two places the tests disagreed with the fix's semantics were reconciled to the fix: the swap-all-BTC case plans off `maxSendable` (not `available`), and `restoreFromKey` passes `cover`, as arkade.money's restore does. The fix was developed as commits c484d68c + a513ffeb on the author's follow-up branch and is squashed into c321a429 here.

Original report below, for the record:

---

Tests only, on purpose. The cases that fail on master are the report.

## Cases

| # | Asked for | Test |
|---|---|---|
| 1 | Swap ALL BTC -> asset | `swap ALL BTC -> RGT: the balance the wallet reports available funds the offer, and it fills` |
| 2 | Swap ALL asset -> BTC | `swap ALL RGT -> BTC: the whole asset balance goes, and the solver pays sats` |
| 3 | Asset -> BTC at the wrong price, stays pending, cancel | `RGT -> BTC at the WRONG price stays pending, and cancels` |
| 4 | Asset -> BTC leaving change | `RGT -> BTC leaving asset change: part of the balance goes, the solver pays sats, the rest stays` |
| 5 | BTC -> asset leaving change | `BTC -> RGT leaving change: quoted off the card, validated, funded, and filled` |
| 6 | Wrong price, restore, cancel from the restored wallet | `RGT -> BTC at the WRONG price, restored from the key alone, then cancelled from the restored wallet` |
| 7 | Asset -> BTC, restore, then filled | `RGT -> BTC restored before the solver takes it: the restored wallet sees the fill` |
| + | Statuses stay right across a reload | `reload on the same storage: a fill that landed while nothing watched is picked up, a pending offer still cancels` |
| + | Statuses stay right across a restore | `restored from the key alone, every record reads the status the live wallet holds` |

Every case goes through the path arkade.money takes: `planOffer` off the solver's card, `validatePlan`, `createOffer`, `wallet.send`, the record, then `watchOfferSwaps`, `restoreAssetSwaps` or `cancelOffer`. "Restore" is the same key on fresh repositories. "Reload" is the same key on the same repositories, with a new `Wallet` instance and watcher. Case 7 pauses the `solver` container across the funding, so the solver only sees the offer once the restored wallet is watching.

## Results on master (CI run 3150, head 0f3f6db): 9 pass, 5 fail

The five failures are the report. Each is a product defect, with the actual CI message:

- **Swap all BTC -> RGT** — `funding the offer with the wallet's own available balance (10330 sats, 10000 RGT held) was refused: Insufficient funds`. A wallet holding an asset offers its whole `available`; every asset sits on a dust carrier that `available` counts, so the send leaves the asset change nothing to ride on and `send` refuses it. This is the "swap all" arkade.money's Max button hits.
- **Wrong price, restore, cancel from the restored wallet** — `expected 6700n to be 8000n`. After a restore the escrowed asset should still read as owned. The live maker, which kept the covenant registration, counts it (8000); a wallet restored from the key alone does not (6700), because nothing re-covers the covenant, so the 1300-unit escrow is invisible until the cancel brings it back.
- **Restore before the fill** — `record … reads "pending" 90000 ms on, expected "fulfilled" — its deposit is spent on chain`. `restoreAssetSwaps` rebuilds the record, but nothing registers the covenant with the restored wallet, so its watcher never receives the spend.
- **Reload on the same storage** — same message. A fill that lands while no watcher runs produces no event afterward, so the record stays pending.
- **Restore, every record's status** — `expected [ Array(1) ] to deeply equal []`. Follows from the reload gap: a live record still pending whose deposit is spent.

Swap all RGT -> BTC passes, which is correct: sending the whole asset frees its carriers, so that direction has no swap-all hazard.

The candidate fix for all five failures (`maxSendable`, re-registration on restore, a watcher start-up reconcile) was developed at commits c484d68c + a513ffeb and now lands here as c321a429, with its unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vNcqAg1BGU3KJgU5jVJsL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `maxSendable` to wallet balances to show the maximum transferable amount while preserving asset-backed funds.
  * Improved send validation with detailed errors when asset dust reserves limit transfers.
  * Restored swaps can automatically re-register and watch live deposits.
  * Swap monitoring now reconciles missed, swept, and filled deposits at startup.
  * Added support for watching already-landed deposits without recording a new issuance.

* **Documentation**
  * Updated balance, swap funding, and restore guidance for sendable amounts and deposit recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->