### PR TITLE
feat(payment): state a quote's validity on RouteQuote

### DIFF
--- a/packages/swap/src/payment/solverLightning.ts
+++ b/packages/swap/src/payment/solverLightning.ts
@@ -120,6 +120,9 @@ export function solverLightningRail(deps: SolverLightningRailDeps): PaymentRail 
                 amount: facts.amountSats,
                 fee: swap.fundAmount - facts.amountSats,
                 total: swap.fundAmount,
+                // The invoice can lapse before the quote does; the earlier bound
+                // is the one a holder must observe.
+                validUntil: Math.min(swap.quote.valid_until, facts.expiresAt),
                 meta: {
                     rfqId: swap.rfqId,
                     validUntil: swap.quote.valid_until,

--- a/packages/swap/src/payment/solverOnchain.ts
+++ b/packages/swap/src/payment/solverOnchain.ts
@@ -135,6 +135,7 @@ export function solverOnchainRail(deps: SolverOnchainRailDeps): PaymentRail {
                 amount,
                 fee: swap.fundAmount - amount,
                 total: swap.fundAmount,
+                validUntil: swap.quote.valid_until,
                 meta: {
                     rfqId: swap.rfqId,
                     validUntil: swap.quote.valid_until,

--- a/packages/swap/test/payment/solverLightning.test.ts
+++ b/packages/swap/test/payment/solverLightning.test.ts
@@ -391,4 +391,14 @@ describe("the gates are re-run before anything is spent", () => {
         await expect((await quote.send()).settled()).rejects.toThrow(/quote expired/);
         expect(send).not.toHaveBeenCalled();
     });
+
+    it("states the earlier of the quote validity and the invoice expiry", async () => {
+        const soonInvoice = facts({ expiresAt: NOW() + 60 });
+        const { quote } = await quoted(soonInvoice, NOW() + 3600);
+        expect(quote.validUntil).toBe(soonInvoice.expiresAt);
+
+        const soonQuote = NOW() + 30;
+        const { quote: other } = await quoted(facts(), soonQuote);
+        expect(other.validUntil).toBe(soonQuote);
+    });
 });

--- a/packages/ts-sdk/src/payment/types.ts
+++ b/packages/ts-sdk/src/payment/types.ts
@@ -54,6 +54,18 @@ export interface RouteQuote {
     /** `amount + fee` — what leaves the wallet. */
     total: number;
     /**
+     * Unix seconds after which the counterparty stops honouring this quote.
+     *
+     * Absent means "nothing to observe", not "never expires": a rail with no
+     * counterparty and no quote book — an Arkade transfer, an asset transfer, a
+     * collaborative exit — has no validity to state. A caller holding a quote
+     * across user think-time should read absence as "no check possible", and must
+     * still expect {@link send} to refuse either way: the swap rails re-check
+     * validity there, which is the only point that can judge it against the
+     * moment of spending.
+     */
+    validUntil?: number;
+    /**
      * @experimental The asset shape is provisional. The v2 swap client models
      * assets as `give`/`take`/`amountOn` over `AssetRef`, and the two
      * vocabularies are expected to converge on v0.5; do not treat this field as


### PR DESCRIPTION
`RouteQuote` is what a router consumer holds, and it does not say how long the quote is good for. The two solver rails already compute the answer and put it in the untyped `meta` bag, where nothing reads it — there is no consumer of `meta.validUntil` in this repo or in the wallet. This promotes it to a typed optional field.

## Why a consumer needs it

A wallet that quotes on screen mount and executes on a tap holds the quote across user think-time. Without a stated validity it has two choices, and both are bad:

- treat the quote as fresh forever, and hand the user a `quote expired` failure at the moment of spending on a send that would have succeeded had it re-quoted;
- invent a constant. Too long is the same failure; too short throws the benefit away.

The counterparty already states the answer — `quote.valid_until` — and `assertFundable` already enforces it at `send()`. The only thing missing is a typed way for the holder to read it.

## What this does

- `RouteQuote.validUntil?: number` — unix seconds, matching what `assertFundable` compares against.
- `solver-onchain` sets it from `swap.quote.valid_until`.
- `solver-lightning` sets it to `Math.min(swap.quote.valid_until, facts.expiresAt)`. Both bounds already gate that rail — `assertFundable` fails on `invoice_expired` and `quote_expired` independently — so the earlier of the two is the one a holder must observe.

## Why it is optional

Not every rail has a counterparty, and the ones that do not have nothing to state. Of the rails in this repo, only `solver-onchain` and `solver-lightning` carry a validity today:

| rail | validity |
|---|---|
| `ark`, `ark-asset` | none — no counterparty, no quote book |
| `onchain` (collaborative exit) | none — local arithmetic |
| `cross-asset` | none — an `OfferPlan` carries no expiry, as documented on the type |
| boltz `lightning`, `onchain-swap` | none at quote time — the swap is created inside `send()` |
| `solver-onchain`, `solver-lightning` | `quote.valid_until` |

So absence has to mean "nothing to observe" rather than "never expires", and the doc comment says so, along with the warning that `send()` can still refuse regardless — the rails re-check at the only point that can judge lapsing against the moment of spending.

There is precedent for the shape carrying more than the four numbers: `assets?: { delivered, spent }` is already an optional, `@experimental` field on the same type.

## `meta.validUntil`

Left in place, so nothing outside this repo that happens to read the untyped key breaks. It is now redundant and has no readers here or in the wallet — happy to drop it in this PR or leave it for a follow-up, whichever you prefer.

## Tests

`packages/swap/test/payment/solverLightning.test.ts` — the new case asserts the earlier of the two bounds is the one stated, in both directions (invoice sooner, quote sooner). It sits in the existing `the gates are re-run before anything is spent` block, next to the cases that assert the same two bounds refuse at `send()`.

Verified it fails without the change: replacing `Math.min(...)` with `swap.quote.valid_until` turns it red.

Unit suites, before → after:

```
ts-sdk       179 files / 2997 passed / 1 skipped  ->  179 / 2997 / 1
boltz-swap    23 files /  617 passed              ->   23 /  617
swap          33 files /  810 passed              ->   33 /  811   (+1, this PR)
```

`pnpm -r build` and `pnpm -r typecheck` both clean.

## Consumer

Written for a wallet change that holds one quote from screen mount to tap instead of quoting twice, so the duplicate RFQ leaves the user-visible window. That change is deliberately not in this PR and is blocked on this one, because the staleness rule it needs cannot be written without this field.
