### PR TITLE
feat(swap): keep the preimage that settled a lightning send

### DIFF
--- a/packages/swap/src/client/driveRecords.ts
+++ b/packages/swap/src/client/driveRecords.ts
@@ -70,6 +70,9 @@ export const rfqRecordOf = (record: CorridorSwapRecord): RfqSwapRecord => ({
     updatedAt: record.updatedAt,
     ...(record.refundTxid === undefined ? {} : { refundTxid: record.refundTxid }),
     ...(record.lockupSpendTxids?.length ? { lockupSpendTxids: [...record.lockupSpendTxids] } : {}),
+    ...(record.settlementPreimageHex === undefined
+        ? {}
+        : { settlementPreimageHex: record.settlementPreimageHex }),
     ...(record.failure === undefined ? {} : { failure: record.failure }),
     ...(record.claimFailure === undefined ? {} : { claimFailure: record.claimFailure }),
     ...(record.blockedReason === undefined ? {} : { blockedReason: record.blockedReason }),
@@ -92,6 +95,7 @@ export const withRfqState = (
     const {
         refundTxid: _refundTxid,
         lockupSpendTxids: _lockupSpendTxids,
+        settlementPreimageHex: _settlementPreimageHex,
         failure: _failure,
         claimFailure: _claimFailure,
         blockedReason: _blockedReason,
@@ -106,6 +110,9 @@ export const withRfqState = (
         ...(state.lockupSpendTxids?.length
             ? { lockupSpendTxids: [...state.lockupSpendTxids] }
             : {}),
+        ...(state.settlementPreimageHex === undefined
+            ? {}
+            : { settlementPreimageHex: state.settlementPreimageHex }),
         ...(state.failure === undefined ? {} : { failure: state.failure }),
         ...(state.claimFailure === undefined ? {} : { claimFailure: state.claimFailure }),
         ...(state.blockedReason === undefined ? {} : { blockedReason: state.blockedReason }),

--- a/packages/swap/src/client/record.ts
+++ b/packages/swap/src/client/record.ts
@@ -301,6 +301,17 @@ export interface CorridorSwapRecord extends SwapRecordCommon {
     readonly profile: Record<string, unknown>;
     readonly refundTxid?: string;
     readonly lockupSpendTxids?: readonly string[];
+    /**
+     * `P`, hex — the preimage the solver revealed to settle a Lightning send.
+     *
+     * The exception the doctrine above allows for, and only on that leg: the
+     * payee mints `P`, so {@link profile}'s hashlock carries the payment hash
+     * and no claim-secret material. This is the counterparty's revealed
+     * settlement proof, not a second copy of the wallet's own claim secret —
+     * and public by the time it is written, being read out of the witness that
+     * spent the lockup.
+     */
+    readonly settlementPreimageHex?: string;
 }
 
 /** Everything `accept()` persists, both families in one key space. */

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -160,6 +160,9 @@ export interface RfqSwapRecord extends RfqSwapOrigin {
      * the chain read that ended the swap. See
      * `RfqSwapCommon.lockupSpendTxids`. */
     lockupSpendTxids?: string[];
+    /** The preimage that settled a Lightning send, stamped by the manager from
+     * the same chain read. See `RfqSwapCommon.settlementPreimageHex`. */
+    settlementPreimageHex?: string;
     failure?: string;
     /** Last local receive-claim error while the swap is still retryable. */
     claimFailure?: string;
@@ -247,6 +250,7 @@ const managerState = (swap: PersistableRfqSwap) => ({
     updatedAt: swap.updatedAt,
     ...(swap.refundTxid ? { refundTxid: swap.refundTxid } : {}),
     ...(swap.lockupSpendTxids?.length ? { lockupSpendTxids: [...swap.lockupSpendTxids] } : {}),
+    ...(swap.settlementPreimageHex ? { settlementPreimageHex: swap.settlementPreimageHex } : {}),
     ...(swap.failure ? { failure: swap.failure } : {}),
     ...(swap.claimFailure ? { claimFailure: swap.claimFailure } : {}),
     ...(swap.blockedReason ? { blockedReason: swap.blockedReason } : {}),
@@ -332,6 +336,7 @@ export function updateRfqSwapRecord(
     const {
         refundTxid: _refundTxid,
         lockupSpendTxids: _lockupSpendTxids,
+        settlementPreimageHex: _settlementPreimageHex,
         failure: _failure,
         claimFailure: _claimFailure,
         blockedReason: _blockedReason,
@@ -429,6 +434,9 @@ export function rebuildRfqSwap(record: RfqSwapRecord, params: LockupParams): Per
         ...(stored.refundTxid ? { refundTxid: stored.refundTxid } : {}),
         ...(stored.lockupSpendTxids?.length
             ? { lockupSpendTxids: [...stored.lockupSpendTxids] }
+            : {}),
+        ...(stored.settlementPreimageHex
+            ? { settlementPreimageHex: stored.settlementPreimageHex }
             : {}),
         ...(stored.failure ? { failure: stored.failure } : {}),
         ...(stored.claimFailure ? { claimFailure: stored.claimFailure } : {}),

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -210,6 +210,22 @@ interface RfqSwapCommon {
      * `LockupSpend` declares optional, for the same reason.
      */
     lockupSpendTxids?: string[];
+    /**
+     * `P`, hex — the preimage the solver revealed to claim the lockup,
+     * stamped from the chain read that ended the swap.
+     *
+     * Lightning sends only, and the one leg where the wallet cannot produce
+     * `P` itself: the payee mints it, so the quote carries only
+     * {@link paymentHash}. The claiming legs keep their own secret in
+     * `profile`, where `preimageForSwapRecord` recovers it — so this is a
+     * settlement receipt, not a second home for a claim secret, and not a
+     * secret at all: it is already public in the witness it came from.
+     * `readLockupFate` hashes it against {@link paymentHash} before returning
+     * it, so what is stamped here is verified by construction.
+     *
+     * Absent on the other legs, and on a send that did not settle.
+     */
+    settlementPreimageHex?: string;
     /** Why `state` is `failed`. */
     failure?: string;
     /**
@@ -1549,6 +1565,7 @@ export class RfqSwapManager {
             // makes dirty carries the spend with it — one write, not two, and
             // no window in which a terminal record names no ending transaction.
             this.stampLockupSpends(swap, fate.spends);
+            if (fate.fate === "claimed") this.stampSettlementPreimage(swap, fate.preimage);
             this.setState(swap, fate.fate === "claimed" ? "settled" : "refunded");
             return;
         }
@@ -2054,6 +2071,20 @@ export class RfqSwapManager {
             .filter((txid): txid is string => txid !== undefined);
         if (txids.length === 0) return;
         swap.lockupSpendTxids = txids;
+        this.touch(swap);
+    }
+
+    /**
+     * Keep the preimage that settled a Lightning send.
+     *
+     * Only that leg. A receive's `claimed` verdict reveals the wallet's own
+     * claim secret and an onchain send's reveals the one it minted — both
+     * already recoverable from `profile`, so stamping either would be a second
+     * home for a secret that has one.
+     */
+    private stampSettlementPreimage(swap: RfqSwap, preimage: Uint8Array): void {
+        if (swap.kind !== "lightning_send") return;
+        swap.settlementPreimageHex = hex.encode(preimage);
         this.touch(swap);
     }
 

--- a/packages/swap/test/client/drive.test.ts
+++ b/packages/swap/test/client/drive.test.ts
@@ -8,8 +8,14 @@
  * assumes that read works.
  */
 import { describe, expect, it, vi } from "vitest";
-import { hex } from "@scure/base";
-import { SingleKey } from "@arkade-os/sdk";
+import { base64, hex } from "@scure/base";
+import {
+    CSVMultisigTapscript,
+    ConditionWitness,
+    SingleKey,
+    buildOffchainTx,
+    setArkPsbtField,
+} from "@arkade-os/sdk";
 import { createSwapDrive, SwapDriveRefusedError, type SwapDrive } from "../../src/client/drive";
 import type { SwapUpdate } from "../../src/client/outcome";
 import {
@@ -26,6 +32,10 @@ import {
     AFTER,
     BEFORE,
     OFFER_SCRIPT,
+    OPERATOR,
+    PAYMENT_HASH,
+    PAYOUT,
+    PREIMAGE,
     RECEIVE_LOCKUP,
     REFUND_LOCKTIME,
     SEND_LOCKUP,
@@ -62,12 +72,48 @@ const signable = (over: Partial<CorridorSwapRecord> = {}): CorridorSwapRecord =>
         ...over,
     });
 
+/** `signable`, but committed to the hash the claim fixture below answers:
+ * `signable` defaults `paymentHash` to zeros, which no witness can hash to. */
+const settleable = (over: Partial<CorridorSwapRecord> = {}): CorridorSwapRecord =>
+    signable({
+        profile: {
+            signer: { signingDescriptor: SENDER_DESCRIPTOR },
+            hashlock: { paymentHash: PAYMENT_HASH },
+        },
+        ...over,
+    });
+
 const LOCKUP_OUTPOINT = { txid: "99".repeat(32), vout: 0 };
 /** An unspent output at the lockup — the shape `readLockupFate` reads as `open`. */
 const unspent = (): FakeVtxo[] => [{ ...LOCKUP_OUTPOINT, spentBy: "" }];
 const funded = (over: Partial<FakeFunded> = {}): FakeFunded[] => [
     { ...LOCKUP_OUTPOINT, value: 100_000, ...over },
 ];
+
+/** The solver's claim of the send lockup, with the preimage attached the way a
+ * condition closure is finalized — Ark's `ConditionWitness` PSBT field.
+ * `buildOffchainTx` emits one checkpoint per input, and that checkpoint is the
+ * transaction the indexer names in `spentBy`, so it is the one handed back. */
+const claimSpend = (): { txid: string; psbt: string } => {
+    const { checkpoints } = buildOffchainTx(
+        [
+            {
+                ...LOCKUP_OUTPOINT,
+                value: 100_000,
+                tapLeafScript: SEND_LOCKUP.claim(),
+                tapTree: SEND_LOCKUP.encode(),
+            },
+        ],
+        [{ script: PAYOUT, amount: BigInt(100_000) }],
+        CSVMultisigTapscript.encode({
+            timelock: { type: "blocks", value: BigInt(144) },
+            pubkeys: [OPERATOR],
+        }),
+    );
+    const checkpoint = checkpoints[0];
+    setArkPsbtField(checkpoint, 0, ConditionWitness, [PREIMAGE]);
+    return { txid: checkpoint.id, psbt: base64.encode(checkpoint.toPSBT()) };
+};
 
 interface Harness {
     readonly drive: SwapDrive;
@@ -88,6 +134,7 @@ const build = async (
         now?: number;
         vtxos?: FakeVtxo[];
         funded?: FakeFunded[];
+        txs?: { txid: string; psbt: string }[];
         indexerFails?: boolean;
         identity?: unknown;
         chain?: unknown | null;
@@ -122,6 +169,7 @@ const build = async (
         indexer: fakeIndexer({
             ...(over.vtxos === undefined ? {} : { vtxos: over.vtxos }),
             ...(over.funded === undefined ? {} : { funded: over.funded }),
+            ...(over.txs === undefined ? {} : { txs: over.txs }),
             ...(over.indexerFails ? { fail: true } : {}),
         }),
         contracts,
@@ -834,5 +882,69 @@ describe("the drive's own record write", () => {
         expect(stored.refundLocktime).toBe(REFUND_LOCKTIME);
         expect(stored.lockupPkScript).toBe(hex.encode(SEND_LOCKUP.pkScript));
         await h.drive.dispose();
+    });
+});
+
+describe("the settlement receipt", () => {
+    it("stamps the preimage that settled a send onto the stored record", async () => {
+        // Driven, not seeded: the receipt is learned from the witness the fate
+        // read verifies, and only the real pass exercises the path from that
+        // verdict through `save` to the repository.
+        const spend = claimSpend();
+        const h = await build({
+            records: [settleable({ fundingTxid: "aa".repeat(32) })],
+            vtxos: [{ ...LOCKUP_OUTPOINT, spentBy: spend.txid }],
+            txs: [spend],
+        });
+
+        const stored = (await h.repository.getSwapRecord("q1")) as CorridorSwapRecord;
+        expect(stored.state).toBe("settled");
+        expect(stored.settlementPreimageHex).toBe(hex.encode(PREIMAGE));
+        await h.drive.dispose();
+    });
+
+    it("answers a restarted client's receipt off storage, reading no indexer", async () => {
+        const spend = claimSpend();
+        const first = await build({
+            records: [settleable({ fundingTxid: "aa".repeat(32) })],
+            vtxos: [{ ...LOCKUP_OUTPOINT, spentBy: spend.txid }],
+            txs: [spend],
+        });
+        const settled = (await first.repository.getSwapRecord("q1")) as CorridorSwapRecord;
+        await first.drive.dispose();
+
+        // Through JSON, so no object the first drive still holds can be what
+        // the second one reads the receipt off.
+        const repository = memoryRepository();
+        await repository.saveSwapRecord(JSON.parse(JSON.stringify(settled)) as CorridorSwapRecord);
+        const contracts = fakeContracts([SEND_LOCKUP]);
+        const { wallet } = fakeWallet({ contracts, identity: SENDER });
+        const unreachable = () => {
+            throw new Error("the restart read the indexer");
+        };
+        const getVtxos = vi.fn(unreachable);
+        const getVirtualTxs = vi.fn(unreachable);
+        const drive = createSwapDrive({
+            wallet,
+            operator: fakeOperator(),
+            repository,
+            corridors: fakeCorridors(),
+            indexer: { getVtxos, getVirtualTxs } as never,
+            contracts,
+            now: () => BEFORE,
+            pollIntervalMs: 10 * 60 * 1000,
+        });
+        await drive.ready;
+        await drive.idle();
+
+        const restored = (await repository.getSwapRecord("q1")) as CorridorSwapRecord;
+        expect(restored.settlementPreimageHex).toBe(hex.encode(PREIMAGE));
+        expect(drive.swap("q1")?.outcome).toBe("paid");
+        // The whole point of storing it: a settled swap needs no network at
+        // all, so a restart neither re-reads the lockup nor re-fetches the
+        // witness to hand back the proof.
+        expect(getVtxos).not.toHaveBeenCalled();
+        expect(getVirtualTxs).not.toHaveBeenCalled();
+        await drive.dispose();
     });
 });

--- a/packages/swap/test/client/driveRecords.test.ts
+++ b/packages/swap/test/client/driveRecords.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The two-way record bridge: the v2 record projected down to the manager's, and
+ * the manager's mutable half written back onto it.
+ *
+ * Both directions are total — a field missing from either projection is not a
+ * gap, it is a loss. `withRfqState` REPLACES the mutable half rather than
+ * merging it, so a field the manager no longer carries has to leave the record;
+ * and a field `rfqRecordOf` fails to hand down comes back absent from the
+ * manager's next save and is erased from disk on the write-back. The tests here
+ * pin both halves of that rule against the receipt fields, whose whole value is
+ * that they survive a restart.
+ */
+import { describe, expect, it } from "vitest";
+import { hex } from "@scure/base";
+import { rfqRecordOf, withRfqState } from "../../src/client/driveRecords";
+import type { RfqSwapRecord } from "../../src/rfqRecord";
+import type { CorridorSwapRecord } from "../../src/client/record";
+import { PREIMAGE, corridorRecord } from "./driveFixtures";
+
+/** What the solver revealed in the witness that claimed the send lockup. */
+const RECEIPT = hex.encode(PREIMAGE);
+const SPEND = "ab".repeat(32);
+
+/** The manager's record for a settled send, as the bridge itself produces it. */
+const settledState = (record: CorridorSwapRecord, over: Partial<RfqSwapRecord> = {}) => ({
+    ...rfqRecordOf(record),
+    state: "settled" as const,
+    updatedAt: 2_000,
+    ...over,
+});
+
+describe("the settlement receipt across the bridge", () => {
+    it("reaches the manager's record and survives the write-back", () => {
+        const record = corridorRecord({ settlementPreimageHex: RECEIPT, state: "settled" });
+        const state = rfqRecordOf(record);
+        expect(state.settlementPreimageHex).toBe(RECEIPT);
+        expect(withRfqState(record, state).settlementPreimageHex).toBe(RECEIPT);
+    });
+
+    it("is absent, not undefined, on a swap that never settled", () => {
+        // The record is asserted JSON-safe, so an explicitly-undefined key is
+        // noise that survives one serialization round trip and not the next.
+        const record = corridorRecord();
+        const state = rfqRecordOf(record);
+        expect("settlementPreimageHex" in state).toBe(false);
+        expect("settlementPreimageHex" in withRfqState(record, state)).toBe(false);
+    });
+});
+
+describe("withRfqState replaces the mutable half", () => {
+    it("clears state the live swap no longer carries", () => {
+        // The trap: leave either field in `origin` instead of stripping it and
+        // the stale value outlives the swap that earned it.
+        const stored = corridorRecord({
+            state: "settled",
+            settlementPreimageHex: RECEIPT,
+            lockupSpendTxids: [SPEND],
+            refundTxid: "cd".repeat(32),
+            blockedReason: "no signer for this descriptor",
+        });
+        const written = withRfqState(stored, {
+            ...rfqRecordOf(stored),
+            settlementPreimageHex: undefined,
+            lockupSpendTxids: undefined,
+            refundTxid: undefined,
+            blockedReason: undefined,
+        });
+        expect("settlementPreimageHex" in written).toBe(false);
+        expect("lockupSpendTxids" in written).toBe(false);
+        expect("refundTxid" in written).toBe(false);
+        expect("blockedReason" in written).toBe(false);
+    });
+
+    it("takes the receipt from the state, not from the record it overwrites", () => {
+        const stored = corridorRecord({ settlementPreimageHex: "00".repeat(32) });
+        const written = withRfqState(
+            stored,
+            settledState(stored, {
+                settlementPreimageHex: RECEIPT,
+            }),
+        );
+        expect(written.settlementPreimageHex).toBe(RECEIPT);
+    });
+
+    it("leaves the accept path's half untouched", () => {
+        // Without this the clearing above reads as arbitrary: `origin` is what
+        // the request produced, and the manager learns none of it — `fundingTxid`
+        // included, which is why a state that omits it does not clear it.
+        const stored = corridorRecord({ fundingTxid: "ef".repeat(32) });
+        const written = withRfqState(stored, settledState(stored, { fundingTxid: undefined }));
+        expect(written.fundingTxid).toBe(stored.fundingTxid);
+        expect(written.kind).toBe(stored.kind);
+        expect(written.lockupAddress).toBe(stored.lockupAddress);
+        expect(written.lockupPkScript).toBe(stored.lockupPkScript);
+        expect(written.route).toEqual(stored.route);
+        expect(written.market).toEqual(stored.market);
+        expect(written.lock).toEqual(stored.lock);
+        expect(written.refundLocktime).toBe(stored.refundLocktime);
+        expect(written.createdAt).toBe(stored.createdAt);
+        // And the mutable half is the state's, not the record's.
+        expect(written.state).toBe("settled");
+        expect(written.updatedAt).toBe(2_000);
+    });
+});

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -509,6 +509,7 @@ describe("rfqSwapOriginOf", () => {
         blockedReason: "no signer for this descriptor",
         refundTxid: "ff".repeat(32),
         lockupSpendTxids: ["ab".repeat(32)],
+        settlementPreimageHex: "11".repeat(32),
     };
 
     it("keeps every request-time fact", () => {
@@ -526,6 +527,7 @@ describe("rfqSwapOriginOf", () => {
         expect(rebuilt.blockedReason).toBeUndefined();
         expect(rebuilt.refundTxid).toBeUndefined();
         expect(rebuilt.lockupSpendTxids).toBeUndefined();
+        expect(rebuilt.settlementPreimageHex).toBeUndefined();
     });
 
     it("gives the profile its own top-level object, so a new key does not reach the record", () => {
@@ -557,6 +559,38 @@ describe("the spend that ended the swap", () => {
             lockupSpendTxids: ["ab".repeat(32)],
         });
         expect(updateRfqSwapRecord(record, swapOf(sendOrigin)).lockupSpendTxids).toBeUndefined();
+    });
+});
+
+describe("the preimage that settled a send", () => {
+    // The one leg whose P the wallet never minted: it is a receipt of the
+    // solver's claim, so the record is the only place it can survive.
+    const PREIMAGE_HEX = "11".repeat(32);
+
+    it("round-trips through the record and back onto the live swap", () => {
+        const swap = { ...swapOf(sendOrigin, "settled"), settlementPreimageHex: PREIMAGE_HEX };
+        const record = createRfqSwapRecord(sendOrigin, swap);
+        expect(record.settlementPreimageHex).toBe(PREIMAGE_HEX);
+        expect(rebuildRfqSwap(record, paramsOf(sendOrigin)).settlementPreimageHex).toBe(
+            PREIMAGE_HEX,
+        );
+    });
+
+    it("stays absent when the swap never carried one", () => {
+        const record = createRfqSwapRecord(sendOrigin, swapOf(sendOrigin, "settled"));
+        expect(record).not.toHaveProperty("settlementPreimageHex");
+        expect(rebuildRfqSwap(record, paramsOf(sendOrigin)).settlementPreimageHex).toBeUndefined();
+    });
+
+    it("is cleared by an update whose swap no longer carries it", () => {
+        // Same replacement rule as the spends: nothing merges the mutable half.
+        const record = createRfqSwapRecord(sendOrigin, {
+            ...swapOf(sendOrigin, "settled"),
+            settlementPreimageHex: PREIMAGE_HEX,
+        });
+        expect(
+            updateRfqSwapRecord(record, swapOf(sendOrigin)).settlementPreimageHex,
+        ).toBeUndefined();
     });
 });
 

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -3364,4 +3364,94 @@ describe("RfqSwapManager — manager-owned persistence", () => {
             expect(result.restored[0].lockupSpendTxids).toEqual([ARK_TXID]);
         });
     });
+
+    describe("stamping the preimage that settled the swap", () => {
+        it("keeps the preimage the solver revealed to claim a lightning send", async () => {
+            const store = fakeStore();
+            const s = spies();
+            const swap = lightningSwap();
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.addSwap(swap, sendOrigin());
+            await m.poll();
+
+            expect(swap.state).toBe("settled");
+            // The one leg whose `P` the wallet never had: the payee minted it,
+            // so the quote carries only the hash and nothing else on the record
+            // can give it back.
+            expect(swap.settlementPreimageHex).toBe(hex.encode(PREIMAGE));
+            expect(store.records.get(RFQ_ID)?.settlementPreimageHex).toBe(hex.encode(PREIMAGE));
+        });
+
+        it("stamps nothing on a receive whose own claim is what the chain read", async () => {
+            // `P` here is the wallet's claim secret, already recoverable from
+            // `profile` — stamping it would be a second home for it.
+            const store = fakeStore();
+            const s = spies();
+            const swap = receiveSwap({ state: "claimed", claimTxid: CLAIM_TXID });
+            const spend = spendOfLockup({ script: RECEIVE_LOCKUP, conditionWitness: [PREIMAGE] });
+            const m = manager({
+                indexer: fakeIndexer({ vtxos: spentBy(spend.txid), txs: [spend] }),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.addSwap(swap, receiveOrigin());
+            await m.poll();
+
+            expect(swap.state).toBe("settled");
+            expect(swap.settlementPreimageHex).toBeUndefined();
+            // the stored record reached the end too, so the absence below is
+            // the stamp declining rather than a row that was never written
+            expect(store.records.get(RFQ_ID)?.state).toBe("settled");
+            expect(store.records.get(RFQ_ID)?.settlementPreimageHex).toBeUndefined();
+        });
+
+        it("stamps nothing on an onchain send, whose P the wallet minted", async () => {
+            const store = fakeStore();
+            const s = spies();
+            const swap = onchainSwap();
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.addSwap(swap, sendOrigin({ kind: "onchain_send" }));
+            await m.poll();
+
+            expect(swap.state).toBe("settled");
+            expect(swap.settlementPreimageHex).toBeUndefined();
+            expect(store.records.get(RFQ_ID)?.state).toBe("settled");
+            expect(store.records.get(RFQ_ID)?.settlementPreimageHex).toBeUndefined();
+        });
+
+        it("stamps nothing on a send that came back instead of settling", async () => {
+            const store = fakeStore();
+            const s = spies();
+            const swap = lightningSwap();
+            const refund = spendOfLockup({ leaf: "refundWithoutReceiver" });
+            const m = manager({
+                indexer: fakeIndexer({ vtxos: spentBy(refund.txid), txs: [refund] }),
+                repository: store,
+                now: SAFE_NOW,
+                spies: s,
+            });
+
+            await m.addSwap(swap, sendOrigin());
+            await m.poll();
+
+            expect(swap.state).toBe("refunded");
+            expect(swap.settlementPreimageHex).toBeUndefined();
+            expect(store.records.get(RFQ_ID)?.state).toBe("refunded");
+            expect(store.records.get(RFQ_ID)?.settlementPreimageHex).toBeUndefined();
+        });
+    });
 });


### PR DESCRIPTION
Implements `plans/send-leg-settlement-preimage.md`.

On a Lightning send the payee mints `P`, so the quote carries only `paymentHash` and the solver's claim witness is the only place the wallet can learn the preimage. `readLockupFate` already reads it and hash-checks it against the quote's own payment hash, then `runPass` throws it away. This stamps it onto the record instead, so a consumer reads the settlement receipt off storage rather than paying another indexer round trip.

`settlementPreimageHex?: string` — 32 bytes, hex, on the corridor record. Stamped between `stampLockupSpends` and `setState`, so the `settled` write carries it: one write, not two. Gated on `fate.fate === "claimed"` **and** `kind === "lightning_send"` — a receive's claimed verdict reveals the wallet's own claim secret and an onchain send's reveals the one it minted, both already recoverable from `profile`.

Nine touch points, modelled on `lockupSpendTxids`: the manager's `RfqSwapCommon` and the stamp; `rfqRecord.ts`'s declaration, `managerState`, `updateRfqSwapRecord` strip and `rebuildRfqSwap`; `driveRecords.ts`'s `rfqRecordOf` and both halves of `withRfqState`; and `CorridorSwapRecord`.

Deliberately **not** on the public `Swap`/`swapOf` — same as `lockupSpendTxids`, which is learned from the same verdict on the same line. Additive and optional in both directions; both backends store the record as an opaque blob, so no migration.

Tests: stamping plus three negatives (claimed receive, claimed onchain send, refunded send) asserting both the live swap and the stored record; record round trip and absent-stays-absent; clearing through both replacement helpers and `rfqSwapOriginOf`; the bridge write-back; and settlement through the real drive, JSON round-tripped into a fresh repository whose indexer throws on `getVtxos`/`getVirtualTxs` and is asserted uncalled.

https://claude.ai/code/session_01WwV2RAfshJVbBnpSg6YFRx