### PR TITLE
fix(sdk): gate transaction history the way balance is gated

### DIFF
--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -46,15 +46,23 @@ export type GatedContracts = ReadonlyMap<string, string>;
  * generic spending is open to it.
  *
  * The single spelling of the per-VTXO question, so the gate cannot be asked two
- * subtly different ways. Strict on `script`, matching `isVtxoForScript`: a VTXO
- * with a missing or empty script belongs to no contract row at all, so it is the
- * wallet's own coin.
+ * subtly different ways. A VTXO with no script belongs to no contract row, so it
+ * is the wallet's own coin.
+ *
+ * The `undefined` check is deliberately not a truthiness check, so that an
+ * empty-string script still asks the map rather than being read as "no
+ * contract". The two spellings are indistinguishable on both SDK read paths —
+ * `isVtxoForScript` keeps a `""`-scripted coin out of every snapshot bucket, and
+ * `saveVtxosForContract` refuses to persist one — so this is not a guarantee to
+ * lean on, only the pre-existing semantics preserved verbatim. It is kept
+ * because this predicate now decides coin selection and the `available` balance
+ * as well as history, which is not the place to take on a gratuitous difference.
  */
 function gatedTypeOf(
     vtxo: Pick<ExcludableVtxo, "script">,
     gated: GatedContracts,
 ): string | undefined {
-    return vtxo.script ? gated.get(vtxo.script) : undefined;
+    return vtxo.script === undefined ? undefined : gated.get(vtxo.script);
 }
 
 /** {@link gatedTypeOf} as a predicate, for callers with no use for the type. */

--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -31,7 +31,7 @@ export function gatedContracts(contracts: readonly Contract[]): Map<string, stri
  * actually holds, so the four callers that need the gate do not keep
  * `gatedContracts(snapshot.map((_) => _.contract))` in step by hand.
  */
-export function gatedFrom(snapshot: readonly { contract: Contract }[]): Map<string, string> {
+export function gatedFrom(snapshot: readonly { contract: Contract }[]): GatedContracts {
     return gatedContracts(snapshot.map((entry) => entry.contract));
 }
 
@@ -50,7 +50,7 @@ export type GatedContracts = ReadonlyMap<string, string>;
  * with a missing or empty script belongs to no contract row at all, so it is the
  * wallet's own coin.
  */
-export function gatedTypeOf(
+function gatedTypeOf(
     vtxo: Pick<ExcludableVtxo, "script">,
     gated: GatedContracts,
 ): string | undefined {

--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -26,6 +26,15 @@ export function gatedContracts(contracts: readonly Contract[]): Map<string, stri
     return gated;
 }
 
+/**
+ * {@link gatedContracts} over the contract+VTXO snapshot every read path
+ * actually holds, so the four callers that need the gate do not keep
+ * `gatedContracts(snapshot.map((_) => _.contract))` in step by hand.
+ */
+export function gatedFrom(snapshot: readonly { contract: Contract }[]): Map<string, string> {
+    return gatedContracts(snapshot.map((entry) => entry.contract));
+}
+
 /** The minimum a VTXO must carry to be matched against an exclusion set. */
 export type ExcludableVtxo = { txid: string; vout: number; script?: string };
 

--- a/packages/ts-sdk/src/contracts/spendability.ts
+++ b/packages/ts-sdk/src/contracts/spendability.ts
@@ -29,6 +29,30 @@ export function gatedContracts(contracts: readonly Contract[]): Map<string, stri
 /** The minimum a VTXO must carry to be matched against an exclusion set. */
 export type ExcludableVtxo = { txid: string; vout: number; script?: string };
 
+/** {@link gatedContracts}' answer, as callers that only read it should take it. */
+export type GatedContracts = ReadonlyMap<string, string>;
+
+/**
+ * The type of the gated contract this VTXO belongs to, or `undefined` when
+ * generic spending is open to it.
+ *
+ * The single spelling of the per-VTXO question, so the gate cannot be asked two
+ * subtly different ways. Strict on `script`, matching `isVtxoForScript`: a VTXO
+ * with a missing or empty script belongs to no contract row at all, so it is the
+ * wallet's own coin.
+ */
+export function gatedTypeOf(
+    vtxo: Pick<ExcludableVtxo, "script">,
+    gated: GatedContracts,
+): string | undefined {
+    return vtxo.script ? gated.get(vtxo.script) : undefined;
+}
+
+/** {@link gatedTypeOf} as a predicate, for callers with no use for the type. */
+export function isGatedVtxo(vtxo: Pick<ExcludableVtxo, "script">, gated: GatedContracts): boolean {
+    return gatedTypeOf(vtxo, gated) !== undefined;
+}
+
 /**
  * Why generic spending skips a VTXO, or `undefined` when it does not — phrased
  * to follow the outpoint in a log line.
@@ -51,9 +75,9 @@ export type VtxoExclusion = (vtxo: ExcludableVtxo) => string | undefined;
  * already available here, so the message can tell them apart instead of
  * collapsing both into one sentence that reads as the same case either way.
  */
-export function gateExclusion(gated: ReadonlyMap<string, string>): VtxoExclusion {
+export function gateExclusion(gated: GatedContracts): VtxoExclusion {
     return (vtxo) => {
-        const type = vtxo.script === undefined ? undefined : gated.get(vtxo.script);
+        const type = gatedTypeOf(vtxo, gated);
         if (type === undefined) return undefined;
         // A handler present but declaring no `isGenericallySpendable` predicate
         // reads the same as an explicit decline here: both are this build

--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -36,9 +36,10 @@ function localCreatedAtByTxid(vtxos: readonly NormalizedVirtualCoin[]): Map<stri
  * "into my own escrow" from "to a stranger" rather than the movement arriving
  * unattributed.
  *
- * Offchain only. A gated coin settled in a batch carries `settledBy` and no
- * `arkTxId`, so it reaches neither set and the exit or batch row facing it stays
- * untagged — the corridor case this change deliberately does not interpret.
+ * Offchain only: a gated coin settled in a batch carries `settledBy` and no
+ * `arkTxId`, so it reaches neither set and the batch or exit row facing it goes
+ * untagged. What that partition does to those arms' arithmetic is a larger gap,
+ * described where the partition happens.
  */
 function gatedTouchpoints(gated: readonly NormalizedVirtualCoin[]): {
     paidIn: ReadonlySet<string>;
@@ -165,21 +166,27 @@ export async function buildTransactionHistory(
         .map(normalizeVtxo)
         .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
+    const localCreatedAt = localCreatedAtByTxid(normalized);
+
     // `getBalance`'s predicate, put to a different question. Balance asks what
     // may be spent, and still counts a gated coin in `total`; history asks whose
-    // money moved, and everything below cross-references this set to decide
-    // change, receives and spent totals — so a gated coin left in it is one the
+    // money moved — so a gated coin left among the wallet's own is one the
     // history reads as the user's, which is exactly how an escrowed deposit and
     // its return used to cancel each other out and vanish.
-    // Built over every coin, before the partition: which transactions the wallet
-    // can date locally does not depend on which side of the gate a coin fell.
-    const localCreatedAt = localCreatedAtByTxid(normalized);
+    //
+    // `ownVtxos` is what every arm below cross-references, and only the two
+    // offchain arms have been reasoned about against its new, narrower
+    // membership. The batch and exit arms read it too: a gated coin settled in a
+    // batch is missing from both `forfeitVtxos` and their `changes`, so an exit
+    // row can under- or over-count and an escrow returning through a batch can
+    // produce no row at all, depending on which side of the settle it sits.
+    // Tracked in #860; this change does not interpret that corridor.
     const gatedVtxos = normalized.filter((vtxo) => isGatedVtxo(vtxo, gatedScripts));
-    const fromOldestVtxo = normalized.filter((vtxo) => !isGatedVtxo(vtxo, gatedScripts));
+    const ownVtxos = normalized.filter((vtxo) => !isGatedVtxo(vtxo, gatedScripts));
     const { paidIn: paidIntoGated, paidOut: paidOutOfGated } = gatedTouchpoints(gatedVtxos);
 
     const txidsNeedingCreatedAt = resolveTxCreatedAt
-        ? collectArkTxidsNeedingCreatedAt(fromOldestVtxo, localCreatedAt)
+        ? collectArkTxidsNeedingCreatedAt(ownVtxos, localCreatedAt)
         : [];
     const resolvedCreatedAt =
         resolveTxCreatedAt && txidsNeedingCreatedAt.length > 0
@@ -192,7 +199,7 @@ export async function buildTransactionHistory(
     const sent: ExtendedArkTransaction[] = [];
     let received: ExtendedArkTransaction[] = [];
 
-    for (const vtxo of fromOldestVtxo) {
+    for (const vtxo of ownVtxos) {
         if (vtxo.status.isLeaf) {
             // If this virtual output is a leaf and it's not the settlement of a boarding or there's no virtual output refreshed by it,
             // it's translated into a received batch transaction
@@ -211,7 +218,7 @@ export async function buildTransactionHistory(
                             tx.key.commitmentTxid === vtxo.settledBy),
                 );
             } else if (
-                fromOldestVtxo.filter((v) => v.settledBy === vtxo.commitmentTxIds[0]).length === 0
+                ownVtxos.filter((v) => v.settledBy === vtxo.commitmentTxIds[0]).length === 0
             ) {
                 const duplicateBoardingReceive = consumeBoardingReceive(
                     unmatchedSettledBoardingTxs,
@@ -234,7 +241,7 @@ export async function buildTransactionHistory(
                     });
                 }
             }
-        } else if (fromOldestVtxo.filter((v) => v.arkTxId === vtxo.txid).length === 0) {
+        } else if (ownVtxos.filter((v) => v.arkTxId === vtxo.txid).length === 0) {
             // If this virtual output is preconfirmed and does not spend any other virtual outputs,
             // it's translated into a received offchain transaction
             const assets = collectAssets([vtxo]);
@@ -258,11 +265,11 @@ export async function buildTransactionHistory(
         if (vtxo.isSpent) {
             // If the virtual output is spent offchain, it's translated into an offchain sent tx
             if (vtxo.arkTxId && !sent.some((s) => s.key.arkTxid === vtxo.arkTxId)) {
-                const changes = fromOldestVtxo.filter((_) => _.txid === vtxo.arkTxId);
+                const changes = ownVtxos.filter((_) => _.txid === vtxo.arkTxId);
 
                 // We want to find all the other virtual outputs spent by the same transaction to
                 // calculate the full amount of the change.
-                const allSpent = fromOldestVtxo.filter((v) => v.arkTxId === vtxo.arkTxId);
+                const allSpent = ownVtxos.filter((v) => v.arkTxId === vtxo.arkTxId);
                 const spentAmount = allSpent.reduce((acc, v) => acc + v.value, 0);
 
                 let txAmount = 0;
@@ -314,14 +321,14 @@ export async function buildTransactionHistory(
                 !commitmentsToIgnore.has(vtxo.settledBy) &&
                 !sent.some((s) => s.key.commitmentTxid === vtxo.settledBy)
             ) {
-                const changes = fromOldestVtxo.filter(
+                const changes = ownVtxos.filter(
                     (v) =>
                         v.status.isLeaf &&
                         v.commitmentTxIds.length > 0 &&
                         v.commitmentTxIds.every((_) => vtxo.settledBy === _),
                 );
 
-                const forfeitVtxos = fromOldestVtxo.filter((v) => v.settledBy === vtxo.settledBy);
+                const forfeitVtxos = ownVtxos.filter((v) => v.settledBy === vtxo.settledBy);
                 const forfeitAmount = forfeitVtxos.reduce((acc, v) => acc + v.value, 0);
 
                 if (changes.length > 0) {

--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -7,32 +7,47 @@ type ExtendedArkTransaction = ArkTransaction & {
 };
 
 /**
- * Where an Arkade transaction touched one of the wallet's gated contracts:
- * `paidIn` maps the txid of a transaction that created a gated output to when
- * that output was created, `paidOut` holds the txids that spent one.
+ * When each transaction the wallet holds an output of was created, keyed by
+ * txid. Every coin counts, gated or not: holding *any* output of a transaction
+ * is what makes its creation time known without asking the indexer.
  *
- * Two jobs, one pass over the coins the gate set aside. Membership tags the row
- * facing the contract, so a consumer can tell "into my own escrow" from "to a
- * stranger" rather than the movement being dropped unattributed. `paidIn`'s
- * value dates a send whose outputs all went to the escrow: the wallet keeps no
- * change to read the time off, and the gated output is that time — already
- * local, where the fallback is the *input* coin's timestamp, which files a fresh
- * deposit at the wrong end of the history.
+ * Stating that once is what keeps the gate from complicating it. The rule is
+ * older than the gate — a spend that left change has always read its time off
+ * that change — and the partition below must not turn it into a per-partition
+ * special case, or a swap deposit with no change would be dated from the *input*
+ * coin and filed at the wrong end of the history.
+ */
+function localCreatedAtByTxid(vtxos: readonly NormalizedVirtualCoin[]): Map<string, number> {
+    const createdAt = new Map<string, number>();
+    for (const vtxo of vtxos) {
+        // Outputs of one transaction share a creation time, so the first write
+        // settles it; the caller's ascending sort makes that the earliest.
+        if (vtxo.txid && !createdAt.has(vtxo.txid)) {
+            createdAt.set(vtxo.txid, vtxo.createdAt.getTime());
+        }
+    }
+    return createdAt;
+}
+
+/**
+ * Where an Arkade transaction touched one of the wallet's gated contracts:
+ * `paidIn` holds the txids that created a gated output, `paidOut` the txids that
+ * spent one. Membership tags the row facing the contract, so a consumer can tell
+ * "into my own escrow" from "to a stranger" rather than the movement arriving
+ * unattributed.
  *
  * Offchain only. A gated coin settled in a batch carries `settledBy` and no
  * `arkTxId`, so it reaches neither set and the exit or batch row facing it stays
  * untagged — the corridor case this change deliberately does not interpret.
  */
 function gatedTouchpoints(gated: readonly NormalizedVirtualCoin[]): {
-    paidIn: ReadonlyMap<string, number>;
+    paidIn: ReadonlySet<string>;
     paidOut: ReadonlySet<string>;
 } {
-    const paidIn = new Map<string, number>();
+    const paidIn = new Set<string>();
     const paidOut = new Set<string>();
     for (const vtxo of gated) {
-        // First write wins: the caller passes these in `createdAt` order, and
-        // outputs of one transaction share a creation time anyway.
-        if (vtxo.txid && !paidIn.has(vtxo.txid)) paidIn.set(vtxo.txid, vtxo.createdAt.getTime());
+        if (vtxo.txid) paidIn.add(vtxo.txid);
         if (vtxo.isSpent && vtxo.arkTxId) paidOut.add(vtxo.arkTxId);
     }
     return { paidIn, paidOut };
@@ -99,28 +114,20 @@ function subtractAssets(spent: VirtualCoin[], change: VirtualCoin[]): Asset[] | 
 
 /**
  * Ark txids the main loop needs a `createdAt` for: spent virtual outputs whose
- * spending tx left no change output in the wallet. Exactly the loop's fetch set.
- *
- * `datedLocally` is the gate's contribution — transactions whose only outputs
- * went to a gated contract still have one of those outputs in hand, so they need
- * no round-trip. Without it, gating history would add an indexer call for every
- * escrow deposit, which is precisely the shape it exists to surface.
+ * spending transaction left the wallet no output to read the time off. Exactly
+ * the loop's fetch set, and exactly the complement of {@link localCreatedAtByTxid}
+ * — which is why gating history costs no extra indexer call, even though it
+ * moves a swap deposit's only local output out of the loop's own set.
  */
 function collectArkTxidsNeedingCreatedAt(
-    vtxos: NormalizedVirtualCoin[],
-    datedLocally: ReadonlyMap<string, number>,
+    vtxos: readonly NormalizedVirtualCoin[],
+    localCreatedAt: ReadonlyMap<string, number>,
 ): string[] {
     // Set, not a scan per vtxo: this runs over the whole history, and the wallets
     // that need the batching are the ones large enough for O(n²) to hurt.
-    const ownTxids = new Set(vtxos.map((v) => v.txid));
     const txids = new Set<string>();
     for (const vtxo of vtxos) {
-        if (
-            vtxo.isSpent &&
-            vtxo.arkTxId &&
-            !ownTxids.has(vtxo.arkTxId) &&
-            !datedLocally.has(vtxo.arkTxId)
-        ) {
+        if (vtxo.isSpent && vtxo.arkTxId && !localCreatedAt.has(vtxo.arkTxId)) {
             txids.add(vtxo.arkTxId);
         }
     }
@@ -164,12 +171,15 @@ export async function buildTransactionHistory(
     // change, receives and spent totals — so a gated coin left in it is one the
     // history reads as the user's, which is exactly how an escrowed deposit and
     // its return used to cancel each other out and vanish.
+    // Built over every coin, before the partition: which transactions the wallet
+    // can date locally does not depend on which side of the gate a coin fell.
+    const localCreatedAt = localCreatedAtByTxid(normalized);
     const gatedVtxos = normalized.filter((vtxo) => isGatedVtxo(vtxo, gatedScripts));
     const fromOldestVtxo = normalized.filter((vtxo) => !isGatedVtxo(vtxo, gatedScripts));
     const { paidIn: paidIntoGated, paidOut: paidOutOfGated } = gatedTouchpoints(gatedVtxos);
 
     const txidsNeedingCreatedAt = resolveTxCreatedAt
-        ? collectArkTxidsNeedingCreatedAt(fromOldestVtxo, paidIntoGated)
+        ? collectArkTxidsNeedingCreatedAt(fromOldestVtxo, localCreatedAt)
         : [];
     const resolvedCreatedAt =
         resolveTxCreatedAt && txidsNeedingCreatedAt.length > 0
@@ -263,13 +273,12 @@ export async function buildTransactionHistory(
                     txTime = changes[0].createdAt.getTime();
                 } else {
                     txAmount = spentAmount;
-                    // No change output to read the time off. The escrow's own
-                    // output dates it exactly and needs no network; the resolver
-                    // answers for an ordinary send-all; the input coin's
-                    // timestamp is the last resort and is only approximately
-                    // right.
+                    // No change to read the time off, but the wallet may still
+                    // hold another of this tx's outputs — an escrow deposit does.
+                    // Failing that the resolver answers, and the input coin's
+                    // timestamp is the last resort, only approximately right.
                     txTime =
-                        paidIntoGated.get(vtxo.arkTxId) ??
+                        localCreatedAt.get(vtxo.arkTxId) ??
                         resolvedCreatedAt.get(vtxo.arkTxId) ??
                         vtxo.createdAt.getTime() + 1;
                 }

--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -30,14 +30,9 @@ function gatedTouchpoints(gated: readonly NormalizedVirtualCoin[]): {
     const paidIn = new Map<string, number>();
     const paidOut = new Set<string>();
     for (const vtxo of gated) {
-        if (vtxo.txid) {
-            const createdAt = vtxo.createdAt.getTime();
-            const known = paidIn.get(vtxo.txid);
-            // Outputs of one transaction share a creation time; taking the
-            // earliest keeps the answer independent of iteration order if a
-            // backend ever hands back two that disagree.
-            if (known === undefined || createdAt < known) paidIn.set(vtxo.txid, createdAt);
-        }
+        // First write wins: the caller passes these in `createdAt` order, and
+        // outputs of one transaction share a creation time anyway.
+        if (vtxo.txid && !paidIn.has(vtxo.txid)) paidIn.set(vtxo.txid, vtxo.createdAt.getTime());
         if (vtxo.isSpent && vtxo.arkTxId) paidOut.add(vtxo.arkTxId);
     }
     return { paidIn, paidOut };

--- a/packages/ts-sdk/src/utils/transactionHistory.ts
+++ b/packages/ts-sdk/src/utils/transactionHistory.ts
@@ -1,9 +1,48 @@
 import { ArkTransaction, Asset, BuiltinTxTag, TxKey, TxType, VirtualCoin } from "../wallet";
 import { normalizeVtxo, type NormalizedVirtualCoin } from "../wallet/vtxo";
+import { isGatedVtxo, type GatedContracts } from "../contracts/spendability";
 
 type ExtendedArkTransaction = ArkTransaction & {
     tag: BuiltinTxTag;
 };
+
+/**
+ * Where an Arkade transaction touched one of the wallet's gated contracts:
+ * `paidIn` maps the txid of a transaction that created a gated output to when
+ * that output was created, `paidOut` holds the txids that spent one.
+ *
+ * Two jobs, one pass over the coins the gate set aside. Membership tags the row
+ * facing the contract, so a consumer can tell "into my own escrow" from "to a
+ * stranger" rather than the movement being dropped unattributed. `paidIn`'s
+ * value dates a send whose outputs all went to the escrow: the wallet keeps no
+ * change to read the time off, and the gated output is that time — already
+ * local, where the fallback is the *input* coin's timestamp, which files a fresh
+ * deposit at the wrong end of the history.
+ *
+ * Offchain only. A gated coin settled in a batch carries `settledBy` and no
+ * `arkTxId`, so it reaches neither set and the exit or batch row facing it stays
+ * untagged — the corridor case this change deliberately does not interpret.
+ */
+function gatedTouchpoints(gated: readonly NormalizedVirtualCoin[]): {
+    paidIn: ReadonlyMap<string, number>;
+    paidOut: ReadonlySet<string>;
+} {
+    const paidIn = new Map<string, number>();
+    const paidOut = new Set<string>();
+    for (const vtxo of gated) {
+        if (vtxo.txid) {
+            const createdAt = vtxo.createdAt.getTime();
+            const known = paidIn.get(vtxo.txid);
+            // Outputs of one transaction share a creation time; taking the
+            // earliest keeps the answer independent of iteration order if a
+            // backend ever hands back two that disagree.
+            if (known === undefined || createdAt < known) paidIn.set(vtxo.txid, createdAt);
+        }
+        if (vtxo.isSpent && vtxo.arkTxId) paidOut.add(vtxo.arkTxId);
+    }
+    return { paidIn, paidOut };
+}
+
 const txKey: TxKey = {
     commitmentTxid: "",
     boardingTxid: "",
@@ -66,14 +105,27 @@ function subtractAssets(spent: VirtualCoin[], change: VirtualCoin[]): Asset[] | 
 /**
  * Ark txids the main loop needs a `createdAt` for: spent virtual outputs whose
  * spending tx left no change output in the wallet. Exactly the loop's fetch set.
+ *
+ * `datedLocally` is the gate's contribution — transactions whose only outputs
+ * went to a gated contract still have one of those outputs in hand, so they need
+ * no round-trip. Without it, gating history would add an indexer call for every
+ * escrow deposit, which is precisely the shape it exists to surface.
  */
-function collectArkTxidsNeedingCreatedAt(vtxos: NormalizedVirtualCoin[]): string[] {
+function collectArkTxidsNeedingCreatedAt(
+    vtxos: NormalizedVirtualCoin[],
+    datedLocally: ReadonlyMap<string, number>,
+): string[] {
     // Set, not a scan per vtxo: this runs over the whole history, and the wallets
     // that need the batching are the ones large enough for O(n²) to hurt.
     const ownTxids = new Set(vtxos.map((v) => v.txid));
     const txids = new Set<string>();
     for (const vtxo of vtxos) {
-        if (vtxo.isSpent && vtxo.arkTxId && !ownTxids.has(vtxo.arkTxId)) {
+        if (
+            vtxo.isSpent &&
+            vtxo.arkTxId &&
+            !ownTxids.has(vtxo.arkTxId) &&
+            !datedLocally.has(vtxo.arkTxId)
+        ) {
             txids.add(vtxo.arkTxId);
         }
     }
@@ -89,6 +141,15 @@ function collectArkTxidsNeedingCreatedAt(vtxos: NormalizedVirtualCoin[]): string
  * @param {Set<string>} commitmentsToIgnore - A set of commitment IDs that should be excluded from processing.
  * @param resolveTxCreatedAt - Batched `createdAt` resolver, called at most once; missing txids
  * fall back to the spent output's `createdAt + 1`.
+ * @param gatedScripts - The contracts generic spending is closed on, as
+ * `gatedContracts()` returns them. Their VTXOs are read as an external
+ * counterparty: they are not the wallet's own coins, so a deposit into one is a
+ * send and its return is a receive, rather than both cancelling out as change.
+ * The rows facing them are tagged `"gated"`. It defaults to empty — every VTXO
+ * counts as the wallet's own, the behaviour that predates the gate — so that
+ * histories with no contract rows to judge, the unit suite's included, stay
+ * source-compatible. Every SDK read path passes it; a new one that means to
+ * report a wallet's own money must too.
  * @return {ExtendedArkTransaction[]} A sorted array of extended Arkade transactions, representing the transaction history.
  */
 export async function buildTransactionHistory(
@@ -96,13 +157,24 @@ export async function buildTransactionHistory(
     allBoardingTxs: ArkTransaction[],
     commitmentsToIgnore: Set<string>,
     resolveTxCreatedAt?: (txids: string[]) => Promise<Map<string, number>>,
+    gatedScripts: GatedContracts = new Map(),
 ): Promise<ExtendedArkTransaction[]> {
-    const fromOldestVtxo = vtxos
+    const normalized = vtxos
         .map(normalizeVtxo)
         .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
+    // `getBalance`'s predicate, put to a different question. Balance asks what
+    // may be spent, and still counts a gated coin in `total`; history asks whose
+    // money moved, and everything below cross-references this set to decide
+    // change, receives and spent totals — so a gated coin left in it is one the
+    // history reads as the user's, which is exactly how an escrowed deposit and
+    // its return used to cancel each other out and vanish.
+    const gatedVtxos = normalized.filter((vtxo) => isGatedVtxo(vtxo, gatedScripts));
+    const fromOldestVtxo = normalized.filter((vtxo) => !isGatedVtxo(vtxo, gatedScripts));
+    const { paidIn: paidIntoGated, paidOut: paidOutOfGated } = gatedTouchpoints(gatedVtxos);
+
     const txidsNeedingCreatedAt = resolveTxCreatedAt
-        ? collectArkTxidsNeedingCreatedAt(fromOldestVtxo)
+        ? collectArkTxidsNeedingCreatedAt(fromOldestVtxo, paidIntoGated)
         : [];
     const resolvedCreatedAt =
         resolveTxCreatedAt && txidsNeedingCreatedAt.length > 0
@@ -163,7 +235,10 @@ export async function buildTransactionHistory(
             const assets = collectAssets([vtxo]);
             received.push({
                 key: { ...txKey, arkTxid: vtxo.txid! },
-                tag: "offchain",
+                // The escrow paying out: a swap fill or a cancel spends the
+                // gated coin and lands the proceeds here. Nothing else about
+                // the row changes — the tag only names the counterparty.
+                tag: paidOutOfGated.has(vtxo.txid!) ? "gated" : "offchain",
                 type: TxType.TxReceived,
                 amount: vtxo.value,
                 settled: vtxo.status.isLeaf || vtxo.isSpent!,
@@ -193,7 +268,15 @@ export async function buildTransactionHistory(
                     txTime = changes[0].createdAt.getTime();
                 } else {
                     txAmount = spentAmount;
-                    txTime = resolvedCreatedAt.get(vtxo.arkTxId) ?? vtxo.createdAt.getTime() + 1;
+                    // No change output to read the time off. The escrow's own
+                    // output dates it exactly and needs no network; the resolver
+                    // answers for an ordinary send-all; the input coin's
+                    // timestamp is the last resort and is only approximately
+                    // right.
+                    txTime =
+                        paidIntoGated.get(vtxo.arkTxId) ??
+                        resolvedCreatedAt.get(vtxo.arkTxId) ??
+                        vtxo.createdAt.getTime() + 1;
                 }
 
                 const assets = subtractAssets(allSpent, changes);
@@ -207,7 +290,10 @@ export async function buildTransactionHistory(
                 if (txAmount !== 0 || assets) {
                     sent.push({
                         key: { ...txKey, arkTxid: vtxo.arkTxId },
-                        tag: "offchain",
+                        // Funding the escrow: an output of this tx landed on a
+                        // gated contract of the wallet's, so the send is to the
+                        // user's own covenant rather than to a stranger.
+                        tag: paidIntoGated.has(vtxo.arkTxId) ? "gated" : "offchain",
                         type: TxType.TxSent,
                         amount: txAmount,
                         settled: true,

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -878,14 +878,24 @@ export interface TxKey {
     arkTxid: string;
 }
 
-/** The categories the history builder itself assigns. */
-export type BuiltinTxTag = "offchain" | "boarding" | "exit" | "batch";
+/**
+ * The categories the history builder itself assigns.
+ *
+ * Four of them name the mechanism that moved the coin. `"gated"` names the
+ * counterparty instead: an offchain row facing a contract row of this wallet's
+ * that generic spending is closed on — a swap covenant, a lockup — which is the
+ * same money {@link WalletBalance.gated} reports. History reads such a contract
+ * as an external party, so the movement is a real send or receive rather than
+ * change, and the tag is what lets a consumer tell "into my own escrow" from
+ * "to a stranger" instead of the movement arriving unattributed.
+ */
+export type BuiltinTxTag = "offchain" | "boarding" | "exit" | "batch" | "gated";
 
 /**
  * The category the history builder assigns to a transaction. The `(string & {})`
  * arm keeps the union open — apps and resolvers can introduce their own
  * categories without a breaking change — while preserving editor autocomplete
- * for the built-in four.
+ * for the built-in ones.
  */
 export type TxTag = BuiltinTxTag | (string & {});
 

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -50,7 +50,7 @@ import {
 } from "../wallet";
 import { computeOffchainBalance } from "../balance";
 import { isHDAllocationCapable, isHDWalletCapable } from "../hdWalletCapable";
-import { gatedContracts } from "../../contracts/spendability";
+import { gatedFrom, isGatedVtxo } from "../../contracts/spendability";
 import type {
     DeprecatedSignerMigrationReport,
     DeprecatedSignerReport,
@@ -1650,7 +1650,7 @@ export class WalletMessageHandler
             }
         }
 
-        const gated = gatedContracts(snapshot.map((_) => _.contract));
+        const gated = gatedFrom(snapshot);
         const unlocked = new Set(
             (
                 await spendableVtxosExcludingLocked(allVtxos, this.readonlyWallet?.intentRepository)
@@ -1662,7 +1662,7 @@ export class WalletMessageHandler
         const offchain = computeOffchainBalance(allVtxos, {
             now: { timestamp: new Date() },
             isPendingRecovery: (vtxo) => pendingOutpoints.has(`${vtxo.txid}:${vtxo.vout}`),
-            isGenericallySpendable: (vtxo) => !gated.has(vtxo.script),
+            isGenericallySpendable: (vtxo) => !isGatedVtxo(vtxo, gated),
             isUnlocked: (vtxo) => unlocked.has(`${vtxo.txid}:${vtxo.vout}`),
         });
 
@@ -2157,27 +2157,29 @@ export class WalletMessageHandler
     private async buildTransactionHistoryFromCache(): Promise<ArkTransaction[] | null> {
         if (!this.readonlyWallet) return null;
 
-        const { snapshot, vtxos } = await this.repoSnapshot();
-
-        const { boardingTxs, commitmentsToIgnore } = await this.readonlyWallet.getBoardingTxs();
+        // Independent halves — repository rows here, the onchain provider
+        // there — so they run together, as `handleGetBalance` already runs its
+        // own pair.
+        const [{ snapshot, vtxos }, { boardingTxs, commitmentsToIgnore }] = await Promise.all([
+            this.repoSnapshot(),
+            this.readonlyWallet.getBoardingTxs(),
+        ]);
 
         const indexerProvider = this.indexerProvider;
         const resolveTxCreatedAt = indexerProvider
             ? (txids: string[]) => fetchVtxoCreatedAtByTxid(indexerProvider, txids)
             : undefined;
 
-        // The gate `handleGetBalance` builds off this same snapshot, for the
-        // same reason: an escrowed contract's coins are not the wallet's own,
-        // so history must not read them as change. `ReadonlyWallet` derives the
-        // identical expression from its own snapshot, so the two sides of the
-        // bus classify a coin the same way — they still differ in freshness, as
-        // the balance reads do, because this snapshot never syncs.
+        // Same gate `handleGetBalance` builds, off the same kind of snapshot as
+        // `ReadonlyWallet`'s, so both sides of the bus classify a coin alike —
+        // still differing in freshness, as the balance reads do, because this
+        // snapshot never syncs.
         return buildTransactionHistory(
             vtxos,
             boardingTxs,
             commitmentsToIgnore,
             resolveTxCreatedAt,
-            gatedContracts(snapshot.map((_) => _.contract)),
+            gatedFrom(snapshot),
         );
     }
 

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -2150,16 +2150,14 @@ export class WalletMessageHandler
      *
      * Takes its own {@link repoSnapshot} rather than a caller-supplied VTXO
      * list: the coins and the gate that judges them have to come off one read
-     * or they answer about different instants. It is also the worker's only
-     * history builder, so neither of its two callers can pass coins without the
-     * gate that judges them.
+     * or they answer about different instants, and being the worker's only
+     * history builder means neither caller can supply one without the other.
+     * The snapshot and the boarding read are independent, so they run together
+     * — the same pairing `handleGetBalance` makes.
      */
     private async buildTransactionHistoryFromCache(): Promise<ArkTransaction[] | null> {
         if (!this.readonlyWallet) return null;
 
-        // Independent halves — repository rows here, the onchain provider
-        // there — so they run together, as `handleGetBalance` already runs its
-        // own pair.
         const [{ snapshot, vtxos }, { boardingTxs, commitmentsToIgnore }] = await Promise.all([
             this.repoSnapshot(),
             this.readonlyWallet.getBoardingTxs(),
@@ -2170,10 +2168,9 @@ export class WalletMessageHandler
             ? (txids: string[]) => fetchVtxoCreatedAtByTxid(indexerProvider, txids)
             : undefined;
 
-        // Same gate `handleGetBalance` builds, off the same kind of snapshot as
-        // `ReadonlyWallet`'s, so both sides of the bus classify a coin alike —
-        // still differing in freshness, as the balance reads do, because this
-        // snapshot never syncs.
+        // `ReadonlyWallet` derives the same gate from its own snapshot, so both
+        // sides of the bus classify a coin alike — differing only in freshness,
+        // as the balance reads do, because this one never syncs.
         return buildTransactionHistory(
             vtxos,
             boardingTxs,

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet-message-handler.ts
@@ -1166,9 +1166,7 @@ export class WalletMessageHandler
                     });
                 }
                 case "GET_TRANSACTION_HISTORY": {
-                    const allVtxos = await this.getVtxosFromRepo();
-                    const transactions =
-                        (await this.buildTransactionHistoryFromCache(allVtxos)) ?? [];
+                    const transactions = (await this.buildTransactionHistoryFromCache()) ?? [];
                     return this.tagged({
                         id,
                         type: "TRANSACTION_HISTORY",
@@ -1865,9 +1863,6 @@ export class WalletMessageHandler
             return;
         }
 
-        // Read virtual outputs from repository (now populated by contract manager)
-        const vtxos = await this.getVtxosFromRepo();
-
         // Fetch boarding inputs across the full boarding-address set (current +
         // historical rotated; plan §6-IV.2). Fetch FIRST: getBoardingUtxos
         // re-fetches each boarding address from the onchain provider and saves
@@ -1888,7 +1883,7 @@ export class WalletMessageHandler
 
         // Build transaction history from cached virtual outputs (no indexer call)
         const address = await this.readonlyWallet.getAddress();
-        const txs = await this.buildTransactionHistoryFromCache(vtxos);
+        const txs = await this.buildTransactionHistoryFromCache();
         if (txs) await this.walletRepository.saveTransactions(address, txs);
     }
 
@@ -2152,11 +2147,17 @@ export class WalletMessageHandler
     /**
      * Build transaction history from cached virtual outputs, hitting the indexer only for
      * uncached timestamps. Best-effort, like the plain Wallet path.
+     *
+     * Takes its own {@link repoSnapshot} rather than a caller-supplied VTXO
+     * list: the coins and the gate that judges them have to come off one read
+     * or they answer about different instants. It is also the worker's only
+     * history builder, so neither of its two callers can pass coins without the
+     * gate that judges them.
      */
-    private async buildTransactionHistoryFromCache(
-        vtxos: ExtendedVirtualCoin[],
-    ): Promise<ArkTransaction[] | null> {
+    private async buildTransactionHistoryFromCache(): Promise<ArkTransaction[] | null> {
         if (!this.readonlyWallet) return null;
+
+        const { snapshot, vtxos } = await this.repoSnapshot();
 
         const { boardingTxs, commitmentsToIgnore } = await this.readonlyWallet.getBoardingTxs();
 
@@ -2165,7 +2166,19 @@ export class WalletMessageHandler
             ? (txids: string[]) => fetchVtxoCreatedAtByTxid(indexerProvider, txids)
             : undefined;
 
-        return buildTransactionHistory(vtxos, boardingTxs, commitmentsToIgnore, resolveTxCreatedAt);
+        // The gate `handleGetBalance` builds off this same snapshot, for the
+        // same reason: an escrowed contract's coins are not the wallet's own,
+        // so history must not read them as change. `ReadonlyWallet` derives the
+        // identical expression from its own snapshot, so the two sides of the
+        // bus classify a coin the same way — they still differ in freshness, as
+        // the balance reads do, because this snapshot never syncs.
+        return buildTransactionHistory(
+            vtxos,
+            boardingTxs,
+            commitmentsToIgnore,
+            resolveTxCreatedAt,
+            gatedContracts(snapshot.map((_) => _.contract)),
+        );
     }
 
     private async ensureContractEventBroadcasting() {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -176,6 +176,8 @@ import { CandidateDeps, Contract, ContractWithVtxos, DiscoveryDeps } from "../co
 import {
     gateExclusion,
     gatedContracts,
+    gatedFrom,
+    isGatedVtxo,
     logExcludedVtxos,
     outpointExclusion,
     type VtxoExclusion,
@@ -1284,7 +1286,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const vtxos = filterSnapshotVtxos(snapshot, filter, this._pendingSpendOutpoints);
         const { gated, pendingRecovery } = this.spendabilityView(snapshot);
         const selectable = vtxos.filter(
-            (vtxo) => !gated.has(vtxo.script) && !pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`),
+            (vtxo) =>
+                !isGatedVtxo(vtxo, gated) && !pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`),
         );
         const unlocked = await spendableVtxosExcludingLocked(selectable, this.intentRepository);
         logExcludedVtxos("getSpendableVtxos", vtxos, [
@@ -1415,7 +1418,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         pendingRecovery: ReadonlySet<string>;
     } {
         return {
-            gated: gatedContracts(snapshot.map((_) => _.contract)),
+            gated: gatedFrom(snapshot),
             pendingRecovery: this.selectPendingRecovery(snapshot),
         };
     }
@@ -1435,7 +1438,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         return {
             now: { timestamp: new Date() },
             isPendingRecovery: (vtxo) => pendingRecovery.has(`${vtxo.txid}:${vtxo.vout}`),
-            isGenericallySpendable: (vtxo) => !gated.has(vtxo.script),
+            isGenericallySpendable: (vtxo) => !isGatedVtxo(vtxo, gated),
             isUnlocked: (vtxo) => unlocked.has(`${vtxo.txid}:${vtxo.vout}`),
         };
     }
@@ -1479,29 +1482,28 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * Return wallet transaction history derived from Arkade state and boarding transactions.
      */
     async getTransactionHistory(): Promise<ArkTransaction[]> {
-        const snapshot = await this.contractSnapshot();
+        // Independent: one syncs against the indexer, the other reads the
+        // onchain provider. `getBalance` pairs its two reads the same way.
+        const [snapshot, { boardingTxs, commitmentsToIgnore }] = await Promise.all([
+            this.contractSnapshot(),
+            this.getBoardingTxs(),
+        ]);
         const allVtxos = snapshot.flatMap((_) => _.vtxos);
-
-        const { boardingTxs, commitmentsToIgnore } = await this.getBoardingTxs();
 
         // Best-effort: a retryable indexer failure yields a partial map, not a
         // failed read; terminal failures still propagate.
         const resolveTxCreatedAt = (txids: string[]) =>
             fetchVtxoCreatedAtByTxid(this.indexerProvider, txids);
 
-        // `getBalance`'s gate, built the same way off one snapshot: an escrowed
-        // contract's coins are not the wallet's own money, so history must not
-        // read them as change. Without it a swap deposit and its covenant output
-        // cancel to zero and the whole movement disappears. Balance withholds
-        // such a coin from `available` but still counts it in `total`; history
-        // drops it from the ledger, because the movement it reports is the one
-        // facing the escrow, not the escrow itself.
+        // The gate off the same snapshot the coins came from, so both answer
+        // about one instant — see `buildTransactionHistory`'s `gatedScripts` for
+        // why history needs it at all.
         return buildTransactionHistory(
             allVtxos,
             boardingTxs,
             commitmentsToIgnore,
             resolveTxCreatedAt,
-            gatedContracts(snapshot.map((_) => _.contract)),
+            gatedFrom(snapshot),
         );
     }
 

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -178,6 +178,7 @@ import {
     gatedContracts,
     gatedFrom,
     isGatedVtxo,
+    type GatedContracts,
     logExcludedVtxos,
     outpointExclusion,
     type VtxoExclusion,
@@ -1414,7 +1415,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * {@link getSpendableVtxos} and the balance answer about the same instant.
      */
     private spendabilityView(snapshot: readonly ContractWithVtxos[]): {
-        gated: ReturnType<typeof gatedContracts>;
+        gated: GatedContracts;
         pendingRecovery: ReadonlySet<string>;
     } {
         return {

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -1479,9 +1479,8 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * Return wallet transaction history derived from Arkade state and boarding transactions.
      */
     async getTransactionHistory(): Promise<ArkTransaction[]> {
-        const contractManager = await this.getContractManager();
-        const response = await contractManager.getContractsWithVtxos();
-        const allVtxos = response.flatMap((_) => _.vtxos);
+        const snapshot = await this.contractSnapshot();
+        const allVtxos = snapshot.flatMap((_) => _.vtxos);
 
         const { boardingTxs, commitmentsToIgnore } = await this.getBoardingTxs();
 
@@ -1490,11 +1489,19 @@ export class ReadonlyWallet implements IReadonlyWallet {
         const resolveTxCreatedAt = (txids: string[]) =>
             fetchVtxoCreatedAtByTxid(this.indexerProvider, txids);
 
+        // `getBalance`'s gate, built the same way off one snapshot: an escrowed
+        // contract's coins are not the wallet's own money, so history must not
+        // read them as change. Without it a swap deposit and its covenant output
+        // cancel to zero and the whole movement disappears. Balance withholds
+        // such a coin from `available` but still counts it in `total`; history
+        // drops it from the ledger, because the movement it reports is the one
+        // facing the escrow, not the escrow itself.
         return buildTransactionHistory(
             allVtxos,
             boardingTxs,
             commitmentsToIgnore,
             resolveTxCreatedAt,
+            gatedContracts(snapshot.map((_) => _.contract)),
         );
     }
 

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -959,12 +959,14 @@ describe("main-thread / worker balance parity", () => {
      * because it is bounded and self-inflicted — such a spend is doomed at the
      * server, and the wedge lasts until it rejects.
      */
+    /**
+     * One worker request against the same wallet and repository the main-thread
+     * read uses — two stubs would agree with each other and prove nothing.
+     */
     const workerRequest = async (
         seeded: Awaited<ReturnType<typeof seededWallet>>,
         type: "GET_BALANCE" | "GET_TRANSACTION_HISTORY",
     ) => {
-        // Same wallet, same repository as the main-thread read — two stubs
-        // would agree with each other and prove nothing.
         const handler = new WalletMessageHandler();
         (handler as any).readonlyWallet = seeded.wallet;
         (handler as any).walletRepository = seeded.walletRepository;

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -551,14 +551,38 @@ describe("getBalance", () => {
 });
 
 describe("gated reads stay ungated (D1b/D1d)", () => {
-    it("keeps escrowed funds in the recovery and history reads", async () => {
+    it("keeps escrowed funds in the recovery read", async () => {
         const { wallet } = await seededWallet();
 
         expect(scriptsOf(await wallet.getVtxos({ withRecoverable: true }))).toContain(
             ESCROW_SCRIPT,
         );
+    });
+
+    /**
+     * History used to be listed alongside `getVtxos` as an ungated read. It is
+     * not one, and treating it as one was the defect: because a swap covenant is
+     * registered as a contract of the wallet that funds it, its deposit output
+     * counted as change, so the deposit and its return cancelled and the whole
+     * movement — funding, fill and cancel alike — produced no row at all.
+     *
+     * The two reads answer different questions. `getVtxos` reports which coins
+     * exist, and an escrowed one does; history reports whose money moved, and an
+     * escrowed one is not the wallet's to move. So the coins stay in the
+     * recovery read above and leave this one, and what history reports instead
+     * is the wallet-side movement facing the escrow.
+     */
+    it("gates the history read, so escrow is a counterparty rather than change", async () => {
+        const { wallet, defaultScript } = await seededWallet();
+
         const history = await wallet.getTransactionHistory();
-        expect(history.length).toBeGreaterThan(0);
+
+        // Only the two coins generic spending may touch: the wallet's own, and
+        // the `arkade` row marked `genericallySpendable`. The unmarked escrow
+        // and the unregistered type are both default-closed.
+        expect(history.map((tx) => tx.amount).sort((a, b) => a - b)).toEqual([10_000, 40_000]);
+        expect(scriptsOf(await wallet.getVtxos())).toContain(ESCROW_SCRIPT);
+        expect(defaultScript).not.toBe(ESCROW_SCRIPT);
     });
 
     it("settles a gated VTXO when it is named explicitly (D1d)", async () => {
@@ -986,5 +1010,41 @@ describe("main-thread / worker balance parity", () => {
         expect(main.unrolled).toBe(0);
         expect(main.total).toBe(worker.total);
         expect(main.total).toBe(70_000);
+    });
+
+    /**
+     * The gate is assembled separately on each side of the bus — off
+     * `contractSnapshot()` here, off `repoSnapshot()` there — so nothing but a
+     * test stops one of them from being dropped. Without it the whole wiring
+     * could be reverted (both call sites simply stop passing the gate) and every
+     * unit test over `buildTransactionHistory` would stay green, because none of
+     * them goes through a wallet.
+     */
+    it("gates the history read on both sides of the bus", async () => {
+        const seeded = await seededWallet();
+
+        const main = await seeded.wallet.getTransactionHistory();
+        const handler = new WalletMessageHandler();
+        (handler as any).readonlyWallet = seeded.wallet;
+        (handler as any).walletRepository = seeded.walletRepository;
+        (handler as any).indexerProvider = offlineIndexer();
+        (handler as any).arkProvider = {};
+        const response = await handler.handleMessage({
+            id: "1",
+            tag: DEFAULT_MESSAGE_TAG,
+            type: "GET_TRANSACTION_HISTORY",
+        } as any);
+        expect(response.error).toBeUndefined();
+        const worker = (response as any).payload.transactions as Awaited<
+            ReturnType<Wallet["getTransactionHistory"]>
+        >;
+
+        const amounts = (txs: { amount: number }[]) =>
+            txs.map((t) => t.amount).sort((a, b) => a - b);
+        // Non-empty first: two paths both reporting nothing must not pass as
+        // parity. The escrowed 10_000 and the unregistered-type 10_000 are the
+        // two the gate removes.
+        expect(amounts(main)).toEqual([10_000, 40_000]);
+        expect(amounts(worker)).toEqual(amounts(main));
     });
 });

--- a/packages/ts-sdk/test/spendability-gate.test.ts
+++ b/packages/ts-sdk/test/spendability-gate.test.ts
@@ -167,6 +167,7 @@ async function seededWallet(opts?: {
     return { wallet, defaultScript, walletRepository, contractRepository };
 }
 
+const amountsOf = (txs: { amount: number }[]) => txs.map((t) => t.amount).sort((a, b) => a - b);
 const scriptsOf = (vtxos: { script: string }[]) => vtxos.map((v) => v.script).sort();
 const txidsOf = (vtxos: { txid: string }[]) => vtxos.map((v) => v.txid).sort();
 
@@ -580,7 +581,7 @@ describe("gated reads stay ungated (D1b/D1d)", () => {
         // Only the two coins generic spending may touch: the wallet's own, and
         // the `arkade` row marked `genericallySpendable`. The unmarked escrow
         // and the unregistered type are both default-closed.
-        expect(history.map((tx) => tx.amount).sort((a, b) => a - b)).toEqual([10_000, 40_000]);
+        expect(amountsOf(history)).toEqual([10_000, 40_000]);
         expect(scriptsOf(await wallet.getVtxos())).toContain(ESCROW_SCRIPT);
         expect(defaultScript).not.toBe(ESCROW_SCRIPT);
     });
@@ -958,7 +959,10 @@ describe("main-thread / worker balance parity", () => {
      * because it is bounded and self-inflicted — such a spend is doomed at the
      * server, and the wedge lasts until it rejects.
      */
-    const workerBalance = async (seeded: Awaited<ReturnType<typeof seededWallet>>) => {
+    const workerRequest = async (
+        seeded: Awaited<ReturnType<typeof seededWallet>>,
+        type: "GET_BALANCE" | "GET_TRANSACTION_HISTORY",
+    ) => {
         // Same wallet, same repository as the main-thread read — two stubs
         // would agree with each other and prove nothing.
         const handler = new WalletMessageHandler();
@@ -970,11 +974,14 @@ describe("main-thread / worker balance parity", () => {
         const response = await handler.handleMessage({
             id: "1",
             tag: DEFAULT_MESSAGE_TAG,
-            type: "GET_BALANCE",
+            type,
         } as any);
         expect(response.error).toBeUndefined();
-        return (response as any).payload as Awaited<ReturnType<Wallet["getBalance"]>>;
+        return (response as any).payload;
     };
+
+    const workerBalance = async (seeded: Awaited<ReturnType<typeof seededWallet>>) =>
+        (await workerRequest(seeded, "GET_BALANCE")) as Awaited<ReturnType<Wallet["getBalance"]>>;
 
     it("reports the same unrolled bucket on both sides of the bus", async () => {
         const seeded = await seededWallet();
@@ -1024,27 +1031,13 @@ describe("main-thread / worker balance parity", () => {
         const seeded = await seededWallet();
 
         const main = await seeded.wallet.getTransactionHistory();
-        const handler = new WalletMessageHandler();
-        (handler as any).readonlyWallet = seeded.wallet;
-        (handler as any).walletRepository = seeded.walletRepository;
-        (handler as any).indexerProvider = offlineIndexer();
-        (handler as any).arkProvider = {};
-        const response = await handler.handleMessage({
-            id: "1",
-            tag: DEFAULT_MESSAGE_TAG,
-            type: "GET_TRANSACTION_HISTORY",
-        } as any);
-        expect(response.error).toBeUndefined();
-        const worker = (response as any).payload.transactions as Awaited<
-            ReturnType<Wallet["getTransactionHistory"]>
-        >;
+        const worker = (await workerRequest(seeded, "GET_TRANSACTION_HISTORY"))
+            .transactions as Awaited<ReturnType<Wallet["getTransactionHistory"]>>;
 
-        const amounts = (txs: { amount: number }[]) =>
-            txs.map((t) => t.amount).sort((a, b) => a - b);
         // Non-empty first: two paths both reporting nothing must not pass as
         // parity. The escrowed 10_000 and the unregistered-type 10_000 are the
         // two the gate removes.
-        expect(amounts(main)).toEqual([10_000, 40_000]);
-        expect(amounts(worker)).toEqual(amounts(main));
+        expect(amountsOf(main)).toEqual([10_000, 40_000]);
+        expect(amountsOf(worker)).toEqual(amountsOf(main));
     });
 });

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -1144,8 +1144,40 @@ describe("buildTransactionHistory", () => {
             ...overrides,
         });
 
-        /** The gate as both read paths build it, straight off the contract rows. */
-        const gate = (...contracts: Contract[]) => gatedContracts(contracts);
+        /**
+         * The builder under the gate both read paths build, straight off the
+         * contract rows. Boarding transactions and ignored commitments are
+         * beside the point here; the `createdAt` resolver is only passed by the
+         * one test that asserts it is never called.
+         */
+        const history = (
+            vtxos: VirtualCoin[],
+            contract: Contract = offerContract(),
+            resolveTxCreatedAt?: (txids: string[]) => Promise<Map<string, number>>,
+        ) =>
+            buildTransactionHistory(
+                vtxos,
+                [],
+                new Set(),
+                resolveTxCreatedAt,
+                gatedContracts([contract]),
+            );
+
+        /** The same builder with no gate at all: the behaviour that predates it. */
+        const ungatedHistory = (vtxos: VirtualCoin[]) =>
+            buildTransactionHistory(vtxos, [], new Set());
+
+        /**
+         * A funding fixture with its covenant coin spent by whichever leg closes
+         * the offer — a solver's fill, or a cancel. Keyed on the script rather
+         * than a position, so it survives a fixture growing an output.
+         */
+        const closedBy = (coins: VirtualCoin[], txid: string) =>
+            coins.map((c) =>
+                c.script === covenantScript
+                    ? { ...c, isSpent: true, spentBy: checkpointOf(txid), arkTxId: txid }
+                    : c,
+            );
 
         const coin = (
             over: Partial<VirtualCoin> & Pick<VirtualCoin, "txid" | "value">,
@@ -1197,24 +1229,8 @@ describe("buildTransactionHistory", () => {
                 }),
             ];
 
-            /** The covenant coin, spent by whichever leg closes the offer. */
-            const closedBy = (txid: string) => {
-                const [walletCoin, covenant, change] = funding();
-                return [
-                    walletCoin,
-                    { ...covenant, isSpent: true, spentBy: checkpointOf(txid), arkTxId: txid },
-                    change,
-                ];
-            };
-
             it("records the deposit as a send once the covenant is funded", async () => {
-                const txs = await buildTransactionHistory(
-                    funding(),
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history(funding());
 
                 const sent = sentFor(txs, fundingTxid);
                 expect(sent).toHaveLength(1);
@@ -1227,21 +1243,15 @@ describe("buildTransactionHistory", () => {
             });
 
             it("records the solver's fill as a receive of the bought asset", async () => {
-                const txs = await buildTransactionHistory(
-                    [
-                        ...closedBy(fillTxid),
-                        coin({
-                            txid: fillTxid,
-                            value: 330,
-                            createdAt: at(2_000),
-                            assets: [{ assetId: assetX, amount: 5_000n }],
-                        }),
-                    ],
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history([
+                    ...closedBy(funding(), fillTxid),
+                    coin({
+                        txid: fillTxid,
+                        value: 330,
+                        createdAt: at(2_000),
+                        assets: [{ assetId: assetX, amount: 5_000n }],
+                    }),
+                ]);
 
                 // The escrow leaving is not a second send: it was already sent.
                 const sent = sentOf(txs);
@@ -1257,16 +1267,10 @@ describe("buildTransactionHistory", () => {
             });
 
             it("records a cancel as the deposit coming back", async () => {
-                const txs = await buildTransactionHistory(
-                    [
-                        ...closedBy(cancelTxid),
-                        coin({ txid: cancelTxid, value: 6_000, createdAt: at(2_000) }),
-                    ],
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history([
+                    ...closedBy(funding(), cancelTxid),
+                    coin({ txid: cancelTxid, value: 6_000, createdAt: at(2_000) }),
+                ]);
 
                 const sent = sentOf(txs);
                 expect(sent).toHaveLength(1);
@@ -1283,7 +1287,7 @@ describe("buildTransactionHistory", () => {
                 // no gate the covenant output is change, so `spentAmount -
                 // changeAmount` is 0, no assets move, and the ghost-row guard
                 // drops the only record the swap would have had.
-                const txs = await buildTransactionHistory(funding(), [], new Set());
+                const txs = await ungatedHistory(funding());
                 expect(sentOf(txs)).toHaveLength(0);
                 expect(rowsFor(txs, fundingTxid)).toHaveLength(0);
             });
@@ -1317,22 +1321,8 @@ describe("buildTransactionHistory", () => {
                 }),
             ];
 
-            const closedBy = (txid: string) => {
-                const [walletCoin, covenant] = funding();
-                return [
-                    walletCoin,
-                    { ...covenant, isSpent: true, spentBy: checkpointOf(txid), arkTxId: txid },
-                ];
-            };
-
             it("records the deposited units on the funding send", async () => {
-                const txs = await buildTransactionHistory(
-                    funding(),
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history(funding());
 
                 const sent = sentFor(txs, fundingTxid);
                 expect(sent).toHaveLength(1);
@@ -1344,37 +1334,31 @@ describe("buildTransactionHistory", () => {
             });
 
             it("leaves units that stayed behind out of the funding send", async () => {
-                const txs = await buildTransactionHistory(
-                    [
-                        coin({
-                            txid: "wallet-coin-asset-partial",
-                            value: 800,
-                            isSpent: true,
-                            spentBy: checkpointOf(fundingTxid),
-                            arkTxId: fundingTxid,
-                            assets: [{ assetId: assetX, amount: 1_000n }],
-                        }),
-                        coin({
-                            txid: fundingTxid,
-                            vout: 0,
-                            value: 300,
-                            script: covenantScript,
-                            createdAt: at(1_000),
-                            assets: [{ assetId: assetX, amount: 600n }],
-                        }),
-                        coin({
-                            txid: fundingTxid,
-                            vout: 1,
-                            value: 500,
-                            createdAt: at(1_000),
-                            assets: [{ assetId: assetX, amount: 400n }],
-                        }),
-                    ],
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history([
+                    coin({
+                        txid: "wallet-coin-asset-partial",
+                        value: 800,
+                        isSpent: true,
+                        spentBy: checkpointOf(fundingTxid),
+                        arkTxId: fundingTxid,
+                        assets: [{ assetId: assetX, amount: 1_000n }],
+                    }),
+                    coin({
+                        txid: fundingTxid,
+                        vout: 0,
+                        value: 300,
+                        script: covenantScript,
+                        createdAt: at(1_000),
+                        assets: [{ assetId: assetX, amount: 600n }],
+                    }),
+                    coin({
+                        txid: fundingTxid,
+                        vout: 1,
+                        value: 500,
+                        createdAt: at(1_000),
+                        assets: [{ assetId: assetX, amount: 400n }],
+                    }),
+                ]);
 
                 const sent = sentFor(txs, fundingTxid);
                 expect(sent).toHaveLength(1);
@@ -1384,16 +1368,10 @@ describe("buildTransactionHistory", () => {
             });
 
             it("records the fill as a receive of the sats the solver paid", async () => {
-                const txs = await buildTransactionHistory(
-                    [
-                        ...closedBy(fillTxid),
-                        coin({ txid: fillTxid, value: 9_000, createdAt: at(2_000) }),
-                    ],
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history([
+                    ...closedBy(funding(), fillTxid),
+                    coin({ txid: fillTxid, value: 9_000, createdAt: at(2_000) }),
+                ]);
 
                 const received = receivedFor(txs, fillTxid);
                 expect(received).toHaveLength(1);
@@ -1409,21 +1387,15 @@ describe("buildTransactionHistory", () => {
             });
 
             it("records a cancel as every unit coming back", async () => {
-                const txs = await buildTransactionHistory(
-                    [
-                        ...closedBy(cancelTxid),
-                        coin({
-                            txid: cancelTxid,
-                            value: 500,
-                            createdAt: at(2_000),
-                            assets: [{ assetId: assetX, amount: 1_000n }],
-                        }),
-                    ],
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history([
+                    ...closedBy(funding(), cancelTxid),
+                    coin({
+                        txid: cancelTxid,
+                        value: 500,
+                        createdAt: at(2_000),
+                        assets: [{ assetId: assetX, amount: 1_000n }],
+                    }),
+                ]);
 
                 const received = receivedFor(txs, cancelTxid);
                 expect(received).toHaveLength(1);
@@ -1435,7 +1407,7 @@ describe("buildTransactionHistory", () => {
             it("reports nothing at all with the covenant left in the wallet's set", async () => {
                 // The worse half of the defect: the movement is entirely
                 // asset-side, so both the sats and the units cancel.
-                const txs = await buildTransactionHistory(funding(), [], new Set());
+                const txs = await ungatedHistory(funding());
                 expect(sentOf(txs)).toHaveLength(0);
                 expect(rowsFor(txs, fundingTxid)).toHaveLength(0);
             });
@@ -1447,13 +1419,7 @@ describe("buildTransactionHistory", () => {
                 // back to the input coin's timestamp — which would be a month
                 // stale here — nor pay for a round-trip to learn it.
                 const resolveTxCreatedAt = vi.fn(async () => new Map<string, number>());
-                const txs = await buildTransactionHistory(
-                    funding(),
-                    [],
-                    new Set(),
-                    resolveTxCreatedAt,
-                    gate(offerContract()),
-                );
+                const txs = await history(funding(), offerContract(), resolveTxCreatedAt);
 
                 expect(resolveTxCreatedAt).not.toHaveBeenCalled();
                 expect(sentFor(txs, fundingTxid)[0].createdAt).toBe(at(1_000).getTime());
@@ -1478,14 +1444,8 @@ describe("buildTransactionHistory", () => {
                     metadata: { genericallySpendable: true, kind: "asset-swap-offer" },
                 });
 
-                expect(gate(marked).size).toBe(0);
-                const kept = await buildTransactionHistory(
-                    deposit,
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(marked),
-                );
+                expect(gatedContracts([marked]).size).toBe(0);
+                const kept = await history(deposit, marked);
                 expect(kept).toHaveLength(1);
                 expect(kept[0].type).toBe(TxType.TxReceived);
                 expect(kept[0].amount).toBe(7_000);
@@ -1494,51 +1454,37 @@ describe("buildTransactionHistory", () => {
                 // no row. This is the gate's reach beyond swaps — any default-
                 // closed `arkade` row funded from outside the wallet loses the
                 // receive it used to report.
-                expect(gate(offerContract()).get(covenantScript)).toBe("arkade");
-                expect(
-                    await buildTransactionHistory(
-                        deposit,
-                        [],
-                        new Set(),
-                        undefined,
-                        gate(offerContract()),
-                    ),
-                ).toHaveLength(0);
+                expect(gatedContracts([offerContract()]).get(covenantScript)).toBe("arkade");
+                expect(await history(deposit)).toHaveLength(0);
             });
 
             it("leaves an ordinary payment made while an offer is live alone", async () => {
                 const paymentTxid = "ordinary-payment-tx";
-                const txs = await buildTransactionHistory(
-                    [
-                        coin({
-                            txid: "wallet-coin-ordinary",
-                            value: 10_000,
-                            isSpent: true,
-                            spentBy: checkpointOf(paymentTxid),
-                            arkTxId: paymentTxid,
-                        }),
-                        // What the stranger got is not in the wallet's set; the
-                        // change is.
-                        coin({
-                            txid: paymentTxid,
-                            vout: 1,
-                            value: 3_000,
-                            createdAt: at(1_000),
-                        }),
-                        // A funded covenant sits in the same history and must
-                        // not colour a payment it has nothing to do with.
-                        coin({
-                            txid: "unrelated-funding-tx",
-                            value: 6_000,
-                            script: covenantScript,
-                            createdAt: at(500),
-                        }),
-                    ],
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history([
+                    coin({
+                        txid: "wallet-coin-ordinary",
+                        value: 10_000,
+                        isSpent: true,
+                        spentBy: checkpointOf(paymentTxid),
+                        arkTxId: paymentTxid,
+                    }),
+                    // What the stranger got is not in the wallet's set; the
+                    // change is.
+                    coin({
+                        txid: paymentTxid,
+                        vout: 1,
+                        value: 3_000,
+                        createdAt: at(1_000),
+                    }),
+                    // A funded covenant sits in the same history and must
+                    // not colour a payment it has nothing to do with.
+                    coin({
+                        txid: "unrelated-funding-tx",
+                        value: 6_000,
+                        script: covenantScript,
+                        createdAt: at(500),
+                    }),
+                ]);
 
                 const sent = sentFor(txs, paymentTxid);
                 expect(sent).toHaveLength(1);
@@ -1554,22 +1500,16 @@ describe("buildTransactionHistory", () => {
                     return rest as VirtualCoin;
                 };
 
-                const txs = await buildTransactionHistory(
-                    [
-                        scriptless({
-                            txid: "scriptless-spent",
-                            value: 1_000,
-                            isSpent: true,
-                            spentBy: checkpointOf("scriptless-tx"),
-                            arkTxId: "scriptless-tx",
-                        }),
-                        scriptless({ txid: "scriptless-tx", value: 400, createdAt: at(1_000) }),
-                    ],
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history([
+                    scriptless({
+                        txid: "scriptless-spent",
+                        value: 1_000,
+                        isSpent: true,
+                        spentBy: checkpointOf("scriptless-tx"),
+                        arkTxId: "scriptless-tx",
+                    }),
+                    scriptless({ txid: "scriptless-tx", value: 400, createdAt: at(1_000) }),
+                ]);
 
                 // No script means no contract row to judge the coin by, so it is
                 // the wallet's own and the ordinary send stands.
@@ -1581,22 +1521,16 @@ describe("buildTransactionHistory", () => {
 
             it("still records no ghost row for a signer-rotation self-transfer", async () => {
                 const arkTxId = "gated-migration-ark-tx";
-                const txs = await buildTransactionHistory(
-                    [
-                        coin({
-                            txid: "old-signer-coin",
-                            value: 184_875,
-                            isSpent: true,
-                            spentBy: checkpointOf(arkTxId),
-                            arkTxId,
-                        }),
-                        coin({ txid: arkTxId, value: 184_875, createdAt: at(1_000) }),
-                    ],
-                    [],
-                    new Set(),
-                    undefined,
-                    gate(offerContract()),
-                );
+                const txs = await history([
+                    coin({
+                        txid: "old-signer-coin",
+                        value: 184_875,
+                        isSpent: true,
+                        spentBy: checkpointOf(arkTxId),
+                        arkTxId,
+                    }),
+                    coin({ txid: arkTxId, value: 184_875, createdAt: at(1_000) }),
+                ]);
 
                 expect(sentOf(txs)).toHaveLength(0);
                 expect(rowsFor(txs, arkTxId)).toHaveLength(0);
@@ -1610,30 +1544,24 @@ describe("buildTransactionHistory", () => {
             ] as const)(
                 "still records %s as a zero-sat asset row",
                 async (_name, arkTxId, spentUnits, changeUnits, expected) => {
-                    const txs = await buildTransactionHistory(
-                        [
-                            coin({
-                                txid: `${arkTxId}-input`,
-                                value: 1_000,
-                                isSpent: true,
-                                spentBy: checkpointOf(arkTxId),
-                                arkTxId,
-                                ...(spentUnits > 0n && {
-                                    assets: [{ assetId: assetX, amount: spentUnits }],
-                                }),
+                    const txs = await history([
+                        coin({
+                            txid: `${arkTxId}-input`,
+                            value: 1_000,
+                            isSpent: true,
+                            spentBy: checkpointOf(arkTxId),
+                            arkTxId,
+                            ...(spentUnits > 0n && {
+                                assets: [{ assetId: assetX, amount: spentUnits }],
                             }),
-                            coin({
-                                txid: arkTxId,
-                                value: 1_000,
-                                createdAt: at(1_000),
-                                assets: [{ assetId: assetX, amount: changeUnits }],
-                            }),
-                        ],
-                        [],
-                        new Set(),
-                        undefined,
-                        gate(offerContract()),
-                    );
+                        }),
+                        coin({
+                            txid: arkTxId,
+                            value: 1_000,
+                            createdAt: at(1_000),
+                            assets: [{ assetId: assetX, amount: changeUnits }],
+                        }),
+                    ]);
 
                     const sent = sentFor(txs, arkTxId);
                     expect(sent).toHaveLength(1);
@@ -1644,7 +1572,6 @@ describe("buildTransactionHistory", () => {
             );
         });
     });
-
     describe("Handles real-life histories correctly", () => {
         transactionHistory.forEach(
             ({

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -1132,6 +1132,13 @@ describe("buildTransactionHistory", () => {
          */
         const checkpointOf = (arkTxid: string) => `${arkTxid}-checkpoint`;
 
+        /** The three fields that together say "this coin was spent by that tx". */
+        const spentIn = (arkTxid: string) => ({
+            isSpent: true,
+            spentBy: checkpointOf(arkTxid),
+            arkTxId: arkTxid,
+        });
+
         /** A contract row the way `@arkade-os/swap`'s `createOffer` registers it. */
         const offerContract = (overrides: Partial<Contract> = {}): Contract => ({
             type: "arkade",
@@ -1147,21 +1154,11 @@ describe("buildTransactionHistory", () => {
         /**
          * The builder under the gate both read paths build, straight off the
          * contract rows. Boarding transactions and ignored commitments are
-         * beside the point here; the `createdAt` resolver is only passed by the
-         * one test that asserts it is never called.
+         * beside the point here, and no `createdAt` resolver is wired: the one
+         * test that cares whether it is called passes its own.
          */
-        const history = (
-            vtxos: VirtualCoin[],
-            contract: Contract = offerContract(),
-            resolveTxCreatedAt?: (txids: string[]) => Promise<Map<string, number>>,
-        ) =>
-            buildTransactionHistory(
-                vtxos,
-                [],
-                new Set(),
-                resolveTxCreatedAt,
-                gatedContracts([contract]),
-            );
+        const history = (vtxos: VirtualCoin[], contract: Contract = offerContract()) =>
+            buildTransactionHistory(vtxos, [], new Set(), undefined, gatedContracts([contract]));
 
         /** The same builder with no gate at all: the behaviour that predates it. */
         const ungatedHistory = (vtxos: VirtualCoin[]) =>
@@ -1173,11 +1170,7 @@ describe("buildTransactionHistory", () => {
          * than a position, so it survives a fixture growing an output.
          */
         const closedBy = (coins: VirtualCoin[], txid: string) =>
-            coins.map((c) =>
-                c.script === covenantScript
-                    ? { ...c, isSpent: true, spentBy: checkpointOf(txid), arkTxId: txid }
-                    : c,
-            );
+            coins.map((c) => (c.script === covenantScript ? { ...c, ...spentIn(txid) } : c));
 
         const coin = (
             over: Partial<VirtualCoin> & Pick<VirtualCoin, "txid" | "value">,
@@ -1195,8 +1188,7 @@ describe("buildTransactionHistory", () => {
         const sentOf = (txs: ArkTransaction[]) => txs.filter((t) => t.type === TxType.TxSent);
         const rowsFor = (txs: ArkTransaction[], arkTxid: string) =>
             txs.filter((t) => t.key.arkTxid === arkTxid);
-        const sentFor = (txs: ArkTransaction[], arkTxid: string) =>
-            rowsFor(txs, arkTxid).filter((t) => t.type === TxType.TxSent);
+        const sentFor = (txs: ArkTransaction[], arkTxid: string) => sentOf(rowsFor(txs, arkTxid));
         const receivedFor = (txs: ArkTransaction[], arkTxid: string) =>
             rowsFor(txs, arkTxid).filter((t) => t.type === TxType.TxReceived);
 
@@ -1210,9 +1202,7 @@ describe("buildTransactionHistory", () => {
                 coin({
                     txid: "wallet-coin-btc-give",
                     value: 10_000,
-                    isSpent: true,
-                    spentBy: checkpointOf(fundingTxid),
-                    arkTxId: fundingTxid,
+                    ...spentIn(fundingTxid),
                 }),
                 coin({
                     txid: fundingTxid,
@@ -1306,9 +1296,7 @@ describe("buildTransactionHistory", () => {
                 coin({
                     txid: "wallet-coin-asset-give",
                     value: 500,
-                    isSpent: true,
-                    spentBy: checkpointOf(fundingTxid),
-                    arkTxId: fundingTxid,
+                    ...spentIn(fundingTxid),
                     assets: [{ assetId: assetX, amount: 1_000n }],
                 }),
                 coin({
@@ -1338,9 +1326,7 @@ describe("buildTransactionHistory", () => {
                     coin({
                         txid: "wallet-coin-asset-partial",
                         value: 800,
-                        isSpent: true,
-                        spentBy: checkpointOf(fundingTxid),
-                        arkTxId: fundingTxid,
+                        ...spentIn(fundingTxid),
                         assets: [{ assetId: assetX, amount: 1_000n }],
                     }),
                     coin({
@@ -1419,7 +1405,13 @@ describe("buildTransactionHistory", () => {
                 // back to the input coin's timestamp — which would be a month
                 // stale here — nor pay for a round-trip to learn it.
                 const resolveTxCreatedAt = vi.fn(async () => new Map<string, number>());
-                const txs = await history(funding(), offerContract(), resolveTxCreatedAt);
+                const txs = await buildTransactionHistory(
+                    funding(),
+                    [],
+                    new Set(),
+                    resolveTxCreatedAt,
+                    gatedContracts([offerContract()]),
+                );
 
                 expect(resolveTxCreatedAt).not.toHaveBeenCalled();
                 expect(sentFor(txs, fundingTxid)[0].createdAt).toBe(at(1_000).getTime());
@@ -1464,9 +1456,7 @@ describe("buildTransactionHistory", () => {
                     coin({
                         txid: "wallet-coin-ordinary",
                         value: 10_000,
-                        isSpent: true,
-                        spentBy: checkpointOf(paymentTxid),
-                        arkTxId: paymentTxid,
+                        ...spentIn(paymentTxid),
                     }),
                     // What the stranger got is not in the wallet's set; the
                     // change is.
@@ -1508,9 +1498,7 @@ describe("buildTransactionHistory", () => {
                     scriptless({
                         txid: "scriptless-spent",
                         value: 1_000,
-                        isSpent: true,
-                        spentBy: checkpointOf("scriptless-tx"),
-                        arkTxId: "scriptless-tx",
+                        ...spentIn("scriptless-tx"),
                     }),
                     scriptless({ txid: "scriptless-tx", value: 400, createdAt: at(1_000) }),
                 ]);
@@ -1529,9 +1517,7 @@ describe("buildTransactionHistory", () => {
                     coin({
                         txid: "old-signer-coin",
                         value: 184_875,
-                        isSpent: true,
-                        spentBy: checkpointOf(arkTxId),
-                        arkTxId,
+                        ...spentIn(arkTxId),
                     }),
                     coin({ txid: arkTxId, value: 184_875, createdAt: at(1_000) }),
                 ]);
@@ -1552,9 +1538,7 @@ describe("buildTransactionHistory", () => {
                         coin({
                             txid: `${arkTxId}-input`,
                             value: 1_000,
-                            isSpent: true,
-                            spentBy: checkpointOf(arkTxId),
-                            arkTxId,
+                            ...spentIn(arkTxId),
                             ...(spentUnits > 0n && {
                                 assets: [{ assetId: assetX, amount: spentUnits }],
                             }),

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -1493,6 +1493,10 @@ describe("buildTransactionHistory", () => {
             });
 
             it("keeps a VTXO with no script in history", async () => {
+                // `script` is required on `VirtualCoin`, so the cast is the
+                // point rather than a shortcut: it models the shape a legacy
+                // repository row actually arrives in, which is why
+                // `isVtxoForScript` and the gate both guard on its absence.
                 const scriptless = (
                     over: Partial<VirtualCoin> & Pick<VirtualCoin, "txid" | "value">,
                 ) => {

--- a/packages/ts-sdk/test/transactionHistory.test.ts
+++ b/packages/ts-sdk/test/transactionHistory.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import transactionHistory from "./fixtures/transaction_history.json";
 import { VirtualCoin, TxType, ArkTransaction } from "../src/wallet";
 import { buildTransactionHistory } from "../src/utils/transactionHistory";
+import { gatedContracts, type Contract } from "../src";
 
 describe("buildTransactionHistory", () => {
     // TODO FIX THIS!
@@ -1095,6 +1096,552 @@ describe("buildTransactionHistory", () => {
             const byTxid = new Map(sentTxs.map((t) => [t.key.arkTxid, t.createdAt]));
             expect(byTxid.get("ark-tx-1")).toBe(1_700_000_000_000);
             expect(byTxid.get("ark-tx-2")).toBe(baseDate.getTime() + 1);
+        });
+    });
+
+    /**
+     * The gate history shares with `getBalance`: VTXOs locked to a contract row
+     * generic spending is closed on are read as an external counterparty, not as
+     * the wallet's own coins.
+     *
+     * Without it a swap covenant registered by `@arkade-os/swap` is a contract
+     * of the funding wallet, so its deposit output counts as change: the sats
+     * net to zero, `subtractAssets` cancels the units to nothing, and the guard
+     * against ghost rows drops the whole movement. Funding, fill and cancel each
+     * produce no row at all, and an asset-side swap — whose whole movement is
+     * asset units on a dust carrier — disappears completely.
+     *
+     * Assertions key on the ark txid of the leg under test rather than on the
+     * whole array. Each fixture starts from a coin the wallet already held, and
+     * the transaction that created *that* is outside the fixture, so the builder
+     * reports it as an earlier receive — correctly, and irrelevantly here.
+     */
+    describe("Gated contracts (swap covenants)", () => {
+        const baseDate = new Date("2026-02-01T10:00:00Z");
+        const at = (offsetMs: number) => new Date(baseDate.getTime() + offsetMs);
+        const assetX = "asset-id-xxx";
+
+        const walletScript = "wallet-receive-script";
+        const covenantScript = "swap-covenant-script";
+
+        /**
+         * A spend is a checkpoint per input plus the ark tx that spends the
+         * checkpoints, so `spentBy` and `arkTxId` are never the same value. The
+         * builder keys on `arkTxId`; `spentBy` is here so the fixtures are the
+         * shape `convertVtxo` actually produces.
+         */
+        const checkpointOf = (arkTxid: string) => `${arkTxid}-checkpoint`;
+
+        /** A contract row the way `@arkade-os/swap`'s `createOffer` registers it. */
+        const offerContract = (overrides: Partial<Contract> = {}): Contract => ({
+            type: "arkade",
+            params: {},
+            script: covenantScript,
+            address: "ark1swapcovenant",
+            state: "active",
+            createdAt: baseDate.getTime(),
+            metadata: { genericallySpendable: false, kind: "asset-swap-offer" },
+            ...overrides,
+        });
+
+        /** The gate as both read paths build it, straight off the contract rows. */
+        const gate = (...contracts: Contract[]) => gatedContracts(contracts);
+
+        const coin = (
+            over: Partial<VirtualCoin> & Pick<VirtualCoin, "txid" | "value">,
+        ): VirtualCoin => ({
+            vout: 0,
+            status: { confirmed: false },
+            virtualStatus: { state: "preconfirmed" },
+            createdAt: baseDate,
+            isUnrolled: false,
+            isSpent: false,
+            script: walletScript,
+            ...over,
+        });
+
+        const sentOf = (txs: ArkTransaction[]) => txs.filter((t) => t.type === TxType.TxSent);
+        const rowsFor = (txs: ArkTransaction[], arkTxid: string) =>
+            txs.filter((t) => t.key.arkTxid === arkTxid);
+        const sentFor = (txs: ArkTransaction[], arkTxid: string) =>
+            rowsFor(txs, arkTxid).filter((t) => t.type === TxType.TxSent);
+        const receivedFor = (txs: ArkTransaction[], arkTxid: string) =>
+            rowsFor(txs, arkTxid).filter((t) => t.type === TxType.TxReceived);
+
+        describe("BTC give, asset want", () => {
+            const fundingTxid = "btc-give-funding-tx";
+            const fillTxid = "btc-give-fill-tx";
+            const cancelTxid = "btc-give-cancel-tx";
+
+            /** 10_000 sats in, 6_000 into the covenant, 4_000 back as change. */
+            const funding = () => [
+                coin({
+                    txid: "wallet-coin-btc-give",
+                    value: 10_000,
+                    isSpent: true,
+                    spentBy: checkpointOf(fundingTxid),
+                    arkTxId: fundingTxid,
+                }),
+                coin({
+                    txid: fundingTxid,
+                    vout: 0,
+                    value: 6_000,
+                    script: covenantScript,
+                    createdAt: at(1_000),
+                }),
+                coin({
+                    txid: fundingTxid,
+                    vout: 1,
+                    value: 4_000,
+                    createdAt: at(1_000),
+                }),
+            ];
+
+            /** The covenant coin, spent by whichever leg closes the offer. */
+            const closedBy = (txid: string) => {
+                const [walletCoin, covenant, change] = funding();
+                return [
+                    walletCoin,
+                    { ...covenant, isSpent: true, spentBy: checkpointOf(txid), arkTxId: txid },
+                    change,
+                ];
+            };
+
+            it("records the deposit as a send once the covenant is funded", async () => {
+                const txs = await buildTransactionHistory(
+                    funding(),
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                const sent = sentFor(txs, fundingTxid);
+                expect(sent).toHaveLength(1);
+                expect(sent[0].amount).toBe(6_000);
+                // Attributable, not silently dropped: the counterparty is the
+                // user's own escrow, not a stranger.
+                expect(sent[0].tag).toBe("gated");
+                // The change output is change, and the covenant output is not a receive.
+                expect(receivedFor(txs, fundingTxid)).toHaveLength(0);
+            });
+
+            it("records the solver's fill as a receive of the bought asset", async () => {
+                const txs = await buildTransactionHistory(
+                    [
+                        ...closedBy(fillTxid),
+                        coin({
+                            txid: fillTxid,
+                            value: 330,
+                            createdAt: at(2_000),
+                            assets: [{ assetId: assetX, amount: 5_000n }],
+                        }),
+                    ],
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                // The escrow leaving is not a second send: it was already sent.
+                const sent = sentOf(txs);
+                expect(sent).toHaveLength(1);
+                expect(sent[0].key.arkTxid).toBe(fundingTxid);
+                expect(sent[0].amount).toBe(6_000);
+
+                const received = receivedFor(txs, fillTxid);
+                expect(received).toHaveLength(1);
+                expect(received[0].amount).toBe(330);
+                expect(received[0].assets).toStrictEqual([{ assetId: assetX, amount: 5_000n }]);
+                expect(received[0].tag).toBe("gated");
+            });
+
+            it("records a cancel as the deposit coming back", async () => {
+                const txs = await buildTransactionHistory(
+                    [
+                        ...closedBy(cancelTxid),
+                        coin({ txid: cancelTxid, value: 6_000, createdAt: at(2_000) }),
+                    ],
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                const sent = sentOf(txs);
+                expect(sent).toHaveLength(1);
+                expect(sent[0].key.arkTxid).toBe(fundingTxid);
+
+                const received = receivedFor(txs, cancelTxid);
+                expect(received).toHaveLength(1);
+                expect(received[0].amount).toBe(6_000);
+                expect(received[0].tag).toBe("gated");
+            });
+
+            it("nets the funding to nothing with the covenant left in the wallet's set", async () => {
+                // The defect itself, and the guard against a silent revert: with
+                // no gate the covenant output is change, so `spentAmount -
+                // changeAmount` is 0, no assets move, and the ghost-row guard
+                // drops the only record the swap would have had.
+                const txs = await buildTransactionHistory(funding(), [], new Set());
+                expect(sentOf(txs)).toHaveLength(0);
+                expect(rowsFor(txs, fundingTxid)).toHaveLength(0);
+            });
+        });
+
+        describe("asset give, BTC want", () => {
+            const fundingTxid = "asset-give-funding-tx";
+            const fillTxid = "asset-give-fill-tx";
+            const cancelTxid = "asset-give-cancel-tx";
+
+            /**
+             * The whole movement is asset-side: 1_000 units ride a 500-sat dust
+             * carrier into the covenant, with no change.
+             */
+            const funding = () => [
+                coin({
+                    txid: "wallet-coin-asset-give",
+                    value: 500,
+                    isSpent: true,
+                    spentBy: checkpointOf(fundingTxid),
+                    arkTxId: fundingTxid,
+                    assets: [{ assetId: assetX, amount: 1_000n }],
+                }),
+                coin({
+                    txid: fundingTxid,
+                    vout: 0,
+                    value: 500,
+                    script: covenantScript,
+                    createdAt: at(1_000),
+                    assets: [{ assetId: assetX, amount: 1_000n }],
+                }),
+            ];
+
+            const closedBy = (txid: string) => {
+                const [walletCoin, covenant] = funding();
+                return [
+                    walletCoin,
+                    { ...covenant, isSpent: true, spentBy: checkpointOf(txid), arkTxId: txid },
+                ];
+            };
+
+            it("records the deposited units on the funding send", async () => {
+                const txs = await buildTransactionHistory(
+                    funding(),
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                const sent = sentFor(txs, fundingTxid);
+                expect(sent).toHaveLength(1);
+                // The carrier sats are the amount; the units are the movement.
+                expect(sent[0].amount).toBe(500);
+                expect(sent[0].assets).toStrictEqual([{ assetId: assetX, amount: -1_000n }]);
+                expect(sent[0].tag).toBe("gated");
+                expect(receivedFor(txs, fundingTxid)).toHaveLength(0);
+            });
+
+            it("leaves units that stayed behind out of the funding send", async () => {
+                const txs = await buildTransactionHistory(
+                    [
+                        coin({
+                            txid: "wallet-coin-asset-partial",
+                            value: 800,
+                            isSpent: true,
+                            spentBy: checkpointOf(fundingTxid),
+                            arkTxId: fundingTxid,
+                            assets: [{ assetId: assetX, amount: 1_000n }],
+                        }),
+                        coin({
+                            txid: fundingTxid,
+                            vout: 0,
+                            value: 300,
+                            script: covenantScript,
+                            createdAt: at(1_000),
+                            assets: [{ assetId: assetX, amount: 600n }],
+                        }),
+                        coin({
+                            txid: fundingTxid,
+                            vout: 1,
+                            value: 500,
+                            createdAt: at(1_000),
+                            assets: [{ assetId: assetX, amount: 400n }],
+                        }),
+                    ],
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                const sent = sentFor(txs, fundingTxid);
+                expect(sent).toHaveLength(1);
+                expect(sent[0].amount).toBe(300);
+                // 600 deposited, not the 1_000 the input carried.
+                expect(sent[0].assets).toStrictEqual([{ assetId: assetX, amount: -600n }]);
+            });
+
+            it("records the fill as a receive of the sats the solver paid", async () => {
+                const txs = await buildTransactionHistory(
+                    [
+                        ...closedBy(fillTxid),
+                        coin({ txid: fillTxid, value: 9_000, createdAt: at(2_000) }),
+                    ],
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                const received = receivedFor(txs, fillTxid);
+                expect(received).toHaveLength(1);
+                expect(received[0].amount).toBe(9_000);
+                expect(received[0]).not.toHaveProperty("assets");
+                expect(received[0].tag).toBe("gated");
+
+                // The escrowed units leave once, on the funding row — the fill
+                // must not report them as a second send.
+                const sent = sentOf(txs);
+                expect(sent).toHaveLength(1);
+                expect(sent[0].key.arkTxid).toBe(fundingTxid);
+            });
+
+            it("records a cancel as every unit coming back", async () => {
+                const txs = await buildTransactionHistory(
+                    [
+                        ...closedBy(cancelTxid),
+                        coin({
+                            txid: cancelTxid,
+                            value: 500,
+                            createdAt: at(2_000),
+                            assets: [{ assetId: assetX, amount: 1_000n }],
+                        }),
+                    ],
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                const received = receivedFor(txs, cancelTxid);
+                expect(received).toHaveLength(1);
+                expect(received[0].amount).toBe(500);
+                expect(received[0].assets).toStrictEqual([{ assetId: assetX, amount: 1_000n }]);
+                expect(received[0].tag).toBe("gated");
+            });
+
+            it("reports nothing at all with the covenant left in the wallet's set", async () => {
+                // The worse half of the defect: the movement is entirely
+                // asset-side, so both the sats and the units cancel.
+                const txs = await buildTransactionHistory(funding(), [], new Set());
+                expect(sentOf(txs)).toHaveLength(0);
+                expect(rowsFor(txs, fundingTxid)).toHaveLength(0);
+            });
+
+            it("dates the deposit from the covenant output, without an indexer call", async () => {
+                // With no change output there is nothing of the wallet's left in
+                // the funding tx to read the time off. The escrow's own output
+                // is that time and is already in hand, so the row must not fall
+                // back to the input coin's timestamp — which would be a month
+                // stale here — nor pay for a round-trip to learn it.
+                const resolveTxCreatedAt = vi.fn(async () => new Map<string, number>());
+                const txs = await buildTransactionHistory(
+                    funding(),
+                    [],
+                    new Set(),
+                    resolveTxCreatedAt,
+                    gate(offerContract()),
+                );
+
+                expect(resolveTxCreatedAt).not.toHaveBeenCalled();
+                expect(sentFor(txs, fundingTxid)[0].createdAt).toBe(at(1_000).getTime());
+            });
+        });
+
+        describe("what the gate must not swallow", () => {
+            it("keeps an arkade row marked genericallySpendable in history", async () => {
+                // One coin, standing alone at the contract's script with nothing
+                // of the wallet's spending into it: the only shape where "kept"
+                // and "dropped" look different. The marker is the only
+                // difference between the two runs.
+                const deposit = [
+                    coin({
+                        txid: "third-party-deposit",
+                        value: 7_000,
+                        script: covenantScript,
+                        createdAt: at(1_000),
+                    }),
+                ];
+                const marked = offerContract({
+                    metadata: { genericallySpendable: true, kind: "asset-swap-offer" },
+                });
+
+                expect(gate(marked).size).toBe(0);
+                const kept = await buildTransactionHistory(
+                    deposit,
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(marked),
+                );
+                expect(kept).toHaveLength(1);
+                expect(kept[0].type).toBe(TxType.TxReceived);
+                expect(kept[0].amount).toBe(7_000);
+
+                // Unmarked, the same coin is escrow: not the wallet's money, so
+                // no row. This is the gate's reach beyond swaps — any default-
+                // closed `arkade` row funded from outside the wallet loses the
+                // receive it used to report.
+                expect(gate(offerContract()).get(covenantScript)).toBe("arkade");
+                expect(
+                    await buildTransactionHistory(
+                        deposit,
+                        [],
+                        new Set(),
+                        undefined,
+                        gate(offerContract()),
+                    ),
+                ).toHaveLength(0);
+            });
+
+            it("leaves an ordinary payment made while an offer is live alone", async () => {
+                const paymentTxid = "ordinary-payment-tx";
+                const txs = await buildTransactionHistory(
+                    [
+                        coin({
+                            txid: "wallet-coin-ordinary",
+                            value: 10_000,
+                            isSpent: true,
+                            spentBy: checkpointOf(paymentTxid),
+                            arkTxId: paymentTxid,
+                        }),
+                        // What the stranger got is not in the wallet's set; the
+                        // change is.
+                        coin({
+                            txid: paymentTxid,
+                            vout: 1,
+                            value: 3_000,
+                            createdAt: at(1_000),
+                        }),
+                        // A funded covenant sits in the same history and must
+                        // not colour a payment it has nothing to do with.
+                        coin({
+                            txid: "unrelated-funding-tx",
+                            value: 6_000,
+                            script: covenantScript,
+                            createdAt: at(500),
+                        }),
+                    ],
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                const sent = sentFor(txs, paymentTxid);
+                expect(sent).toHaveLength(1);
+                expect(sent[0].amount).toBe(7_000);
+                expect(sent[0].tag).toBe("offchain");
+            });
+
+            it("keeps a VTXO with no script in history", async () => {
+                const scriptless = (
+                    over: Partial<VirtualCoin> & Pick<VirtualCoin, "txid" | "value">,
+                ) => {
+                    const { script: _script, ...rest } = coin(over);
+                    return rest as VirtualCoin;
+                };
+
+                const txs = await buildTransactionHistory(
+                    [
+                        scriptless({
+                            txid: "scriptless-spent",
+                            value: 1_000,
+                            isSpent: true,
+                            spentBy: checkpointOf("scriptless-tx"),
+                            arkTxId: "scriptless-tx",
+                        }),
+                        scriptless({ txid: "scriptless-tx", value: 400, createdAt: at(1_000) }),
+                    ],
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                // No script means no contract row to judge the coin by, so it is
+                // the wallet's own and the ordinary send stands.
+                const sent = sentFor(txs, "scriptless-tx");
+                expect(sent).toHaveLength(1);
+                expect(sent[0].amount).toBe(600);
+                expect(sent[0].tag).toBe("offchain");
+            });
+
+            it("still records no ghost row for a signer-rotation self-transfer", async () => {
+                const arkTxId = "gated-migration-ark-tx";
+                const txs = await buildTransactionHistory(
+                    [
+                        coin({
+                            txid: "old-signer-coin",
+                            value: 184_875,
+                            isSpent: true,
+                            spentBy: checkpointOf(arkTxId),
+                            arkTxId,
+                        }),
+                        coin({ txid: arkTxId, value: 184_875, createdAt: at(1_000) }),
+                    ],
+                    [],
+                    new Set(),
+                    undefined,
+                    gate(offerContract()),
+                );
+
+                expect(sentOf(txs)).toHaveLength(0);
+                expect(rowsFor(txs, arkTxId)).toHaveLength(0);
+            });
+
+            // [name, ark txid, units spent, units in change, the row's asset amount]
+            it.each([
+                ["issuance", "gated-issuance", 0n, 500n, 500n],
+                ["reissuance", "gated-reissuance", 500n, 900n, 400n],
+                ["burn", "gated-burn", 900n, 400n, -500n],
+            ] as const)(
+                "still records %s as a zero-sat asset row",
+                async (_name, arkTxId, spentUnits, changeUnits, expected) => {
+                    const txs = await buildTransactionHistory(
+                        [
+                            coin({
+                                txid: `${arkTxId}-input`,
+                                value: 1_000,
+                                isSpent: true,
+                                spentBy: checkpointOf(arkTxId),
+                                arkTxId,
+                                ...(spentUnits > 0n && {
+                                    assets: [{ assetId: assetX, amount: spentUnits }],
+                                }),
+                            }),
+                            coin({
+                                txid: arkTxId,
+                                value: 1_000,
+                                createdAt: at(1_000),
+                                assets: [{ assetId: assetX, amount: changeUnits }],
+                            }),
+                        ],
+                        [],
+                        new Set(),
+                        undefined,
+                        gate(offerContract()),
+                    );
+
+                    const sent = sentFor(txs, arkTxId);
+                    expect(sent).toHaveLength(1);
+                    expect(sent[0].amount).toBe(0);
+                    expect(sent[0].assets).toStrictEqual([{ assetId: assetX, amount: expected }]);
+                    expect(sent[0].tag).toBe("offchain");
+                },
+            );
         });
     });
 

--- a/packages/ts-sdk/test/wallet-message-handler.test.ts
+++ b/packages/ts-sdk/test/wallet-message-handler.test.ts
@@ -309,7 +309,6 @@ describe("WalletMessageHandler handleMessage", () => {
         const transactions = [{ txid: "tx" }];
         (updater as any).readonlyWallet = {};
         (updater as any).buildTransactionHistoryFromCache = vi.fn().mockResolvedValue(transactions);
-        (updater as any).getVtxosFromRepo = vi.fn().mockResolvedValue([]);
 
         const response = await updater.handleMessage({
             ...baseMessage(),


### PR DESCRIPTION
@gringokiwi for review.

## The defect

`getBalance()` applies the spendability gate. `getTransactionHistory()` applied none — it flat-mapped every contract VTXO in, whatever its `genericallySpendable` marker.

`@arkade-os/swap` registers an offer covenant as a contract of the wallet that funds it, so the covenant's output landed in history's own-coin set and counted as change. Both legs cancelled: `spentAmount - changeAmount` went to zero, and `subtractAssets` deleted every key that reached `0n`. The ghost-row guard (`if (txAmount !== 0 || assets)`) then dropped the row entirely.

Result: funding, fill and cancel each produced **no row at all**. An `offerAsset` swap, whose whole movement is asset units on a dust carrier, disappeared completely. And since `getActivityHistory()` is `buildActivities(getTransactionHistory(), resolvers)` and resolvers contribute no rows of their own, asset swaps could not appear in activity at all.

## The fix

`buildTransactionHistory` takes the gate — exactly what `gatedContracts()` returns — and reads those VTXOs as an external counterparty.

| Step | Before | After |
|---|---|---|
| Fund the covenant | no row | SENT, the deposit |
| Solver fills | SENT of the escrowed amount | RECEIVED, the bought asset on its carrier |
| Cancel | no row | RECEIVED, the deposit coming back |

Both directions, with asset movements carried on the row instead of cancelled away.

Both read paths derive the gate off a single snapshot: `ReadonlyWallet.getTransactionHistory` from `contractSnapshot()`, and the worker's `buildTransactionHistoryFromCache` from its own `repoSnapshot()` — which it now takes itself, so neither of its two callers can hand it coins without the gate that judges them.

## Notes for review

**The covenant movement stays attributable.** Rows facing a gated contract are tagged `"gated"`, through the open string arm of `TxTag`, so a consumer can tell "sent to my own escrow" from "sent to a stranger". `"gated"` rather than a contract-flavoured name because every VTXO here belongs to a contract row — the wallet's own receive address is a `default` contract — and because it points at `WalletBalance.gated`, which is the same money. `BuiltinTxTag` is not in the package's export map, so `TxTag` stays the only public surface.

**Timestamps.** Removing the covenant coin also removed the funding tx's only local timestamp source when the deposit leaves no change — an indexer round-trip per deposit on the main thread, and on the worker's offline read a fallback to the *input* coin's timestamp, filing a fresh deposit at the wrong end of the list. `localCreatedAtByTxid` states the rule once over every coin, before the gate partitions them, so the covenant output dates the row directly and `collectArkTxidsNeedingCreatedAt` is exactly that map's complement.

**One invariant changed on purpose.** `spendability-gate.test.ts` listed history beside `getVtxos` as an ungated read. Treating it as one was the defect. That test is split: the recovery read still keeps escrowed coins, the history read now gates them. Worth a look — it's the one place this contradicts something the repo previously asserted.

**One spelling of the gate.** `isGatedVtxo`/`gatedTypeOf` now live in `contracts/spendability.ts` next to `gatedContracts`, and `gateExclusion` uses them, instead of a private fourth copy in the utils module. `gatedFrom(snapshot)` replaces four hand-kept copies of `gatedContracts(snapshot.map((_) => _.contract))`.

## Follow-ups, deliberately not in scope

`gatedContracts()` is a single predicate that also covers VHTLC lockups, so corridor rows shift as a side effect. Not carved out — a swap-only variant would leave history and balance disagreeing for lockups, which is the bug being fixed — but not tested or tuned here either:

- A gated coin settled in a **batch** changes the exit arm's `forfeitAmount` vs `settledAmount` arithmetic; batch and exit rows carry no tag. Tracked in #860.
- One ark tx spending **both** a gated coin and a wallet coin can drive the amount negative or flip an asset sign. Unreachable in the offer flow (the covenant is always the sole wallet-side input), reachable via `sendBitcoin({ selectedVtxos })`.
- A default-closed `arkade` row funded **from outside the wallet** loses the receive it used to report. Direct consequence of the external-counterparty reading; pinned in a test rather than left latent.
- SQLite and Realm wallet repositories drop `tag` on write. Pre-existing for all tags.
- The gate arrives as a fifth positional parameter carrying the contracts map. Passing a predicate instead — the shape `BalanceCapabilities.isGenericallySpendable` already uses — would let `utils/transactionHistory.ts` drop its `contracts/spendability` import entirely. Not breaking (`buildTransactionHistory` is not exported from `src/index.ts` and has no subpath), just kept out of a bugfix diff.

## Tests

17 cases in a new `Gated contracts (swap covenants)` block covering both directions, plus two wiring tests in `spendability-gate.test.ts`. Stripping the gate argument from either production call site turns exactly those two red — without them the whole feature was revertible while staying green, since the unit block never builds a wallet.

Full suite green: ts-sdk 2987, swap 785. Lint, typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCGopokSkmbcbNZMKnYVEG

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCGopokSkmbcbNZMKnYVEG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transaction history now recognizes gated contract activity and labels it **“gated.”**
  - Gated contract outputs are excluded from ordinary wallet-owned history while remaining available in recovery views.
  - Gated deposits, fills, and cancellations receive consistent send/receive classifications and timestamps.
  - Balance and transaction-history views apply the same gating rules across main-thread and worker paths.

- **Bug Fixes**
  - Prevented contract-controlled funds from being incorrectly reported as wallet change or ordinary wallet activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->