### PR TITLE
fix(hooks): fail the pre-commit gate when its filter selects nothing

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,24 @@
 pnpm exec biome format config
+
+# `...[HEAD]` selects no projects inside a git worktree, where `.git` is a file
+# rather than a directory, so the two filtered steps below exit 0 having run
+# nothing. An empty selection is a broken gate, not "nothing to do".
+selected=$(pnpm --filter="...[HEAD]" ls --depth -1 --parseable 2>/dev/null)
+probe_status=$?
+projects=$(git ls-files -- '*/package.json' | sed 's#/package.json$##' | tr '\n' '|' | sed 's/|$//')
+
+# A failed probe is not an empty selection; let the real steps below report it.
+if [ "$probe_status" -eq 0 ] && [ -z "$selected" ] && [ -n "$projects" ] &&
+	git diff --cached --name-only | grep -qE "^($projects)/"; then
+	echo "pre-commit: staged changes are inside a workspace package, but" >&2
+	echo "  pnpm --filter=\"...[HEAD]\" selected no projects, so lint and" >&2
+	echo "  test:unit below would run nothing." >&2
+	echo "" >&2
+	echo "  Run the gate yourself before committing:" >&2
+	echo "    pnpm -r lint && pnpm -r build && pnpm -r test:unit" >&2
+	echo "  then commit with --no-verify, or commit from the main checkout." >&2
+	exit 1
+fi
+
 pnpm --filter="...[HEAD]" run --if-present lint
 pnpm --filter="...[HEAD]" run --if-present test:unit


### PR DESCRIPTION
Closes #872.

## What is broken

`.husky/pre-commit` is three lines, two of which are filtered:

```sh
pnpm exec biome format config
pnpm --filter="...[HEAD]" run --if-present lint
pnpm --filter="...[HEAD]" run --if-present test:unit
```

Inside a git worktree, `...[HEAD]` selects **zero projects**. Both filtered steps print `No projects matched the filters in "<path>"` and exit 0, so the hook passes having run no lint and no tests. It finishes in seconds instead of minutes, which is the only outward sign.

## Reproduced here

pnpm 10.25.0, Windows, in a worktree created fresh from `origin/master`:

| Checkout | `pnpm --filter="...[HEAD]" ls --depth -1 --parseable` |
|---|---|
| worktree, unstaged edit in `packages/swap` | empty |
| worktree, same edit staged | empty |
| worktree, `...[HEAD~1]` | empty |
| main clone, `...[HEAD~1]` (last commit touched `packages/boltz-swap`) | `packages/boltz-swap` — correct |

Project discovery is fine in the same worktree: `pnpm -r exec pwd` lists all three packages and `--filter=@arkade-os/swap` resolves. It is specifically the changed-since detection that comes back empty. A linked worktree's `.git` is a *file* holding a `gitdir:` pointer rather than a directory, which is the usual cause of this class of failure.

## The fix

Rather than try to outguess pnpm, resolve the selection first and treat an empty one as a broken gate:

- the probe is `ls --depth -1 --parseable`, whose "no projects matched" goes to stderr, so an empty stdout is an unambiguous signal (`exec` writes that message to *stdout*, which is why it is not used here)
- the check only fires when a staged path is inside a workspace package, derived from `git ls-files -- '*/package.json'` rather than hardcoding `packages/`. A commit that only touches root-level files — **this one, for instance** — still passes exactly as before
- the probe's exit status is captured separately from its output, so a pnpm that fails outright falls through to the real steps below rather than being reported as an empty selection
- the message names the manual gate to run, so the failure is actionable rather than just loud

## Verified

Running the hook directly in the worktree:

- staged `packages/swap` change → exit 1, with the manual gate printed
- staged `.husky/pre-commit` change only → exit 0, unchanged behaviour (this is the path the commit on this PR took)
- nothing staged → exit 0
- the probe forced to fail (bad revision) → the empty-selection message is not printed

In a normal clone the selection is non-empty, so `[ -z "$selected" ]` short-circuits and the hook behaves exactly as it does today.

Workspace gate, run manually on this branch: `pnpm -r build`, then `pnpm -r test:unit` — ts-sdk 179 files / 2997 passed + 1 skipped, swap 33 / 810, boltz-swap 23 / 617, no type errors, zero failures. Identical to `origin/master`, as a shell-only change should be.

## One fork worth naming

The alternative was to *fall back* to the whole-workspace gate on an empty selection, which keeps worktree commits gated rather than blocked. It costs several minutes per commit, which is a reliable way to teach people `--no-verify`, so I went with failing. Happy to switch if you would rather have the fallback.

Separately, the upstream pnpm behaviour is worth a report on its own — but even with pnpm fixed, the hook still cannot tell "no project changed" from "the filter selected nothing", and both exit 0 today.
