### PR TITLE
docs(swap): retirement narrows the subscription and the poll, not every sync

### DIFF
--- a/packages/swap/src/coverage.ts
+++ b/packages/swap/src/coverage.ts
@@ -8,7 +8,7 @@
  * ({@link retireSettledOfferContracts}). Identical offers derive one script, so
  * those two can name the same row — and a demotion that lands after a promotion
  * recreates exactly the failure the promotion exists to prevent: an address the
- * user was told to fund, out of the subscription, the poll and every sync.
+ * user was told to fund, out of the subscription and the failsafe poll.
  *
  * Two things keep them apart:
  *
@@ -138,9 +138,10 @@ export async function promoteOfferContract(
  *
  * `retained`, not deleted: the row is what keeps the deposit's VTXOs
  * annotatable and its history readable, while `retained` is what drops it from
- * the subscription, the failsafe poll and every sync. A user who has made
- * hundreds of offers otherwise re-subscribes to hundreds of dead scripts on
- * every wallet start.
+ * the subscription and the failsafe poll — not from every sync, since
+ * `getContractsWithVtxos` reads rows whatever their watch state and syncs the
+ * set it read. A user who has made hundreds of offers otherwise re-subscribes
+ * to hundreds of dead scripts on every wallet start.
  *
  * A `recoverable` record blocks its script for good — nothing moves a record
  * off that status — so a script that once held a swept deposit stays watched


### PR DESCRIPTION
Closes #871.

## The claim that was wrong

`retireOfferContract`'s docblock said `retained` drops a contract from "the subscription, the failsafe poll **and every sync**". The first two hold. The last does not, and it is the sentence that seeded the assumption that retirement would shrink the pre-send synced set.

## Why it does not hold

`Wallet.getVtxos()` → `contractSnapshot()` → `getContractsWithVtxos()` (`contractManager.ts:1592`):

- called with no filter, so `buildContractsDbFilter({})` leaves `watch` undefined and retained rows still match (`:1588`, `:1767`)
- and it passes `contracts` explicitly to `syncContracts({ contracts })` (`:1602`), which bypasses the `options.contracts ?? this.watcher.getWatchedContracts()` fallback at `:2205` — the only place `isWatchedContract` is applied

Measured on the reporter's side with 8 registered contracts, 4 set to `watch: "retained"`: 8 scripts per pre-send indexer call before retirement, 8 after, with `getWatchedContracts()` correctly down to 4.

The module docblock at the top of the file carried the same claim, so both are narrowed.

## Scope

Comment-only. No behaviour change is proposed here — whether the pre-send read *should* narrow is a separate question, and #870 has the mechanism write-up.

`master` carries the same sentence in its own copy of `coverage.ts`; this targets `feat/v0.5` because that is where the file has diverged and where `packages/swap` work lands.

## Gate

`pnpm -r build` then `pnpm --filter=@arkade-os/swap test:unit`, run manually (the pre-commit hook selects no projects in a worktree — see #872):

| | Test files | Tests |
|---|---|---|
| `origin/feat/v0.5` baseline | 63 passed | 1384 passed |
| this branch | 63 passed | 1384 passed |

No failures either side.


## Review coverage

The green CodeRabbit check on this PR does not mean it reviewed. It posted `Review skipped: auto reviews are disabled on base/target branches other than the default branch` — the configured auto-review base is `next-version`, and this targets `feat/v0.5`. The status is reported as a pass regardless, so please do not read it as a second pair of eyes.
