### PR TITLE
fix(swap): retire a corridor lockup when it is SPENT, not merely terminal

### DIFF
--- a/packages/swap/src/coverage.ts
+++ b/packages/swap/src/coverage.ts
@@ -29,6 +29,7 @@
  * the same backstop every other best-effort step here relies on.
  */
 import type { IContractManager } from "@arkade-os/sdk";
+import type { RfqSwapState } from "./rfqSwapState";
 import type { AssetSwapStatus } from "./store";
 
 /**
@@ -60,6 +61,11 @@ export const RETIRABLE: readonly AssetSwapStatus[] = ["fulfilled", "cancelled"];
 
 /** The one contract-manager capability changing coverage needs. */
 export type OfferContractRetirer = Pick<IContractManager, "setContractWatchState">;
+
+/** Corridor states after which the LOCKUP no longer holds funds: both mean it
+ *  WAS SPENT. `failed` is terminal too and excluded on purpose — an action that
+ *  missed its window says nothing about a covenant that can still be funded. */
+export const LOCKUP_RETIRABLE: readonly RfqSwapState[] = ["settled", "refunded"];
 
 /**
  * Scripts whose address has been handed out, by the time it was handed out.

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -116,6 +116,7 @@ import {
     type RfqSwapRecord,
 } from "./rfqRecord";
 import { RefundNotLocallyPossibleError } from "./refundBlocked";
+import { LOCKUP_RETIRABLE } from "./coverage";
 import { isRfqSwapTerminal, type RfqSwapState } from "./rfqSwapState";
 
 // ── Records ──────────────────────────────────────────────────────────────────
@@ -1474,6 +1475,8 @@ export class RfqSwapManager {
         // one that never existed would throw "not found" and report a failure
         // on a swap that had in fact just succeeded.
         if (!this.deps.contracts || !this.registered.get(swap.rfqId)) return;
+        // Terminal is not spent: `failed` can leave the lockup funded.
+        if (!LOCKUP_RETIRABLE.includes(swap.state)) return;
         void this.deps.contracts
             .setContractWatchState(hex.encode(swap.lockupPkScript), "retained")
             .catch((error: unknown) => this.emitFailed(swap, error));

--- a/packages/swap/test/coverage.test.ts
+++ b/packages/swap/test/coverage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { promoteOfferContract, retireOfferContract } from "../src/coverage";
+import { LOCKUP_RETIRABLE, promoteOfferContract, retireOfferContract } from "../src/coverage";
 import type { AssetSwap } from "../src/store";
 
 const SCRIPT = "51" + "aa".repeat(32);
@@ -77,4 +77,17 @@ describe("offer contract coverage", () => {
 
         expect(row).toBe("watched");
     });
+});
+
+describe("corridor lockup coverage", () => {
+    it("retires only the two states that mean the lockup was spent", () => {
+        expect([...LOCKUP_RETIRABLE].sort()).toEqual(["refunded", "settled"]);
+    });
+
+    it.each(["pending", "claimable", "claimed", "needs_counterparty", "failed"] as const)(
+        "never retires %s, which can still hold the user's money",
+        (state) => {
+            expect(LOCKUP_RETIRABLE).not.toContain(state);
+        },
+    );
 });

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -1517,6 +1517,31 @@ describe("RfqSwapManager — the lightning-receive leg", () => {
         await expect(m.waitForSwapCompletion(RFQ_ID)).rejects.toThrow(/ark server unreachable/);
     });
 
+    it("keeps watching a lockup whose swap FAILED — terminal is not spent", async () => {
+        // Still funded here, so retiring drops a live lockup off the watcher.
+        const receiveScript = hex.encode(RECEIVE_LOCKUP.pkScript);
+        const contracts = fakeContracts({
+            preexisting: [{ script: receiveScript } as CreateContractParams],
+        });
+        let now = BEFORE_DEADLINE;
+        const s = spies({
+            claimLockup: async () => {
+                throw new Error("ark server unreachable");
+            },
+        });
+        const swap = receiveSwap();
+        const m = manager({ indexer: fundedIndexer(), contracts, now: () => now, spies: s });
+        await pass(m, swap);
+
+        now = REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS;
+        await m.poll();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(swap.state).toBe("failed");
+        expect(contracts.watched()).toEqual([receiveScript]);
+        expect(contracts.retired).toEqual([]);
+    });
+
     it("reports without acting when auto-actions are off", async () => {
         const s = spies();
         const swap = receiveSwap();


### PR DESCRIPTION
## The money-safety half

`finalize()` calls `retireContract()` for **any** terminal state, `failed` included. But `failed` means an action missed its window — it says nothing about the covenant. A swap can fail with its lockup **still funded and still refundable**, and retiring that drops a live lockup off the watcher: the subscription and the failsafe poll stop seeing money that is still the user's, while the refund is still the thing that ends the swap.

It is the same hazard `RETIRABLE` already excludes `recoverable` for on the offer side, and the docblock there states the rule outright — *"a swept deposit is still the user's money at that script, and unwatching it is how it goes missing."*

`LOCKUP_RETIRABLE` is read off `RfqSwapState`'s own definitions rather than copied from `RETIRABLE`, whose members are offer statuses:

- `settled` — "the lockup was spent by a hash-verified claim"
- `refunded` — "the lockup was spent by something other than a claim"

Both say **spent**, which is the only thing that makes a script safe to stop watching. `failed`, `needs_counterparty` and every live state are excluded.

## The growth half

`RfqSwapManager.retireContract` already existed, so a corridor lockup did leave the watcher once its swap ended. What it did not do was distinguish a swap that **ended** from a covenant that was **spent**. With the guard, the watch set still shrinks on the two states where shrinking is safe.

## What this does NOT do — please do not re-derive a benefit from the diff

**The pre-send sync is unaffected.** Retirement narrows `watcher.getWatchedContracts()` and nothing else. Measured directly with 8 registered contracts, 4 set to `watch: "retained"`:

```
BEFORE retirement -> scripts per pre-send indexer call: [ 8 ]
AFTER  retirement -> scripts per pre-send indexer call: [ 8 ]
watcher.getWatchedContracts(): 4
```

`Wallet.getVtxos()` -> `contractSnapshot()` -> `getContractsWithVtxos()` runs unfiltered — `buildContractsDbFilter({})` leaves `watch` undefined, so retained rows still match — and it passes `contracts` explicitly to `syncContracts({ contracts })`, bypassing the `options.contracts ?? this.watcher.getWatchedContracts()` fallback that is the only place `isWatchedContract` is applied. So there is **no latency or scaling benefit here, and no effect on the 33-contract chunking cliff**. See #870 for the mechanism, and #871 for the `coverage.ts` docblock that overstates what retirement does.

A consequence worth stating for anyone worried this abandons coins: because `getSpendableVtxos()` -> `contractSnapshot()` is also the selection path `renewVtxos` uses, **a retained contract's VTXOs remain renewal candidates**. Retirement is less consequential than the word suggests — it is a watcher change, not an eviction.

## Tests

The state table, plus the case that matters: a receive whose claim kept throwing until its window shut, which ends `failed` with its lockup still funded and must stay watched. Removing the guard turns that one red.

## What I actually exercised

The merge brought in `packages/swap/src/reveal.ts` and the covclaimd Reveal client, so **"gate green at `784cab82`" is a statement about the union and not an endorsement of the base's new code**. What I exercised is the retirement path.

Gated against the merged base checked out and measured directly, rather than subtracting:

| | base `29d9138e` alone | tip `784cab82` | delta |
|---|---|---|---|
| ts-sdk | 177 files / 2963 passed, 1 skipped | 177 / 2963, 1 skipped | 0 |
| swap | 62 files / **1370** passed | 62 / **1377** passed | **+7** |

`pnpm -r build` exit 0, zero failing, +7 exactly the tests added here.

**Those numbers come from manual runs, not from the pre-commit hook.** The hook gated nothing: `pnpm --filter="...[HEAD]"` matches no projects in a git worktree, so both the lint and `test:unit` steps printed "No projects matched the filters" and exited 0, leaving only `biome format config` to run. Filed as #872 — worth reading, since it means a passing hook is not evidence for anyone committing from a worktree.