### PR TITLE
feat(vtxo-manager): let renewVtxos settle into several outputs

### DIFF
--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -173,6 +173,8 @@ import { isVtxoExpiringSoon, VtxoManager } from "./wallet/vtxo-manager";
 import type {
     IVtxoManager,
     RenewVtxosOptions,
+    RenewalSplit,
+    RenewalSplitContext,
     SettlementConfig,
     MigrateDeprecatedSignerOptions,
     DeprecatedSignerMigrationReport,
@@ -976,6 +978,8 @@ export type {
     SettlementConfig,
     IVtxoManager,
     RenewVtxosOptions,
+    RenewalSplit,
+    RenewalSplitContext,
     MigrateDeprecatedSignerOptions,
     DeprecatedSignerMigrationReport,
     DeprecatedSignerReport,

--- a/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
+++ b/packages/ts-sdk/src/wallet/serviceWorker/wallet.ts
@@ -2135,6 +2135,15 @@ export class ServiceWorkerWallet
                 eventCallback?: (event: SettlementEvent) => void,
                 options?: RenewVtxosOptions,
             ): Promise<string> {
+                // `options` is posted to the worker and `split.plan` is a function,
+                // which structured clone refuses. Named rather than left to surface
+                // as a DataCloneError from inside postMessage.
+                if (options?.split) {
+                    throw new Error(
+                        "renewVtxos: split is not supported over the service worker — " +
+                            "its plan callback cannot cross the message bus",
+                    );
+                }
                 const message: RequestRenewVtxos = {
                     tag: messageTag,
                     type: "RENEW_VTXOS",

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -420,10 +420,17 @@ function offchainOutputFee(amount: bigint, estimator: Estimator, arkAddress: str
  * direction {@link deductOffchainOutputFee} already errs in.
  */
 function planSplitOutputs(split: RenewalSplit, context: RenewalSplitContext): bigint[] {
-    const { subtotal, outputFeeOn, maxAmount } = context;
+    const { subtotal, outputFeeOn, maxAmount, hasAssets } = context;
     const amounts = [...split.plan(context)];
     if (amounts.length === 0) {
         throw new Error(`Renewal split produced no outputs for a subtotal of ${subtotal}`);
+    }
+    if (hasAssets && amounts.length > 1) {
+        throw new Error(
+            `Renewal split produced ${amounts.length} outputs while the selected inputs carry assets: ` +
+                "settle assigns every input asset to the first matching output, so they would all land on " +
+                "piece 0. Return a single piece when the split context reports hasAssets.",
+        );
     }
     if (amounts.length > split.maxOutputs) {
         throw new Error(
@@ -792,6 +799,14 @@ export interface RenewalSplitContext {
     dust: bigint;
     /** The address every piece lands on — the wallet's own, after any signer rotation. */
     address: string;
+    /**
+     * Whether any selected input carries assets — when it does, a plan MUST
+     * return a single piece. `Wallet.settle` bags every input asset onto the
+     * FIRST output matching the destination script, and every piece is on that
+     * script, so a split would silently put the whole holding on piece 0. The
+     * SPLIT is refused rather than the renewal: an unrenewed float expires.
+     */
+    hasAssets: boolean;
 }
 
 /**
@@ -1870,6 +1885,9 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                       maxAmount: vtxoMaxAmount,
                       dust: dustAmount,
                       address: arkAddress,
+                      // Read off the FINAL selection, so a cap that dropped the only
+                      // asset-bearing input frees the plan to split again.
+                      hasAssets: vtxos.some((vtxo) => (vtxo.assets?.length ?? 0) > 0),
                   })
                 : // The fee an intent offers IS `sum(inputs) - sum(outputs)`, so the
                   // output has to come back short by what the operator's programs

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -800,11 +800,11 @@ export interface RenewalSplitContext {
     /** The address every piece lands on — the wallet's own, after any signer rotation. */
     address: string;
     /**
-     * Whether any selected input carries assets — when it does, a plan MUST
-     * return a single piece. `Wallet.settle` bags every input asset onto the
-     * FIRST output matching the destination script, and every piece is on that
-     * script, so a split would silently put the whole holding on piece 0. The
-     * SPLIT is refused rather than the renewal: an unrenewed float expires.
+     * Whether any selected input carries assets — then a plan MUST return one
+     * piece. `Wallet.settle` bags every input asset onto the FIRST output
+     * matching the destination script, and every piece is on it, so a split
+     * would silently put the whole holding on piece 0. The SPLIT is refused
+     * rather than the renewal: an unrenewed float expires.
      */
     hasAssets: boolean;
 }
@@ -1824,11 +1824,9 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // this weighs GROSS input value against pieces paid post-fee, so it
             // stays under what they can absorb.
             //
-            // Except when the batch carries assets, which must come back as ONE
-            // piece: several ceilings' worth would leave it no valid plan at all —
-            // split and the asset guard refuses it, don't and the ceiling guard
-            // does. Judged BEFORE the cap so it cannot admit a batch it then
-            // strands; a cap that later drops the asset-bearing input only defers.
+            // Except an asset-bearing batch, which must come back as ONE piece:
+            // several ceilings' worth would leave it no valid plan at all. Judged
+            // BEFORE the cap, so it cannot admit a batch it then strands.
             const carriesAssets = vtxos.some((vtxo) => (vtxo.assets?.length ?? 0) > 0);
             const capacity =
                 vtxoMaxAmount < 0n || !options?.split || carriesAssets

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -1823,8 +1823,15 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // that many ceilings' worth. By the count alone, not the output fee too:
             // this weighs GROSS input value against pieces paid post-fee, so it
             // stays under what they can absorb.
+            //
+            // Except when the batch carries assets, which must come back as ONE
+            // piece: several ceilings' worth would leave it no valid plan at all —
+            // split and the asset guard refuses it, don't and the ceiling guard
+            // does. Judged BEFORE the cap so it cannot admit a batch it then
+            // strands; a cap that later drops the asset-bearing input only defers.
+            const carriesAssets = vtxos.some((vtxo) => (vtxo.assets?.length ?? 0) > 0);
             const capacity =
-                vtxoMaxAmount < 0n || !options?.split
+                vtxoMaxAmount < 0n || !options?.split || carriesAssets
                     ? vtxoMaxAmount
                     : BigInt(options.split.maxOutputs) * vtxoMaxAmount;
             const capped = capSettlementBatch(byExpiryAscending(vtxos, now), capacity);

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -394,18 +394,58 @@ function deductOffchainOutputFee(
     estimator: Estimator,
     arkAddress: string,
 ): bigint {
+    return subtotal - offchainOutputFee(subtotal, estimator, arkAddress);
+}
+
+function offchainOutputFee(amount: bigint, estimator: Estimator, arkAddress: string): bigint {
     // Mirror the estimator's own early return rather than reaching it through
     // `ArkAddress.decode`: with no output program the script is never read, and
     // an operator that doesn't price outputs shouldn't make a decodable address
     // a precondition for renewing or recovering.
     if (!estimator.config.offchainOutput) {
-        return subtotal;
+        return 0n;
     }
     const outputFee = estimator.evalOffchainOutput({
-        amount: subtotal,
+        amount,
         script: hex.encode(ArkAddress.decode(arkAddress).pkScript),
     });
-    return subtotal - BigInt(outputFee.satoshis);
+    return BigInt(outputFee.satoshis);
+}
+
+/**
+ * Run a caller's {@link RenewalSplit} and refuse a plan the server would reject.
+ *
+ * Refused, not corrected — a reshaped plan renews the float into a shape nobody
+ * asked for. Under-claiming IS allowed: it leaves a residue as fee, the
+ * direction {@link deductOffchainOutputFee} already errs in.
+ */
+function planSplitOutputs(split: RenewalSplit, context: RenewalSplitContext): bigint[] {
+    const { subtotal, outputFeeOn, maxAmount } = context;
+    const amounts = [...split.plan(context)];
+    if (amounts.length === 0) {
+        throw new Error(`Renewal split produced no outputs for a subtotal of ${subtotal}`);
+    }
+    if (amounts.length > split.maxOutputs) {
+        throw new Error(
+            `Renewal split produced ${amounts.length} outputs, more than the ${split.maxOutputs} it allows`,
+        );
+    }
+
+    let claimed = 0n;
+    for (const amount of amounts) {
+        if (maxAmount >= 0n && amount > maxAmount) {
+            throw new Error(
+                `Renewal split output ${amount} exceeds the per-output limit ${maxAmount}`,
+            );
+        }
+        claimed += amount + outputFeeOn(amount);
+    }
+    if (claimed > subtotal) {
+        throw new Error(
+            `Renewal split claims ${claimed} with fees, more than the ${subtotal} available`,
+        );
+    }
+    return amounts;
 }
 
 /** Default renewal threshold in seconds (3 days). */
@@ -724,6 +764,34 @@ export interface RenewVtxosOptions {
      * more urgently expiring than the globally configured threshold.
      */
     thresholdSeconds?: number;
+    /** Give the renewal back as several outputs. Omitted, it settles into one. */
+    split?: RenewalSplit;
+}
+
+/**
+ * How a renewal divides its proceeds across outputs. The arithmetic that gets a
+ * settlement accepted stays here; this decides only the SHAPE, which is a policy
+ * the wallet cannot know.
+ */
+export interface RenewalSplit {
+    /**
+     * Most outputs one renewal may create — the caller's own bound, the server
+     * bounding WEIGHT. Also raises admission to this many `vtxoMaxAmount`s.
+     */
+    maxOutputs: number;
+    plan(context: RenewalSplitContext): readonly bigint[];
+}
+
+/** What a {@link RenewalSplit} gets to decide against. */
+export interface RenewalSplitContext {
+    /** Inputs' worth net of their own intent fees, BEFORE any output fee. */
+    subtotal: bigint;
+    outputFeeOn(amount: bigint): bigint;
+    /** Server per-output ceiling; `-1n` means none. */
+    maxAmount: bigint;
+    dust: bigint;
+    /** The address every piece lands on — the wallet's own, after any signer rotation. */
+    address: string;
 }
 
 /**
@@ -1657,6 +1725,16 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             }
         }
 
+        // Same reason, and needed this early: the batch cap below multiplies by it.
+        if (options?.split !== undefined) {
+            const { maxOutputs } = options.split;
+            if (!Number.isInteger(maxOutputs) || maxOutputs < 1) {
+                throw new TypeError(
+                    `Invalid split.maxOutputs: expected a positive integer, got ${String(maxOutputs)}`,
+                );
+            }
+        }
+
         if (this.renewalInProgress) {
             throw new Error("Renewal already in progress");
         }
@@ -1726,14 +1804,22 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 );
             }
 
-            const capped = capSettlementBatch(byExpiryAscending(vtxos, now), vtxoMaxAmount);
-            if (vtxoMaxAmount >= 0n) {
+            // The ceiling bounds each OUTPUT, so a split emitting several carries
+            // that many ceilings' worth. By the count alone, not the output fee too:
+            // this weighs GROSS input value against pieces paid post-fee, so it
+            // stays under what they can absorb.
+            const capacity =
+                vtxoMaxAmount < 0n || !options?.split
+                    ? vtxoMaxAmount
+                    : BigInt(options.split.maxOutputs) * vtxoMaxAmount;
+            const capped = capSettlementBatch(byExpiryAscending(vtxos, now), capacity);
+            if (capacity >= 0n) {
                 // A VTXO whose value alone exceeds the per-output ceiling can
                 // never be renewed by this path (the server would reject it) and
                 // will drift toward a unilateral exit as it nears expiry. The
                 // routine count-cap overflow is benign (deferred next cycle), but
                 // this is not — surface it so operators can act (e.g. split it).
-                const oversized = vtxos.filter((vtxo) => BigInt(vtxo.value) > vtxoMaxAmount);
+                const oversized = vtxos.filter((vtxo) => BigInt(vtxo.value) > capacity);
                 if (oversized.length > 0) {
                     console.warn(
                         `Renewal: ${oversized.length} VTXO(s) exceed the per-output limit ` +
@@ -1775,34 +1861,35 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
             // the script the renewed VTXO actually lands on.
             const arkAddress = await this.wallet.getAddress();
 
-            // The fee an intent offers IS `sum(inputs) - sum(outputs)`, so the
-            // output has to come back short by what the operator's programs
-            // price. Asking for the gross sum offers zero and the server rejects
-            // with INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
-            const totalAmount = deductOffchainOutputFee(
-                subtotalOf(vtxos, net),
-                estimator,
-                arkAddress,
-            );
+            const subtotal = subtotalOf(vtxos, net);
+
+            const amounts = options?.split
+                ? planSplitOutputs(options.split, {
+                      subtotal,
+                      outputFeeOn: (amount) => offchainOutputFee(amount, estimator, arkAddress),
+                      maxAmount: vtxoMaxAmount,
+                      dust: dustAmount,
+                      address: arkAddress,
+                  })
+                : // The fee an intent offers IS `sum(inputs) - sum(outputs)`, so the
+                  // output has to come back short by what the operator's programs
+                  // price. Asking for the gross sum offers zero and the server rejects
+                  // with INTENT_INSUFFICIENT_FEE — see `priceSettlementInputs`.
+                  [deductOffchainOutputFee(subtotal, estimator, arkAddress)];
 
             // Dust is judged on the NET output, not the gross input sum: the fees
             // come off after selection, so a batch that clears dust gross can
             // land under it here.
-            if (totalAmount < dustAmount) {
-                throw new Error(
-                    `Total amount ${totalAmount} is below dust threshold ${dustAmount}`,
-                );
+            for (const amount of amounts) {
+                if (amount < dustAmount) {
+                    throw new Error(`Total amount ${amount} is below dust threshold ${dustAmount}`);
+                }
             }
 
             const txid = await this.wallet.settle(
                 {
                     inputs: vtxos,
-                    outputs: [
-                        {
-                            address: arkAddress,
-                            amount: totalAmount,
-                        },
-                    ],
+                    outputs: amounts.map((amount) => ({ address: arkAddress, amount })),
                 },
                 eventCallback,
             );

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -413,7 +413,9 @@ function offchainOutputFee(amount: bigint, estimator: Estimator, arkAddress: str
 }
 
 /**
- * Run a caller's {@link RenewalSplit} and refuse a plan the server would reject.
+ * Run a caller's {@link RenewalSplit} and refuse a plan whose SHAPE the server
+ * would reject — count, ceiling and budget. Dust is judged by the caller, on
+ * every output whichever path produced it, so the one rule cannot drift.
  *
  * Refused, not corrected — a reshaped plan renews the float into a shape nobody
  * asked for. Under-claiming IS allowed: it leaves a residue as fee, the
@@ -1832,6 +1834,13 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 vtxoMaxAmount < 0n || !options?.split || carriesAssets
                     ? vtxoMaxAmount
                     : BigInt(options.split.maxOutputs) * vtxoMaxAmount;
+            // Name the bound that actually fired. Both messages below count against
+            // `capacity`, so naming the per-output ceiling under a split would have
+            // an operator diagnose against a number nothing was compared to.
+            const limitLabel =
+                capacity === vtxoMaxAmount
+                    ? `per-output limit ${vtxoMaxAmount}`
+                    : `combined split capacity ${capacity} (${options?.split?.maxOutputs} x ${vtxoMaxAmount})`;
             const capped = capSettlementBatch(byExpiryAscending(vtxos, now), capacity);
             if (capacity >= 0n) {
                 // A VTXO whose value alone exceeds the per-output ceiling can
@@ -1842,8 +1851,8 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 const oversized = vtxos.filter((vtxo) => BigInt(vtxo.value) > capacity);
                 if (oversized.length > 0) {
                     console.warn(
-                        `Renewal: ${oversized.length} VTXO(s) exceed the per-output limit ` +
-                            `${vtxoMaxAmount} and cannot be renewed; they risk unilateral exit`,
+                        `Renewal: ${oversized.length} VTXO(s) exceed the ${limitLabel} ` +
+                            "and cannot be renewed; they risk unilateral exit",
                     );
                 }
             }
@@ -1853,12 +1862,10 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                 // keep the original selection (and order) untouched.
                 vtxos = capped;
                 if (vtxos.length === 0) {
-                    // The soonest-expiring VTXO alone exceeds vtxoMaxAmount, so
-                    // no batch fits. Only reachable if the server lowered the
-                    // ceiling below an existing VTXO; it would reject it anyway.
-                    throw new Error(
-                        `No VTXOs available to renew within the per-output limit ${vtxoMaxAmount}`,
-                    );
+                    // The soonest-expiring VTXO alone exceeds the bound, so no
+                    // batch fits. Only reachable if the server lowered the ceiling
+                    // below an existing VTXO; it would reject it anyway.
+                    throw new Error(`No VTXOs available to renew within the ${limitLabel}`);
                 }
             }
 

--- a/packages/ts-sdk/test/serviceWorker/wallet.test.ts
+++ b/packages/ts-sdk/test/serviceWorker/wallet.test.ts
@@ -735,6 +735,25 @@ describe("ServiceWorkerWallet", () => {
         const wallet = createSWWallet(serviceWorker as any, messageTag);
         await expect(wallet.restore()).rejects.toThrow("boom");
     });
+
+    // `split.plan` is a function and the options object is posted to the worker.
+    it("refuses renewVtxos with a split rather than failing to clone it", async () => {
+        const { navigatorServiceWorker, serviceWorker } = createServiceWorkerHarness();
+
+        vi.stubGlobal("navigator", {
+            serviceWorker: navigatorServiceWorker,
+        } as any);
+
+        const wallet = createSWWallet(serviceWorker as any, messageTag);
+        const manager = await wallet.getVtxoManager();
+
+        await expect(
+            manager.renewVtxos(undefined, { split: { maxOutputs: 4, plan: () => [1000n] } }),
+        ).rejects.toThrow("split is not supported over the service worker");
+        expect(serviceWorker.postMessage).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: "RENEW_VTXOS" }),
+        );
+    });
 });
 
 describe("sendMessage reinitialize on SW restart", () => {

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -4339,6 +4339,26 @@ describe("VtxoManager - renewal output split", () => {
         ]);
     });
 
+    // Both diagnostics count against `capacity`, so under a split they have to
+    // name it — an operator sent to the per-output ceiling would be diagnosing
+    // against a number nothing was compared to.
+    it("names the combined split capacity, not the per-output ceiling", async () => {
+        const wallet = createMockWallet([expiring(22_000)], ADDRESS, { vtxoMaxAmount: 5000n });
+        const manager = new VtxoManager(wallet, undefined, {});
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        try {
+            await expect(
+                manager.renewVtxos(undefined, { split: fixedSplit(4, [22_000n]) }),
+            ).rejects.toThrow("within the combined split capacity 20000 (4 x 5000)");
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining("exceed the combined split capacity 20000 (4 x 5000)"),
+            );
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
     describe("refuses a plan the server would reject", () => {
         const renewWith = (split: RenewalSplit, options: MockWalletOptions = {}) => {
             const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, options);

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -10,6 +10,8 @@ import {
     MAX_VTXOS_PER_SETTLEMENT,
     capSettlementBatch,
     SettlementConfig,
+    RenewalSplit,
+    RenewalSplitContext,
 } from "../src/wallet/vtxo-manager";
 import { IWallet, ExtendedCoin, ExtendedVirtualCoin } from "../src/wallet";
 import type { IntentFeeConfig } from "../src/arkfee";
@@ -4220,6 +4222,173 @@ describe("VtxoManager - intent fee pricing", () => {
             await expect(manager.recoverVtxos()).rejects.toThrow(
                 "Recoverable amount 600 net of intent fees is below dust threshold 1000",
             );
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe("VtxoManager - renewal output split", () => {
+    const ADDRESS =
+        "tark1qpt0syx7j0jspe69kldtljet0x9jz6ns4xw70m0w0xl30yfhn0mzmxz6yz8rduexx9sv73mqth7ecy8rtzcgm498kad3avmhyhmy097ew6h83g";
+
+    const expiring = (value: number, txid = `expiring-${value}`): ExtendedVirtualCoin => {
+        const now = Date.now();
+        return {
+            txid,
+            vout: 0,
+            value,
+            createdAt: new Date(now - 100_000),
+            virtualStatus: { state: "settled", batchExpiry: now + 5000 },
+            status: { confirmed: true },
+            isUnrolled: false,
+            isSpent: false,
+        } as any;
+    };
+
+    const settled = (wallet: IWallet) => (wallet.settle as any).mock.calls[0][0];
+
+    const fixedSplit = (
+        maxOutputs: number,
+        amounts: bigint[],
+    ): RenewalSplit & { seen: RenewalSplitContext[] } => {
+        const seen: RenewalSplitContext[] = [];
+        return {
+            maxOutputs,
+            seen,
+            plan(context) {
+                seen.push(context);
+                return amounts;
+            },
+        };
+    };
+
+    it("settles into every piece the plan asks for", async () => {
+        const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS);
+        const manager = new VtxoManager(wallet, undefined, {});
+
+        await manager.renewVtxos(undefined, { split: fixedSplit(4, [5000n, 3000n]) });
+
+        expect(settled(wallet).outputs).toEqual([
+            { address: ADDRESS, amount: 5000n },
+            { address: ADDRESS, amount: 3000n },
+        ]);
+    });
+
+    it("still settles into exactly one output when no split is given", async () => {
+        const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS);
+        const manager = new VtxoManager(wallet, undefined, {});
+
+        await manager.renewVtxos();
+
+        expect(settled(wallet).outputs).toEqual([{ address: ADDRESS, amount: 8000n }]);
+    });
+
+    it("offers the plan the subtotal net of each input's own intent fee", async () => {
+        const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, {
+            intentFee: { offchainInput: "amount * 0.01" },
+        });
+        const split = fixedSplit(4, [7000n]);
+
+        await new VtxoManager(wallet, undefined, {}).renewVtxos(undefined, { split });
+
+        expect(split.seen[0].subtotal).toBe(7920n);
+        expect(split.seen[0].address).toBe(ADDRESS);
+    });
+
+    // `gross - n * fee` is wrong for a proportional policy; one evaluation at the subtotal is wrong for all but one piece.
+    it("prices each piece's output fee at that piece's own size", async () => {
+        const wallet = createMockWallet([expiring(500_000)], ADDRESS, {
+            intentFee: { offchainOutput: "amount * 0.01" },
+        });
+        const split = fixedSplit(4, [100_000n, 50_000n]);
+
+        await new VtxoManager(wallet, undefined, {}).renewVtxos(undefined, { split });
+
+        const { outputFeeOn } = split.seen[0];
+        expect(outputFeeOn(100_000n)).toBe(1000n);
+        expect(outputFeeOn(50_000n)).toBe(500n);
+    });
+
+    it("tells the plan the server's per-output ceiling and dust floor", async () => {
+        const wallet = createMockWallet([expiring(5000)], ADDRESS, { vtxoMaxAmount: 4000n });
+        const split = fixedSplit(4, [3000n, 2000n]);
+
+        await new VtxoManager(wallet, undefined, {}).renewVtxos(undefined, { split });
+
+        expect(split.seen[0].maxAmount).toBe(4000n);
+        expect(split.seen[0].dust).toBe(1000n);
+    });
+
+    // The ceiling bounds one OUTPUT; judged against a single one, every pass caps at one ceiling's worth.
+    it("admits a batch worth several ceilings once a split can place it", async () => {
+        const withoutSplit = createMockWallet([expiring(4000, "a"), expiring(4000, "b")], ADDRESS, {
+            vtxoMaxAmount: 5000n,
+        });
+        await new VtxoManager(withoutSplit, undefined, {}).renewVtxos();
+        expect(settled(withoutSplit).inputs.map((v: ExtendedVirtualCoin) => v.txid)).toEqual(["a"]);
+
+        const withSplit = createMockWallet([expiring(4000, "a"), expiring(4000, "b")], ADDRESS, {
+            vtxoMaxAmount: 5000n,
+        });
+        await new VtxoManager(withSplit, undefined, {}).renewVtxos(undefined, {
+            split: fixedSplit(4, [4000n, 4000n]),
+        });
+        expect(settled(withSplit).inputs.map((v: ExtendedVirtualCoin) => v.txid)).toEqual([
+            "a",
+            "b",
+        ]);
+    });
+
+    describe("refuses a plan the server would reject", () => {
+        const renewWith = (split: RenewalSplit, options: MockWalletOptions = {}) => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS, options);
+            const manager = new VtxoManager(wallet, undefined, {});
+            return { wallet, run: () => manager.renewVtxos(undefined, { split }) };
+        };
+
+        it("when the pieces plus their fees claim more than the subtotal", async () => {
+            const { wallet, run } = renewWith(fixedSplit(4, [8000n]), {
+                intentFee: { offchainOutput: "250.0" },
+            });
+
+            await expect(run()).rejects.toThrow("claims 8250 with fees, more than the 8000");
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+
+        it("when a piece is over the per-output ceiling", async () => {
+            const { wallet, run } = renewWith(fixedSplit(4, [6000n, 2000n]), {
+                vtxoMaxAmount: 5000n,
+            });
+
+            await expect(run()).rejects.toThrow("output 6000 exceeds the per-output limit 5000");
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+
+        it("when a piece is below dust", async () => {
+            const { wallet, run } = renewWith(fixedSplit(4, [7000n, 500n]));
+
+            await expect(run()).rejects.toThrow("Total amount 500 is below dust threshold 1000");
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+
+        it("when it emits more pieces than it allows", async () => {
+            const { wallet, run } = renewWith(fixedSplit(2, [3000n, 3000n, 1000n]));
+
+            await expect(run()).rejects.toThrow("produced 3 outputs, more than the 2 it allows");
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+
+        it("when it emits nothing at all", async () => {
+            const { wallet, run } = renewWith(fixedSplit(4, []));
+
+            await expect(run()).rejects.toThrow("produced no outputs for a subtotal of 8000");
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+
+        it("when maxOutputs is not a positive integer", async () => {
+            const { wallet, run } = renewWith(fixedSplit(0, [8000n]));
+
+            await expect(run()).rejects.toThrow(TypeError);
             expect(wallet.settle).not.toHaveBeenCalled();
         });
     });

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -4439,6 +4439,29 @@ describe("VtxoManager - renewal output split", () => {
             expect(settled(wallet).outputs).toEqual([{ address: ADDRESS, amount: 8000n }]);
         });
 
+        /**
+         * A single piece cannot exceed the ceiling, so admitting several ceilings'
+         * worth would leave an asset-bearing batch with NO valid plan: split and
+         * the asset guard refuses, don't and the ceiling guard does. The batch
+         * takes the unsplit path's cap instead, deferring the overflow.
+         */
+        it("caps an asset-bearing batch to one ceiling so a single piece still fits", async () => {
+            const wallet = createMockWallet([withAssets(4000, "a"), expiring(4000, "b")], ADDRESS, {
+                vtxoMaxAmount: 5000n,
+            });
+            const split: RenewalSplit = {
+                maxOutputs: 4,
+                plan: ({ subtotal, hasAssets }) =>
+                    hasAssets ? [subtotal] : [subtotal / 2n, subtotal / 2n],
+            };
+
+            await new VtxoManager(wallet, undefined, {}).renewVtxos(undefined, { split });
+
+            const args = settled(wallet);
+            expect(args.inputs.map((v: ExtendedVirtualCoin) => v.txid)).toEqual(["a"]);
+            expect(args.outputs).toEqual([{ address: ADDRESS, amount: 4000n }]);
+        });
+
         it("lets the plan split again once no asset-bearing input survives selection", async () => {
             // The 1500 carries the assets and cannot pay its own 2000 fee.
             const wallet = createMockWallet([expiring(5000), withAssets(1500)], ADDRESS, {

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -4393,8 +4393,8 @@ describe("VtxoManager - renewal output split", () => {
         });
     });
 
-    // `Wallet.settle` bags every input asset onto the FIRST matching output, and
-    // every piece is on that script — so a split hands them all to piece 0.
+    // settle bags every input asset onto the FIRST matching output, and every
+    // piece is on that script — so a split hands them all to piece 0.
     describe("assets", () => {
         const withAssets = (value: number, txid = `asset-${value}`): ExtendedVirtualCoin =>
             ({ ...expiring(value, txid), assets: [{ assetId: "aa", amount: 5n }] }) as any;
@@ -4427,8 +4427,7 @@ describe("VtxoManager - renewal output split", () => {
             expect(wallet.settle).not.toHaveBeenCalled();
         });
 
-        // Refusing the SPLIT, not the renewal: an unrenewed float expires, which is
-        // worse than one fat coin carrying the assets unambiguously.
+        // An unrenewed float expires, which is worse than one fat coin.
         it("still renews an asset-bearing float into one piece", async () => {
             const wallet = createMockWallet([withAssets(5000), expiring(3000)], ADDRESS);
 
@@ -4439,12 +4438,8 @@ describe("VtxoManager - renewal output split", () => {
             expect(settled(wallet).outputs).toEqual([{ address: ADDRESS, amount: 8000n }]);
         });
 
-        /**
-         * A single piece cannot exceed the ceiling, so admitting several ceilings'
-         * worth would leave an asset-bearing batch with NO valid plan: split and
-         * the asset guard refuses, don't and the ceiling guard does. The batch
-         * takes the unsplit path's cap instead, deferring the overflow.
-         */
+        // Admitting several ceilings' worth would leave an asset-bearing batch no
+        // valid plan: split and the asset guard refuses, don't and the ceiling does.
         it("caps an asset-bearing batch to one ceiling so a single piece still fits", async () => {
             const wallet = createMockWallet([withAssets(4000, "a"), expiring(4000, "b")], ADDRESS, {
                 vtxoMaxAmount: 5000n,

--- a/packages/ts-sdk/test/vtxo-manager.test.ts
+++ b/packages/ts-sdk/test/vtxo-manager.test.ts
@@ -4392,4 +4392,64 @@ describe("VtxoManager - renewal output split", () => {
             expect(wallet.settle).not.toHaveBeenCalled();
         });
     });
+
+    // `Wallet.settle` bags every input asset onto the FIRST matching output, and
+    // every piece is on that script — so a split hands them all to piece 0.
+    describe("assets", () => {
+        const withAssets = (value: number, txid = `asset-${value}`): ExtendedVirtualCoin =>
+            ({ ...expiring(value, txid), assets: [{ assetId: "aa", amount: 5n }] }) as any;
+
+        it("reports no assets when none of the selected inputs carry any", async () => {
+            const wallet = createMockWallet([expiring(5000), expiring(3000)], ADDRESS);
+            const split = fixedSplit(4, [5000n, 3000n]);
+
+            await new VtxoManager(wallet, undefined, {}).renewVtxos(undefined, { split });
+
+            expect(split.seen[0].hasAssets).toBe(false);
+        });
+
+        it("reports assets when any selected input carries them", async () => {
+            const wallet = createMockWallet([withAssets(5000), expiring(3000)], ADDRESS);
+            const split = fixedSplit(4, [8000n]);
+
+            await new VtxoManager(wallet, undefined, {}).renewVtxos(undefined, { split });
+
+            expect(split.seen[0].hasAssets).toBe(true);
+        });
+
+        it("refuses a multi-piece plan over asset-bearing inputs", async () => {
+            const wallet = createMockWallet([withAssets(5000), expiring(3000)], ADDRESS);
+            const manager = new VtxoManager(wallet, undefined, {});
+
+            await expect(
+                manager.renewVtxos(undefined, { split: fixedSplit(4, [5000n, 3000n]) }),
+            ).rejects.toThrow("they would all land on piece 0");
+            expect(wallet.settle).not.toHaveBeenCalled();
+        });
+
+        // Refusing the SPLIT, not the renewal: an unrenewed float expires, which is
+        // worse than one fat coin carrying the assets unambiguously.
+        it("still renews an asset-bearing float into one piece", async () => {
+            const wallet = createMockWallet([withAssets(5000), expiring(3000)], ADDRESS);
+
+            await new VtxoManager(wallet, undefined, {}).renewVtxos(undefined, {
+                split: fixedSplit(4, [8000n]),
+            });
+
+            expect(settled(wallet).outputs).toEqual([{ address: ADDRESS, amount: 8000n }]);
+        });
+
+        it("lets the plan split again once no asset-bearing input survives selection", async () => {
+            // The 1500 carries the assets and cannot pay its own 2000 fee.
+            const wallet = createMockWallet([expiring(5000), withAssets(1500)], ADDRESS, {
+                intentFee: { offchainInput: "2000.0" },
+            });
+            const split = fixedSplit(4, [2000n, 1000n]);
+
+            await new VtxoManager(wallet, undefined, {}).renewVtxos(undefined, { split });
+
+            expect(split.seen[0].hasAssets).toBe(false);
+            expect(settled(wallet).outputs).toHaveLength(2);
+        });
+    });
 });


### PR DESCRIPTION
## The gap this closes

A renewal has always asked for exactly **one** output. So a wallet that renews its balance gets it back as a single coin — and spending one coin pins the whole balance, which serialises anything that funds more than one thing at a time. Splitting afterwards is not equivalent: it costs a second intent fee and leaves a window where the whole balance sits on one coin.

`Wallet.settle` has always taken an *array* of outputs. What was missing is a way to reach it without also reimplementing the pricing:

- **`Wallet.settle(params)` does no fee arithmetic at all** once `params` are supplied. All of it lives in the `if (!params)` branch (`wallet.ts:3932-4042`); with params, control goes straight to output construction at `wallet.ts:4044`.
- **The three helpers that get it right are module-private and unexported** — `priceSettlementInputs`, `subtotalOf`, `deductOffchainOutputFee` (`vtxo-manager.ts:335/361/392`). They are absent from `index.ts`, so an external caller literally cannot reuse them.
- The one correctly-priced multi-input path, no-arg `Wallet.settle()`, hard-codes a single output to the wallet's own address and sweeps everything.

Net: a caller who wants to renew into a chosen shape today has to re-derive the operator's intent-fee arithmetic from scratch. Getting it wrong in the cheap direction means `INTENT_INSUFFICIENT_FEE` and a float that never renews; getting it wrong in the other direction silently overpays out of user funds.

## What this adds

`RenewVtxosOptions.split?: RenewalSplit`. The SDK hands the caller the **already-priced** subtotal, an output-fee oracle, the per-output ceiling and the dust floor, and takes back piece amounts:

```ts
await manager.renewVtxos(undefined, {
    split: {
        maxOutputs: 8,
        plan: ({ subtotal, outputFeeOn, maxAmount, dust, address }) => [ /* amounts */ ],
    },
});
```

Selection, pricing, capping and validation stay in the SDK. Only the *shape* is the caller's, because the shape is a policy the wallet cannot know.

**Plans are refused, not corrected.** Over budget, over the ceiling, more pieces than `maxOutputs`, or none at all — each throws. Quietly reshaping a bad plan would renew the float into a shape nobody asked for, which is the worst way for a caller's bug to surface. Under-claiming *is* allowed: it only leaves a residue as extra fee, the direction `deductOffchainOutputFee` already deliberately errs in.

**The batch cap had to move with it.** `vtxoMaxAmount` bounds one *output*, so judging the whole batch against a single one capped every renewal at one ceiling's worth however many pieces it emitted:

```ts
const capacity =
    vtxoMaxAmount < 0n || !options?.split
        ? vtxoMaxAmount
        : BigInt(options.split.maxOutputs) * vtxoMaxAmount;
```

Raised by the output count alone and deliberately *not* by the output fee too: the cap weighs **gross** input value while the pieces are paid from the **post-fee** subtotal, so this stays strictly under what they can absorb and defers the remainder to the next cycle.

## A hazard found and closed on the way

`RenewVtxosOptions` crosses the service-worker MessageBus — `serviceWorker/wallet.ts` posts `payload: options` straight through. **A `plan` callback is not structured-cloneable**, so passing `split` there would have died as an opaque `DataCloneError` thrown from inside `postMessage`, with nothing naming the actual constraint. It is now refused by name at that boundary, with a test asserting no `RENEW_VTXOS` message is posted.

This is why `split` is a callback rather than a data description, and why it is honestly unavailable on the service-worker wallet: the plan depends on a budget that is not known until the SDK has priced and capped the inputs, so it cannot be precomputed and shipped as data.

## Assets

Renewal selects through `getSpendableVtxos`, which applies **no asset filter**, so an asset-bearing VTXO can be renewed. `Wallet.settle` does not burn those assets — it bags every input asset and assigns the whole lot to the **first** output whose script matches the destination (`findDestinationOutputIndex` is a plain `findIndex`, `delegate.ts:478`).

With **one** output that is total and unambiguous, and it is what the unsplit path has always done — this PR does not introduce asset handling. With a **split** it is not: every piece lands on the same wallet address, so the entire holding goes to **piece 0** while the caller believes it received interchangeable pieces. A pool built that way has one contaminated piece and no way to know which — and in a consumer that sizes pieces as funding rungs, piece 0 is typically the largest one.

So `RenewalSplitContext` reports `hasAssets`, and **a plan that returns more than one piece while it is set is refused**.

**Refusing the SPLIT rather than the renewal is deliberate, and I would push back on refusing outright.** Renewal is what stops a float expiring. Blocking it whenever the wallet holds an asset would leave that float drifting to batch expiry and into `recoverable`, which is strictly worse than one fat coin — and asset-bearing floats are a real, occurring state, not a hypothetical. A single piece is exactly what the unsplit path already produces and carries the assets unambiguously, so a caller reading `hasAssets` has a correct path that keeps renewing, while one that ignores it fails closed instead of silently poisoning a pool.

`hasAssets` is read off the *final* selection, after pricing and capping, so a cap that drops the only asset-bearing input frees the plan to split again.

**The batch cap moves with the guard, or the guard strands the float.** Refusing a multi-piece split while still admitting `maxOutputs` ceilings' worth leaves an asset-bearing batch with no valid plan at all under any operator that sets a per-output ceiling: split it and the asset guard refuses, return the single piece the guard demands and it exceeds `vtxoMaxAmount`, so the ceiling guard refuses instead — renewal fails every pass and the float expires. An asset-bearing batch therefore takes the unsplit path's cap, deferring the overflow to the next cycle like every other cap here. Judged *before* `capSettlementBatch`, so it cannot admit a batch it then strands; the two reads can only disagree in the safe direction. Caught by writing the test first, which failed with `Renewal split output 8000 exceeds the per-output limit 5000`.

This mirrors the existing `has-assets` idiom (`wallet.ts:5272-5276`), which refuses asset-bearing VTXOs from the BTC-only cash sweep *"up front rather than left to a server rejection"*.

Confirmed by reading, not executed: no test harness exists anywhere in this repo for `Wallet.settle`'s asset routing, so the piece-0 consolidation is established from straight-line code (`wallet.ts:4078-4122`) rather than observed. The guard itself is tested and mutation-verified.

## Compatibility

**Omitted, the default path is byte-identical** — same single output, same `deductOffchainOutputFee`, same dust message. `deductOffchainOutputFee` is now a one-line wrapper over a new `offchainOutputFee`, which is the same arithmetic factored so the split can price each piece at its own size (a proportional policy makes `gross - n * fee` and a single evaluation at the subtotal both wrong).

## Testing

`packages/ts-sdk/test/vtxo-manager.test.ts` — 12 new cases: the pieces actually settled, the subtotal offered net of input fees, per-piece output-fee pricing, the ceiling/dust context, the raised batch admission, and one refusal per rejection reason. Plus 1 in `test/serviceWorker/wallet.test.ts` for the MessageBus guard.

Plus 6 asset cases: the flag reported both ways, the multi-piece refusal, an asset-bearing float still renewing into one piece, and the flag clearing when a cap drops the only asset-bearing input.

**11 of the 12 original split tests were confirmed failing with the source change stashed**, and both halves of the asset guard are mutation-verified: disabling the refusal fails 1 test, hardcoding `hasAssets: false` fails 2. The twelfth is the deliberate regression guard that the no-`split` path still emits exactly one output, so it passes either way by design.

Gate on this branch's base (`102ff3b4`): **179 files / 2997 passed + 1 skipped, no type errors**. On the branch: **179 files / 3016 passed + 1 skipped, no type errors** — +19, exactly the tests added. Rebased onto `102ff3b4` (#857) with no conflicts; #857's `vtxo-manager.ts` changes are in the contract-event subscription, not in the renewal path.

## Not covered

No regtest run — this is exercised by unit tests only. The arithmetic is the same as `runPeriodicSettle`'s and the existing intent-fee tests, but a multi-output renewal has not been observed being accepted by a live arkd.

Downstream consumer, and the change that motivated this: arkade-os/intent-solver#78


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Renewal transactions can be split into multiple outputs using configurable plans.
  - Added public SDK types for configuring renewal splits and accessing planning details.
  - Existing renewals continue to produce a single output by default.

- **Bug Fixes**
  - Split renewals now account for output limits, fees, dust thresholds, and invalid configurations.
  - Renewals involving assets remain restricted to a single output.

- **Known Limitations**
  - Renewal splitting is not supported through the service-worker wallet interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


