### PR TITLE
perf(indexer): serve an identical in-flight vtxo read from one request

### DIFF
--- a/packages/ts-sdk/src/providers/indexer.ts
+++ b/packages/ts-sdk/src/providers/indexer.ts
@@ -401,6 +401,12 @@ export class RestIndexerProvider implements IndexerProvider {
     /** Overrides {@link configureEventSource} for this provider's subscription. */
     protected readonly eventSource?: EventSourceFactory;
 
+    /** @see fetchVtxosJson */
+    private readonly inFlightVtxoReads = new Map<
+        string,
+        Promise<{ vtxos: Vtxo[]; page?: PageResponse }>
+    >();
+
     constructor(
         public serverUrl: string = DEFAULT_ARKADE_SERVER_URL,
         options: EventSourceCapable = {},
@@ -799,18 +805,47 @@ export class RestIndexerProvider implements IndexerProvider {
         if (params.toString()) {
             url += "?" + params.toString();
         }
-        const res = await indexerFetch(url);
-        if (!res.ok) {
-            throw new Error(`Failed to fetch vtxos: ${res.statusText}`);
-        }
-        const data = await res.json();
-        if (!Response.isVtxosResponse(data)) {
-            throw new Error("Invalid vtxos data received");
-        }
+        const data = await this.fetchVtxosJson(url);
+        // Mapped per caller, not shared: `convertVtxo` builds a fresh coin, so
+        // two callers served from one request still get independent results.
         return {
             vtxos: data.vtxos.map(convertVtxo),
             page: data.page,
         };
+    }
+
+    /**
+     * The wire read behind {@link fetchVtxosPage}, with an identical read
+     * already in flight served from that one request instead of repeated.
+     *
+     * Two callers can want the same page at the same instant without either
+     * being redundant, so there is no single call site to remove: a send that
+     * leaves change makes the indexer emit `vtxo_spent` and `vtxo_received` for
+     * the wallet's own contract milliseconds apart, and `handleContractEvent`
+     * delta-syncs that contract on both arms.
+     */
+    private async fetchVtxosJson(url: string): Promise<{ vtxos: Vtxo[]; page?: PageResponse }> {
+        const joined = this.inFlightVtxoReads.get(url);
+        if (joined) return joined;
+
+        const shared = (async () => {
+            const res = await indexerFetch(url);
+            if (!res.ok) {
+                throw new Error(`Failed to fetch vtxos: ${res.statusText}`);
+            }
+            const data = await res.json();
+            if (!Response.isVtxosResponse(data)) {
+                throw new Error("Invalid vtxos data received");
+            }
+            return data;
+        })();
+
+        this.inFlightVtxoReads.set(url, shared);
+        try {
+            return await shared;
+        } finally {
+            if (this.inFlightVtxoReads.get(url) === shared) this.inFlightVtxoReads.delete(url);
+        }
     }
 
     async getAssetDetails(assetId: string): Promise<AssetDetails> {

--- a/packages/ts-sdk/test/indexer-provider.test.ts
+++ b/packages/ts-sdk/test/indexer-provider.test.ts
@@ -90,6 +90,80 @@ describe("RestIndexerProvider", () => {
             expect(requestUrl.searchParams.get("before")).toBe("0");
         });
 
+        const wireVtxo = (txid: string) => ({
+            outpoint: { txid, vout: 0 },
+            createdAt: "1700000000",
+            expiresAt: "1700003600",
+            amount: "1000",
+            script: "51200a",
+            isPreconfirmed: false,
+            isSwept: false,
+            isUnrolled: false,
+            isSpent: false,
+            spentBy: null,
+            commitmentTxids: [],
+        });
+
+        it("serves two identical concurrent reads from one request", async () => {
+            let resolveFetch: (v: unknown) => void = () => {};
+            mockFetch.mockReturnValueOnce(
+                new Promise((resolve) => {
+                    resolveFetch = resolve;
+                }),
+            );
+
+            const provider = new RestIndexerProvider("http://localhost:7070");
+            const first = provider.getVtxos({ scripts: ["script-a"] });
+            const second = provider.getVtxos({ scripts: ["script-a"] });
+
+            resolveFetch({
+                ok: true,
+                json: () => Promise.resolve({ vtxos: [wireVtxo("aa"), wireVtxo("bb")] }),
+            });
+            const [a, b] = await Promise.all([first, second]);
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(a.vtxos.map((v) => v.txid)).toEqual(["aa", "bb"]);
+            expect(b.vtxos.map((v) => v.txid)).toEqual(["aa", "bb"]);
+        });
+
+        it("gives each of those two callers an independently mutable result", async () => {
+            let resolveFetch: (v: unknown) => void = () => {};
+            mockFetch.mockReturnValueOnce(
+                new Promise((resolve) => {
+                    resolveFetch = resolve;
+                }),
+            );
+
+            const provider = new RestIndexerProvider("http://localhost:7070");
+            const first = provider.getVtxos({ scripts: ["script-a"] });
+            const second = provider.getVtxos({ scripts: ["script-a"] });
+            resolveFetch({
+                ok: true,
+                json: () => Promise.resolve({ vtxos: [wireVtxo("aa"), wireVtxo("bb")] }),
+            });
+            const [a, b] = await Promise.all([first, second]);
+
+            // Two kinds of isolation, and the second is the one a shared
+            // response would break: the array, then the coins inside it.
+            a.vtxos.reverse();
+            a.vtxos.find((v) => v.txid === "aa")!.value = 999;
+
+            expect(b.vtxos.map((v) => v.txid)).toEqual(["aa", "bb"]);
+            expect(b.vtxos.find((v) => v.txid === "aa")!.value).toBe(1000);
+        });
+
+        it("re-requests once the shared read has settled", async () => {
+            const page = () => ({ ok: true, json: () => Promise.resolve({ vtxos: [] }) });
+            mockFetch.mockResolvedValueOnce(page()).mockResolvedValueOnce(page());
+
+            const provider = new RestIndexerProvider("http://localhost:7070");
+            await provider.getVtxos({ scripts: ["script-a"] });
+            await provider.getVtxos({ scripts: ["script-a"] });
+
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
         it("rejects requests that mix scripts and outpoints", async () => {
             const provider = new RestIndexerProvider("http://localhost:7070");
 


### PR DESCRIPTION
A send that leaves change makes the indexer emit `vtxo_spent` and `vtxo_received` for the wallet's own contract milliseconds apart, and `ContractManager.handleContractEvent` delta-syncs the named contract on **both** arms. The same `GET /v1/indexer/vtxos` goes out twice, concurrently.

**This is a load fix, not a latency one**, and the measurements below are included partly to show that.

## Traced, not guessed

The first read of this was "duplicate queries", which invites the wrong fix. Capturing the synchronous caller at every `syncContracts` entry during one send gives the real shape:

```
t+3ms   getContractsWithVtxos()      at Wallet.contractSnapshot
                                     at Wallet.getSpendableVtxos
                                     at Wallet._sendImpl
t+3ms   syncContracts(contracts=2)   at ContractManager.getContractsWithVtxos

t+72ms  syncContracts(contracts=1)   at ContractManager.handleContractEvent  (case "vtxo_received")
t+74ms  syncContracts(contracts=1)   at ContractManager.handleContractEvent  (case "vtxo_spent")
```

Not a background poll, and not a redundant foreground read — two event arms, each doing its job:

```js
case "vtxo_received":
  await this.syncContracts({ contracts: [event.contract] });
  ...
case "vtxo_spent":
  await this.syncContracts({ contracts: [event.contract] });
```

Both are individually correct, so there is no call site to delete. Two callers want the identical answer at the same instant and neither needs a distinct result, which is what an in-flight coalescer is for.

## What changed

`fetchVtxosPage` shares the wire read behind a per-URL in-flight map on the provider instance.

The conversion stays **per caller**. The shared value is the validated JSON; each caller then runs its own `data.vtxos.map(convertVtxo)`, so two callers served from one request get their own array *and* their own coins. Isolation is structural rather than a claim about what callers happen to do — a survey of today's callers cannot bind a future one.

## Measurements

Same build, same server, toggling only this change.

| | vtxos calls | redundant | redundant indexer time | wall |
|---|---|---|---|---|
| local regtest, 5 sends, before | 13 | 4 (31%) | 60 ms | **276 ms** |
| local regtest, 5 sends, after | 9 | **0** | **0 ms** | **288 ms** |
| mutinynet, 4 sends, before | 10 | 3 (30%) | 4,112 ms | 12,407 ms |
| mutinynet, 4 sends, after | 6 | **0** | **0 ms** | 9,878 ms |

About **1.0 s of redundant indexer work per send** on mutinynet.

The local wall figures are the honest read on latency: **276 ms before, 288 ms after — no user-visible change**, which is expected, because the duplicate requests overlap. The mutinynet wall column moved 12,407 → 9,878 ms and **that is not claimed as a win**: per-send time there spans 1.2–5.4 s from network variance alone, and this is n=4 with one sample per arm. Nothing here should make a send feel faster; it removes work the indexer was doing twice.

## Reads only — and why `subscribe` must never be added

`POST /v1/indexer/script/subscribe` looks duplicated by endpoint and is not. Each call carries a **larger script set** and the `subscriptionId` the previous one returned:

```
t+   17   subscribe  n=1  sub=-         scripts=[a6d055a2]
t+   39   subscribe  n=2  sub=d203ce22  scripts=[a6d055a2,fda32198]
```

They are the watcher incrementally extending its watch set. Serving the second from the first would drop a contract from it. Keying on the vtxo read's own URL means this coalescer cannot reach them, and it should stay that way.

## Tests, and a bug in my own test worth reading

Three cases: one request serves two identical concurrent reads; each caller gets an independently mutable result; a later read after the shared one settles re-requests.

Both were mutation-checked, and the second one **failed the check on its first version**:

```js
a.vtxos.reverse();
a.vtxos[0].value = 999;              // after the reverse, this is the OTHER coin
expect(b.vtxos[0].value).toBe(1000); // so it never observed the shared write
```

With isolation deliberately removed — sharing the converted array between callers — that test **still passed**. It would have shipped green proving nothing. Rewritten to mutate by identity (`find(v => v.txid === "aa")`), it goes red under exactly that mutation.

Confirmed both directions:

| mutation | result |
|---|---|
| share the converted array between callers | independent-mutability test RED |
| bypass the coalescer entirely | one-request and mutability tests RED |
| as submitted | 17/17 green |

Suite: `packages/ts-sdk` 179 files, 2997 → 3000 passed, 1 skipped, 0 failed. The +3 are these. `typecheck` and `biome` clean.

## Related

The seam is narrower than it could be. The natural place is `indexerFetch` — one funnel for every indexer call, already separating GET/HEAD from other methods. Coalescing there needs each waiter to get its own body, so it needs `arrayBuffer()` or `clone()`, and sixteen test files mock `baseFetch` with `{ ok, json }` object literals that have neither. Rather than turn a load-only fix into a sixteen-file test refactor, that is filed separately as #875.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of concurrent identical VTXO reads by sharing a single request while it is in progress.
  * Subsequent requests after completion continue to fetch fresh data.

* **Bug Fixes**
  * Ensured results from concurrent callers remain independently mutable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->