### PR TITLE
test(sdk): mock the fetch boundary with real Responses

### DIFF
--- a/packages/ts-sdk/test/ark-provider.test.ts
+++ b/packages/ts-sdk/test/ark-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { RestArkProvider } from "../src/providers/ark";
 import { MockEventSource } from "./mocks/eventSource";
+import { jsonResponse } from "./helpers/response";
 
 describe("RestArkProvider.getEventStream", () => {
     beforeEach(() => {
@@ -192,7 +193,7 @@ describe("RestArkProvider.getInfo transaction limits", () => {
     const infoResponse = (body: Record<string, unknown>) => {
         vi.stubGlobal(
             "fetch",
-            vi.fn(async () => ({ ok: true, json: async () => body })),
+            vi.fn(async () => jsonResponse(body)),
         );
         return new RestArkProvider("http://ark.test").getInfo();
     };

--- a/packages/ts-sdk/test/arkProviderDigest.test.ts
+++ b/packages/ts-sdk/test/arkProviderDigest.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { RestArkProvider, DigestMismatchError } from "../src/providers/ark";
+import { jsonResponse } from "./helpers/response";
 
 const SIGNER = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 
 function okInfo(digest: string, signerPubkey: string = SIGNER) {
-    return { ok: true, json: async () => ({ signerPubkey, digest }) };
+    return jsonResponse({ signerPubkey, digest });
 }
 
 /** A rejected non-/info response whose body carries the given marker. */

--- a/packages/ts-sdk/test/cachingArkProvider.test.ts
+++ b/packages/ts-sdk/test/cachingArkProvider.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { CachingArkProvider } from "../src/providers/cachingArk";
 import { ArkInfo, ArkProvider, RestArkProvider } from "../src/providers/ark";
 import { extractArkProviderUrl } from "../src/wallet/wallet";
+import { jsonResponse } from "./helpers/response";
 
 const SIGNER = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 const ROTATED = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
@@ -176,7 +177,7 @@ describe("CachingArkProvider", () => {
         let signerPubkey = SIGNER;
         vi.stubGlobal(
             "fetch",
-            vi.fn(async () => ({ ok: true, json: async () => ({ signerPubkey, digest }) })),
+            vi.fn(async () => jsonResponse({ signerPubkey, digest })),
         );
         const provider = new CachingArkProvider(new RestArkProvider("http://ark.test"), 60_000);
         await provider.getInfo();

--- a/packages/ts-sdk/test/delegate-provider-headers.test.ts
+++ b/packages/ts-sdk/test/delegate-provider-headers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RestDelegateProvider } from "../src/providers/delegate";
+import { jsonResponse } from "./helpers/response";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -15,15 +16,11 @@ describe("RestDelegateProvider request headers (CORS)", () => {
             "fetch",
             vi.fn(async (_url: string, init?: RequestInit) => {
                 seen.push(new Headers(init?.headers));
-                return {
-                    ok: true,
-                    text: async () => "",
-                    json: async () => ({
-                        pubkey: "02abc",
-                        fee: "0",
-                        delegatorAddress: "tark1validaddress",
-                    }),
-                };
+                return jsonResponse({
+                    pubkey: "02abc",
+                    fee: "0",
+                    delegatorAddress: "tark1validaddress",
+                });
             }),
         );
 

--- a/packages/ts-sdk/test/delegate-provider.test.ts
+++ b/packages/ts-sdk/test/delegate-provider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RestDelegateProvider } from "../src";
+import { jsonResponse } from "./helpers/response";
 
 const { mockFetch } = vi.hoisted(() => ({
     mockFetch: vi.fn(),
@@ -19,11 +20,7 @@ describe("RestDelegateProvider.getDelegateInfo", () => {
         vi.unstubAllGlobals();
     });
 
-    const respondWith = (body: unknown) =>
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(body),
-        });
+    const respondWith = (body: unknown) => mockFetch.mockResolvedValueOnce(jsonResponse(body));
 
     it("normalizes delegateAddress to a string when the payload field is a non-string", async () => {
         // delegateAddress is a truthy non-string; delegatorAddress is the valid one.

--- a/packages/ts-sdk/test/esplora-watch-addresses.test.ts
+++ b/packages/ts-sdk/test/esplora-watch-addresses.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EsploraProvider } from "../src";
 import type { ExplorerTransaction } from "../src/providers/onchain";
+import { jsonResponse } from "./helpers/response";
 
 const { mockFetch } = vi.hoisted(() => ({
     mockFetch: vi.fn(),
@@ -60,7 +61,7 @@ function deferred<T>() {
     return { promise, resolve, reject };
 }
 
-const okJson = (data: unknown) => ({ ok: true, json: () => Promise.resolve(data) });
+const okJson = (data: unknown) => jsonResponse(data);
 
 /** The cheap change probe (`/address/{a}`), as opposed to the history below it. */
 const isProbeUrl = (url: string) => /\/address\/[^/]+$/.test(url);
@@ -172,15 +173,18 @@ describe("EsploraProvider.watchAddresses", () => {
             const stop = await provider.watchAddresses(["addr1"], () => {});
 
             // Now hold the fallback's own fetch open.
-            const pending = deferred<ReturnType<typeof okJson>>();
-            mockFetch.mockReturnValue(pending.promise);
+            const pending = deferred<void>();
+            mockFetch.mockImplementation(async () => {
+                await pending.promise;
+                return okJson([]);
+            });
 
             const errorHandled = FakeWebSocket.instances[0].dispatch("error");
             await flush(); // poll() is now suspended on the initial fetch
 
             stop();
 
-            pending.resolve(okJson([]));
+            pending.resolve();
             await errorHandled;
             await flush();
 
@@ -188,7 +192,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("starts at most one poll loop when the websocket errors repeatedly", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const stop = await provider.watchAddresses(["addr1"], () => {});
@@ -214,7 +218,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("does not start polling when the websocket errors after stop()", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const stop = await provider.watchAddresses(["addr1"], () => {});
@@ -230,7 +234,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("stops delivering callbacks after stop()", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const callback = vi.fn();
 
             const provider = new EsploraProvider("http://localhost:3000");
@@ -250,12 +254,12 @@ describe("EsploraProvider.watchAddresses", () => {
             // it found on startup as "already known", so a deposit arriving
             // during the outage — after the socket died, before polling began —
             // was seeded as old and never reported at all.
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const callback = vi.fn();
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], callback);
 
-            mockFetch.mockResolvedValue(okJson([confirmedTx("during-outage")]));
+            mockFetch.mockImplementation(async () => okJson([confirmedTx("during-outage")]));
             await FakeWebSocket.instances[0].dispatch("error");
             await flush();
 
@@ -266,7 +270,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("does not report transactions that predate the watch", async () => {
-            mockFetch.mockResolvedValue(okJson([confirmedTx("old")]));
+            mockFetch.mockImplementation(async () => okJson([confirmedTx("old")]));
             const callback = vi.fn();
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], callback);
@@ -278,7 +282,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("does not re-report a transaction the socket already delivered", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const callback = vi.fn();
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], callback);
@@ -290,7 +294,7 @@ describe("EsploraProvider.watchAddresses", () => {
             expect(callback).toHaveBeenCalledTimes(1);
 
             // The socket dies and the fallback sees the same tx in history.
-            mockFetch.mockResolvedValue(okJson([confirmedTx("aa")]));
+            mockFetch.mockImplementation(async () => okJson([confirmedTx("aa")]));
             await FakeWebSocket.instances[0].dispatch("error");
             await flush();
 
@@ -302,14 +306,14 @@ describe("EsploraProvider.watchAddresses", () => {
             // paying two watched addresses comes back twice in a single batch.
             // Boarding makes that ordinary: the watch covers the current and
             // historical rotated addresses at once.
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const callback = vi.fn();
             const provider = new EsploraProvider("http://localhost:3000", {
                 forcePolling: true,
             });
             await provider.watchAddresses(["addr1", "addr2"], callback);
 
-            mockFetch.mockResolvedValue(okJson([confirmedTx("pays-both")]));
+            mockFetch.mockImplementation(async () => okJson([confirmedTx("pays-both")]));
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
 
             expect(callback).toHaveBeenCalledTimes(1);
@@ -317,7 +321,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("reports a socket transaction listed under two addresses only once", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const callback = vi.fn();
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1", "addr2"], callback);
@@ -344,7 +348,7 @@ describe("EsploraProvider.watchAddresses", () => {
             // not be silent: a deposit going unreported is exactly the thing an
             // operator needs told.
             mockFetch.mockRejectedValueOnce(new Error("explorer down"));
-            mockFetch.mockResolvedValue(okJson([confirmedTx("arrived-in-the-gap")]));
+            mockFetch.mockImplementation(async () => okJson([confirmedTx("arrived-in-the-gap")]));
             const callback = vi.fn();
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], callback);
@@ -360,7 +364,7 @@ describe("EsploraProvider.watchAddresses", () => {
 
         it("keeps watching when the creation-time baseline fetch fails", async () => {
             mockFetch.mockRejectedValueOnce(new Error("explorer down"));
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const callback = vi.fn();
             const provider = new EsploraProvider("http://localhost:3000");
 
@@ -697,7 +701,7 @@ describe("EsploraProvider.watchAddresses", () => {
 
     describe("websocket reconnect", () => {
         const watch = async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const provider = new EsploraProvider("http://localhost:3000");
             const stop = await provider.watchAddresses(["addr1"], () => {});
             mockFetch.mockClear(); // discount the creation-time baseline
@@ -759,8 +763,11 @@ describe("EsploraProvider.watchAddresses", () => {
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], () => {});
 
-            const pending = deferred<ReturnType<typeof okJson>>();
-            mockFetch.mockReturnValue(pending.promise);
+            const pending = deferred<void>();
+            mockFetch.mockImplementation(async () => {
+                await pending.promise;
+                return okJson([]);
+            });
 
             const errorHandled = FakeWebSocket.instances[0].dispatch("error");
             await flush(); // the poll cycle is now suspended on its fetch
@@ -768,7 +775,7 @@ describe("EsploraProvider.watchAddresses", () => {
             await vi.advanceTimersByTimeAsync(RECONNECT_DELAY_MS);
             await FakeWebSocket.instances[1].dispatch("open");
 
-            pending.resolve(okJson([]));
+            pending.resolve();
             await errorHandled;
             await flush();
 
@@ -786,8 +793,11 @@ describe("EsploraProvider.watchAddresses", () => {
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], () => {});
 
-            const pending = deferred<ReturnType<typeof okJson>>();
-            mockFetch.mockReturnValue(pending.promise);
+            const pending = deferred<void>();
+            mockFetch.mockImplementation(async () => {
+                await pending.promise;
+                return okJson([]);
+            });
 
             const errorHandled = FakeWebSocket.instances[0].dispatch("error");
             await flush();
@@ -797,7 +807,7 @@ describe("EsploraProvider.watchAddresses", () => {
             await reconnected.dispatch("open");
             await reconnected.dispatch("error"); // fails again straight away
 
-            pending.resolve(okJson([]));
+            pending.resolve();
             await errorHandled;
             await flush();
 
@@ -805,7 +815,7 @@ describe("EsploraProvider.watchAddresses", () => {
             // (Counting probes rather than timers: a pending reconnect is a
             // legitimate timer too, so a raw count would conflate the two.)
             mockFetch.mockClear();
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
             expect(probeCount()).toBe(1);
         });
@@ -814,7 +824,7 @@ describe("EsploraProvider.watchAddresses", () => {
             // A sandboxed context can make `new WebSocket(...)` throw outright
             // (SecurityError), which is a different entry point to the fallback
             // than an `error` event on a constructed socket.
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             let throwOnConstruct = true;
             (globalThis as any).WebSocket = class extends FakeWebSocket {
                 constructor(url: string) {
@@ -839,7 +849,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("delivers messages received on a reconnected socket", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const callback = vi.fn();
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], callback);
@@ -913,7 +923,7 @@ describe("EsploraProvider.watchAddresses", () => {
         const polling = () => new EsploraProvider("http://localhost:3000", { forcePolling: true });
 
         it("does not report transactions that already existed when polling began", async () => {
-            mockFetch.mockResolvedValue(okJson([confirmedTx("old")]));
+            mockFetch.mockImplementation(async () => okJson([confirmedTx("old")]));
             const callback = vi.fn();
 
             await polling().watchAddresses(["addr1"], callback);
@@ -923,12 +933,14 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("reports a transaction that appears after the baseline pass", async () => {
-            mockFetch.mockResolvedValue(okJson([confirmedTx("old")]));
+            mockFetch.mockImplementation(async () => okJson([confirmedTx("old")]));
             const callback = vi.fn();
 
             await polling().watchAddresses(["addr1"], callback);
 
-            mockFetch.mockResolvedValue(okJson([confirmedTx("old"), confirmedTx("new")]));
+            mockFetch.mockImplementation(async () =>
+                okJson([confirmedTx("old"), confirmedTx("new")]),
+            );
             await vi.advanceTimersByTimeAsync(15_000);
 
             expect(callback).toHaveBeenCalledTimes(1);
@@ -968,7 +980,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("warns when it degrades from websocket to HTTP polling", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
 
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], () => {});
@@ -983,7 +995,7 @@ describe("EsploraProvider.watchAddresses", () => {
 
     describe("coalescing", () => {
         it("shares a single websocket between concurrent watchers on the same address set", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
 
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1", "addr2"], () => {});
@@ -993,7 +1005,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("fans websocket messages out to every subscriber", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
             const first = vi.fn();
             const second = vi.fn();
 
@@ -1012,7 +1024,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("keeps the shared watcher alive until the last subscriber stops", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const stopFirst = await provider.watchAddresses(["addr1"], () => {});
@@ -1027,7 +1039,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("ignores a repeated stop() from the same subscriber", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const stopFirst = await provider.watchAddresses(["addr1"], () => {});
@@ -1043,7 +1055,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("opens a fresh watcher after the previous one was fully released", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const stop = await provider.watchAddresses(["addr1"], () => {});
@@ -1065,7 +1077,7 @@ describe("EsploraProvider.watchAddresses", () => {
         });
 
         it("does not share between different address sets", async () => {
-            mockFetch.mockResolvedValue(okJson([]));
+            mockFetch.mockImplementation(async () => okJson([]));
 
             const provider = new EsploraProvider("http://localhost:3000");
             await provider.watchAddresses(["addr1"], () => {});

--- a/packages/ts-sdk/test/esplora.test.ts
+++ b/packages/ts-sdk/test/esplora.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EsploraProvider, Coin } from "../src";
+import { jsonResponse, textResponse } from "./helpers/response";
 
 const { mockFetch } = vi.hoisted(() => ({
     mockFetch: vi.fn(),
@@ -31,10 +32,7 @@ describe("EsploraProvider", () => {
         ];
 
         it("should fetch and convert UTXOs to coins", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockUTXOs),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockUTXOs));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const utxos = await provider.getCoins("bc1qtest");
@@ -58,12 +56,9 @@ describe("EsploraProvider", () => {
 
     describe("getRawTransaction", () => {
         it("decodes the /hex endpoint into wire bytes", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                // Esplora's plain-text response is newline-terminated on some
-                // deployments; hex.decode rejects the stray byte.
-                text: () => Promise.resolve("0200000001ab\n"),
-            });
+            // Esplora's plain-text response is newline-terminated on some
+            // deployments; hex.decode rejects the stray byte.
+            mockFetch.mockResolvedValueOnce(textResponse("0200000001ab\n"));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const raw = await provider.getRawTransaction("deadbeef");
@@ -91,10 +86,7 @@ describe("EsploraProvider", () => {
         };
 
         it("should fetch and return fee rate", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockFeeResponse),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockFeeResponse));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const feeRate = await provider.getFeeRate();
@@ -121,10 +113,7 @@ describe("EsploraProvider", () => {
         const mockTxid = "abcd1234";
 
         it("should broadcast transaction and return txid", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                text: () => Promise.resolve(mockTxid),
-            });
+            mockFetch.mockResolvedValueOnce(textResponse(mockTxid));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const txid = await provider.broadcastTransaction(mockTxHex);
@@ -162,11 +151,7 @@ describe("EsploraProvider", () => {
         const expectedTip = { hash: "tip-hash", height: 800000, time: 1700000000 };
 
         it("should fetch the tip from /blocks", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                status: 200,
-                json: () => Promise.resolve(mockBlocks),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockBlocks));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const tip = await provider.getChainTip();
@@ -183,11 +168,7 @@ describe("EsploraProvider", () => {
                     status: 404,
                     statusText: "Not Found",
                 })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    status: 200,
-                    json: () => Promise.resolve(mockBlocks),
-                });
+                .mockResolvedValueOnce(jsonResponse(mockBlocks));
 
             const provider = new EsploraProvider("http://localhost:3000");
             const tip = await provider.getChainTip();

--- a/packages/ts-sdk/test/fetch.test.ts
+++ b/packages/ts-sdk/test/fetch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { baseFetch, fetch, FetchError } from "../src/utils/fetch";
+import { jsonResponse } from "./helpers/response";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -73,7 +74,7 @@ describe("baseFetch", () => {
     });
 
     it("passes a resolving Response through unchanged", async () => {
-        const response = { ok: true, status: 200 } as unknown as Response;
+        const response = jsonResponse({});
         vi.stubGlobal(
             "fetch",
             vi.fn(async () => response),
@@ -120,7 +121,7 @@ describe("Ark-server fetch wrapper", () => {
     });
 
     it("passes a resolving Response through unchanged", async () => {
-        const response = { ok: true } as unknown as Response;
+        const response = jsonResponse({});
         vi.stubGlobal(
             "fetch",
             vi.fn(async () => response),

--- a/packages/ts-sdk/test/hdWalletCapable.test.ts
+++ b/packages/ts-sdk/test/hdWalletCapable.test.ts
@@ -16,6 +16,7 @@ import {
 import { sha256 } from "@noble/hashes/sha2.js";
 import { deriveDescriptorLeafCompressedPubKey } from "../src/identity/descriptor";
 import { HDDescriptorProvider } from "../src/wallet/hdDescriptorProvider";
+import { jsonResponse } from "./helpers/response";
 
 const MNEMONIC =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -53,7 +54,7 @@ beforeEach(() => {
     vi.stubGlobal("EventSource", MockEventSource);
     mockFetch.mockReset();
     mockFetch.mockImplementation((url: string) => {
-        const reply = (body: unknown) => Promise.resolve({ ok: true, json: async () => body });
+        const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
         if (url.includes("/info")) return reply(mockArkInfo);
         if (url.includes("subscribe") || url.includes("subscriptions"))
             return reply({ subscriptionId: "sub-1" });

--- a/packages/ts-sdk/test/helpers/response.ts
+++ b/packages/ts-sdk/test/helpers/response.ts
@@ -1,0 +1,20 @@
+/**
+ * Real `Response`s for the fetch mocks. An object literal with `ok` and `json`
+ * answers whichever two members its own call site reads, so production code can
+ * never reach for a third — `clone()`, `arrayBuffer()`, `headers` — without
+ * breaking every test at once.
+ */
+
+/** int64 crosses grpc-gateway as a decimal string, and JSON has no bigint. */
+const wireSafe = (_key: string, value: unknown): unknown =>
+    typeof value === "bigint" ? value.toString() : value;
+
+export const jsonResponse = (body: unknown, init?: ResponseInit): Response =>
+    new Response(JSON.stringify(body, wireSafe), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        ...init,
+    });
+
+export const textResponse = (body: string, init?: ResponseInit): Response =>
+    new Response(body, { status: 200, ...init });

--- a/packages/ts-sdk/test/helpers/restoreWallet.ts
+++ b/packages/ts-sdk/test/helpers/restoreWallet.ts
@@ -10,6 +10,7 @@ import type { IndexerProvider } from "../../src/providers/indexer";
 import type { OnchainProvider } from "../../src/providers/onchain";
 import type { VirtualCoin } from "../../src";
 import { HDDescriptorProvider } from "../../src/wallet/hdDescriptorProvider";
+import { jsonResponse } from "./response";
 
 /**
  * Test harness for the `Wallet.restore()` suite.
@@ -54,11 +55,7 @@ export const mockArkInfo = {
  */
 export function installRestoreHarness(): void {
     const mockFetch = vi.fn().mockImplementation((url: string) => {
-        const reply = (body: unknown) =>
-            Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve(body),
-            });
+        const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
         if (url.includes("/info")) return reply(mockArkInfo);
         if (url.includes("subscribe") || url.includes("subscriptions"))
             return reply({ subscriptionId: "sub-1" });

--- a/packages/ts-sdk/test/indexer-provider.test.ts
+++ b/packages/ts-sdk/test/indexer-provider.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RestIndexerProvider } from "../src";
 import { MockEventSource } from "./mocks/eventSource";
+import { jsonResponse } from "./helpers/response";
 
 const { mockFetch } = vi.hoisted(() => ({
     mockFetch: vi.fn(),
@@ -22,10 +23,7 @@ describe("RestIndexerProvider", () => {
 
     describe("getVtxos", () => {
         it("serializes the current getVtxos query parameters", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ vtxos: [] }),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse({ vtxos: [] }));
 
             const provider = new RestIndexerProvider("http://localhost:7070");
             await provider.getVtxos({
@@ -54,10 +52,7 @@ describe("RestIndexerProvider", () => {
         });
 
         it("serializes the renewableOnly filter", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ vtxos: [] }),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse({ vtxos: [] }));
 
             const provider = new RestIndexerProvider("http://localhost:7070");
             await provider.getVtxos({ scripts: ["script-a"], renewableOnly: true });
@@ -67,10 +62,7 @@ describe("RestIndexerProvider", () => {
         });
 
         it("serializes outpoints and legacy filters alongside the new bounds", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ vtxos: [] }),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse({ vtxos: [] }));
 
             const provider = new RestIndexerProvider("http://localhost:7070");
             await provider.getVtxos({
@@ -173,22 +165,18 @@ describe("RestIndexerProvider", () => {
             // page in `current`; `next` points at the following page until the
             // last one, where it pins at `total`.
             mockFetch
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () =>
-                        Promise.resolve({
-                            vtxos: fullPage,
-                            page: { current: 1, next: 2, total: 2 },
-                        }),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () =>
-                        Promise.resolve({
-                            vtxos: [vtxo("page1-0")],
-                            page: { current: 2, next: 2, total: 2 },
-                        }),
-                });
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        vtxos: fullPage,
+                        page: { current: 1, next: 2, total: 2 },
+                    }),
+                )
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        vtxos: [vtxo("page1-0")],
+                        page: { current: 2, next: 2, total: 2 },
+                    }),
+                );
 
             const provider = new RestIndexerProvider("http://localhost:7070");
             const result = await provider.getVtxos({ scripts: ["script-a"] });
@@ -223,16 +211,14 @@ describe("RestIndexerProvider", () => {
                 spentBy: "",
             });
             const fullPage = Array.from({ length: 500 }, (_, i) => vtxo(`only-${i}`));
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () =>
-                    Promise.resolve({
-                        vtxos: fullPage,
-                        // The server clamps page.index=0 to page 1 and echoes
-                        // the 1-based page: current 1 of 1, next pinned at 1.
-                        page: { current: 1, next: 1, total: 1 },
-                    }),
-            });
+            mockFetch.mockResolvedValueOnce(
+                jsonResponse({
+                    vtxos: fullPage,
+                    // The server clamps page.index=0 to page 1 and echoes
+                    // the 1-based page: current 1 of 1, next pinned at 1.
+                    page: { current: 1, next: 1, total: 1 },
+                }),
+            );
 
             const provider = new RestIndexerProvider("http://localhost:7070");
             const result = await provider.getVtxos({ scripts: ["script-a"] });
@@ -243,10 +229,9 @@ describe("RestIndexerProvider", () => {
         });
 
         it("leaves a caller-named page alone, cursor included", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ vtxos: [], page: { current: 2, next: 3, total: 9 } }),
-            });
+            mockFetch.mockResolvedValueOnce(
+                jsonResponse({ vtxos: [], page: { current: 2, next: 3, total: 9 } }),
+            );
 
             const provider = new RestIndexerProvider("http://localhost:7070");
             const result = await provider.getVtxos({ scripts: ["script-a"], pageIndex: 2 });
@@ -271,14 +256,12 @@ describe("RestIndexerProvider", () => {
             });
             const fullPage = Array.from({ length: 500 }, (_, i) => vtxo(`page0-${i}`));
             mockFetch
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () =>
-                        Promise.resolve({
-                            vtxos: fullPage,
-                            page: { current: 0, next: 1, total: 2 },
-                        }),
-                })
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        vtxos: fullPage,
+                        page: { current: 0, next: 1, total: 2 },
+                    }),
+                )
                 .mockResolvedValueOnce({
                     ok: false,
                     statusText: "Internal Server Error",

--- a/packages/ts-sdk/test/jsonResponse.test.ts
+++ b/packages/ts-sdk/test/jsonResponse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { jsonResponse, textResponse } from "./helpers/response";
+
+describe("the fetch-mock response helpers", () => {
+    it("hand back a real Response, not a duck type", async () => {
+        const res = jsonResponse({ vtxos: [] });
+
+        expect(res).toBeInstanceOf(Response);
+        expect(res.ok).toBe(true);
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toBe("application/json");
+        expect(await res.clone().text()).toBe('{"vtxos":[]}');
+        expect(await res.arrayBuffer()).toBeInstanceOf(ArrayBuffer);
+    });
+
+    it("serialize bigint the way grpc-gateway puts int64 on the wire", async () => {
+        const res = jsonResponse({ batchExpiry: 144n });
+
+        expect(await res.json()).toEqual({ batchExpiry: "144" });
+    });
+
+    it("reject a second body read, exactly as a fetched Response does", async () => {
+        const res = textResponse("0200000001ab");
+
+        expect(await res.text()).toBe("0200000001ab");
+        await expect(res.text()).rejects.toThrow();
+    });
+
+    it("let init override the defaults", () => {
+        const res = jsonResponse({}, { status: 404, statusText: "Not Found" });
+
+        expect(res.ok).toBe(false);
+        expect(res.status).toBe(404);
+        expect(res.statusText).toBe("Not Found");
+    });
+});

--- a/packages/ts-sdk/test/provider-availability.test.ts
+++ b/packages/ts-sdk/test/provider-availability.test.ts
@@ -3,6 +3,7 @@ import { RestIndexerProvider, RestArkProvider, ProviderUnavailableError, ArkErro
 import { throwIfHttpUnavailable, toProviderUnavailable } from "../src/providers/errors";
 import { FetchError } from "../src/utils/fetch";
 import { rateGate } from "../src/providers/rateGate";
+import { jsonResponse } from "./helpers/response";
 
 const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
 
@@ -111,7 +112,7 @@ describe("RestIndexerProvider availability classification", () => {
     it("retries a 503 and succeeds on a later attempt", async () => {
         mockFetch
             .mockResolvedValueOnce({ ok: false, status: 503, statusText: "Service Unavailable" })
-            .mockResolvedValueOnce({ ok: true, json: async () => ({ vtxos: [] }) });
+            .mockResolvedValueOnce(jsonResponse({ vtxos: [] }));
         await expect(provider().getVtxos({ scripts: ["s"] })).resolves.toMatchObject({
             vtxos: [],
         });

--- a/packages/ts-sdk/test/provider-build-version-header.test.ts
+++ b/packages/ts-sdk/test/provider-build-version-header.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { EsploraProvider, RestArkProvider, RestIndexerProvider } from "../src";
 import { version as sdkVersion } from "../package.json";
+import { jsonResponse } from "./helpers/response";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -10,7 +11,7 @@ function captureHeaders(json: () => any = async () => []): Headers[] {
         "fetch",
         vi.fn(async (_url: string, init?: RequestInit) => {
             seen.push(new Headers(init?.headers));
-            return { ok: true, json, text: async () => "[]" };
+            return jsonResponse(await json());
         }),
     );
     return seen;

--- a/packages/ts-sdk/test/rate-gate.test.ts
+++ b/packages/ts-sdk/test/rate-gate.test.ts
@@ -6,6 +6,7 @@ import {
     rateGate,
     requestOrigin,
 } from "../src/providers/rateGate";
+import { jsonResponse } from "./helpers/response";
 
 const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }));
 
@@ -27,7 +28,7 @@ function rateLimited(retryAfter = "10") {
 }
 
 function ok(body: unknown) {
-    return { ok: true, headers: new Headers(), json: async () => body };
+    return jsonResponse(body);
 }
 
 describe("parseRetryAfterMs", () => {
@@ -213,7 +214,7 @@ describe("shared cooldown across requests (herd regression)", () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         // A request that never saw a 429 itself must not reach the network.
-        mockFetch.mockResolvedValue(ok({ vtxos: [] }));
+        mockFetch.mockImplementation(async () => ok({ vtxos: [] }));
         const newcomer = indexer.getVtxos({ scripts: ["b"] });
         await vi.advanceTimersByTimeAsync(5_000);
         expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -260,7 +261,7 @@ describe("shared cooldown across requests (herd regression)", () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         // Different provider class, same host, same limiter.
-        mockFetch.mockResolvedValue(ok({}));
+        mockFetch.mockImplementation(async () => ok({}));
         const info = ark.getInfo().catch((e) => e);
         await vi.advanceTimersByTimeAsync(2_000);
         expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -301,7 +302,9 @@ describe("shared cooldown across requests (herd regression)", () => {
     it("retries a 429 and succeeds once the cooldown lifts", async () => {
         vi.useFakeTimers();
         const indexer = new RestIndexerProvider("http://localhost:7070");
-        mockFetch.mockResolvedValueOnce(rateLimited("1")).mockResolvedValue(ok({ vtxos: [] }));
+        mockFetch
+            .mockResolvedValueOnce(rateLimited("1"))
+            .mockImplementation(async () => ok({ vtxos: [] }));
 
         const pending = indexer.getVtxos({ scripts: ["a"] });
         await vi.advanceTimersByTimeAsync(10_000);

--- a/packages/ts-sdk/test/recipient-address-binding.test.ts
+++ b/packages/ts-sdk/test/recipient-address-binding.test.ts
@@ -9,6 +9,7 @@ import {
     validateRecipients,
     type RecipientAddressContext,
 } from "../src/wallet/utils";
+import { jsonResponse } from "./helpers/response";
 
 // Mock fetch
 const { mockFetch } = vi.hoisted(() => ({
@@ -224,10 +225,7 @@ describe("Wallet recipient address binding", () => {
 
     beforeEach(() => {
         mockFetch.mockReset();
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockArkInfo),
-        });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockArkInfo));
     });
 
     it("send rejects an address from another network before spending", async () => {
@@ -261,16 +259,14 @@ describe("Wallet recipient address binding", () => {
     it("carries cached deprecated signers, cutoffs included, into the recipient context", async () => {
         const cutoff = BigInt(NOW_SECONDS + 100_000);
         mockFetch.mockReset();
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: () =>
-                Promise.resolve({
-                    ...mockArkInfo,
-                    deprecatedSigners: [
-                        { pubkey: hex.encode(DEPRECATED_XONLY), cutoffDate: cutoff.toString() },
-                    ],
-                }),
-        });
+        mockFetch.mockResolvedValueOnce(
+            jsonResponse({
+                ...mockArkInfo,
+                deprecatedSigners: [
+                    { pubkey: hex.encode(DEPRECATED_XONLY), cutoffDate: cutoff.toString() },
+                ],
+            }),
+        );
 
         const wallet = await Wallet.create({
             identity: mockIdentity,
@@ -341,10 +337,7 @@ describe("send with caller-selected vtxos", () => {
 
     beforeEach(() => {
         mockFetch.mockReset();
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockArkInfo),
-        });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockArkInfo));
     });
 
     it("rejects an empty selection instead of choosing for the caller", async () => {
@@ -479,10 +472,7 @@ describe("send argument dispatch", () => {
 
     beforeEach(() => {
         mockFetch.mockReset();
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockArkInfo),
-        });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockArkInfo));
     });
 
     it("reads a lone recipient object as a recipient, not as params", async () => {

--- a/packages/ts-sdk/test/restore.test.ts
+++ b/packages/ts-sdk/test/restore.test.ts
@@ -27,6 +27,7 @@ import {
     makeStaticWalletForTest,
     makeHdWalletForTest,
 } from "./helpers/restoreWallet";
+import { jsonResponse } from "./helpers/response";
 
 const TEST_MNEMONIC =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -1717,8 +1718,7 @@ describe("Wallet.restore", () => {
         deprecatedSigners: { cutoffDate: number; pubkey: string }[],
     ) => {
         const mockFetch = vi.fn().mockImplementation((url: string) => {
-            const reply = (body: unknown) =>
-                Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+            const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
             if (url.includes("/info"))
                 return reply({
                     signerPubkey,

--- a/packages/ts-sdk/test/serverSignerRotation.test.ts
+++ b/packages/ts-sdk/test/serverSignerRotation.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./helpers/restoreWallet";
 import { BoardingContractHandler } from "../src/contracts/handlers/boarding";
 import { CSVMultisigTapscript } from "../src/script/tapscript";
+import { jsonResponse } from "./helpers/response";
 
 const NEW_SERVER = "ab".repeat(32);
 
@@ -245,8 +246,7 @@ describe("Boarding watch path across server-signer rotation", () => {
         vi.stubGlobal(
             "fetch",
             vi.fn().mockImplementation((url: string) => {
-                const reply = (b: unknown) =>
-                    Promise.resolve({ ok: true, json: () => Promise.resolve(b) });
+                const reply = (b: unknown) => Promise.resolve(jsonResponse(b));
                 if (url.includes("/info"))
                     return reply({
                         ...mockArkInfo,
@@ -357,8 +357,7 @@ describe("Offchain baseline matrix across server-signer rotation", () => {
         vi.stubGlobal(
             "fetch",
             vi.fn().mockImplementation((url: string) => {
-                const reply = (b: unknown) =>
-                    Promise.resolve({ ok: true, json: () => Promise.resolve(b) });
+                const reply = (b: unknown) => Promise.resolve(jsonResponse(b));
                 if (url.includes("/info"))
                     return reply({
                         ...mockArkInfo,

--- a/packages/ts-sdk/test/serviceWorkerContractSecrets.test.ts
+++ b/packages/ts-sdk/test/serviceWorkerContractSecrets.test.ts
@@ -48,6 +48,7 @@ import {
     provisionClaimSecret,
     provisionRefundKey,
 } from "../src/wallet/contractSecrets";
+import { jsonResponse } from "./helpers/response";
 
 const MNEMONIC =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -84,7 +85,7 @@ beforeEach(() => {
     vi.stubGlobal("EventSource", MockEventSource);
     mockFetch.mockReset();
     mockFetch.mockImplementation((url: string) => {
-        const reply = (body: unknown) => Promise.resolve({ ok: true, json: async () => body });
+        const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
         if (url.includes("/info")) return reply(mockArkInfo);
         if (url.includes("subscribe") || url.includes("subscriptions"))
             return reply({ subscriptionId: "sub-1" });

--- a/packages/ts-sdk/test/signerRotation.test.ts
+++ b/packages/ts-sdk/test/signerRotation.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/wallet/signerRotation";
 import type { ArkInfo, DeprecatedSigner } from "../src/providers/ark";
 import { RestArkProvider } from "../src/providers/ark";
+import { jsonResponse } from "./helpers/response";
 
 const ACTIVE = "aa".repeat(32);
 const DEPRECATED_A = "bb".repeat(32);
@@ -125,12 +126,7 @@ describe("RestArkProvider.getInfo - deprecated signer parsing", () => {
     const stubInfo = (body: Record<string, unknown>) => {
         vi.stubGlobal(
             "fetch",
-            vi.fn().mockResolvedValue({
-                ok: true,
-                statusText: "OK",
-                json: () => Promise.resolve(body),
-                text: () => Promise.resolve(""),
-            }),
+            vi.fn(async () => jsonResponse(body, { statusText: "OK" })),
         );
     };
 

--- a/packages/ts-sdk/test/wallet.test.ts
+++ b/packages/ts-sdk/test/wallet.test.ts
@@ -27,6 +27,7 @@ import type { Coin, VirtualCoin } from "../src/wallet";
 import { MockEventSource } from "./mocks/eventSource";
 import { timelockToSequence } from "../src/utils/timelock";
 import { DEFAULT_ARKADE_SERVER_URL } from "../src/networks";
+import { jsonResponse, textResponse } from "./helpers/response";
 
 // Mock fetch
 const { mockFetch } = vi.hoisted(() => ({
@@ -83,10 +84,7 @@ describe("Wallet", () => {
         ];
 
         it("should calculate balance from coins", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockUTXOs),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockUTXOs));
 
             const wallet = await OnchainWallet.create(mockIdentity, "mutinynet");
 
@@ -135,44 +133,30 @@ describe("Wallet", () => {
             // fetch sequence above is unchanged.
 
             mockFetch
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () =>
-                        Promise.resolve({
-                            signerPubkey: mockServerKeyHex,
-                            forfeitPubkey: mockServerKeyHex,
-                            batchExpiry: BigInt(144),
-                            unilateralExitDelay: BigInt(144),
-                            boardingExitDelay: BigInt(144),
-                            roundInterval: BigInt(144),
-                            network: "mutinynet",
-                            forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
-                            checkpointTapscript:
-                                "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
-                        }),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve(mockUTXOs),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve({ vtxos: [] }),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve({ subscriptionId: "sub-1" }),
-                })
+                .mockResolvedValueOnce(
+                    jsonResponse({
+                        signerPubkey: mockServerKeyHex,
+                        forfeitPubkey: mockServerKeyHex,
+                        batchExpiry: BigInt(144),
+                        unilateralExitDelay: BigInt(144),
+                        boardingExitDelay: BigInt(144),
+                        roundInterval: BigInt(144),
+                        network: "mutinynet",
+                        forfeitAddress: "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+                        checkpointTapscript:
+                            "039d0440b2752079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ac",
+                    }),
+                )
+                .mockResolvedValueOnce(jsonResponse(mockUTXOs))
+                .mockResolvedValueOnce(jsonResponse({ vtxos: [] }))
+                .mockResolvedValueOnce(jsonResponse({ subscriptionId: "sub-1" }))
                 .mockImplementationOnce((url: string) => {
                     // Extract the script from the request URL so the
                     // mock response matches the wallet's actual script.
                     const params = new URLSearchParams(url.split("?")[1]);
                     const script = params.getAll("scripts")[0];
                     mockServerResponse.vtxos[0].script = script;
-                    return Promise.resolve({
-                        ok: true,
-                        json: () => Promise.resolve(mockServerResponse),
-                    });
+                    return Promise.resolve(jsonResponse(mockServerResponse));
                 });
 
             const wallet = await Wallet.create({
@@ -206,10 +190,7 @@ describe("Wallet", () => {
         ];
 
         it("should return coins from provider", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockUTXOs),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockUTXOs));
 
             const wallet = await OnchainWallet.create(mockIdentity, "mutinynet");
 
@@ -309,14 +290,8 @@ describe("Wallet", () => {
             const mockFeeRate = 3;
             const mockTxId = hex.encode(new Uint8Array(32).fill(1));
 
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockUTXOs),
-            });
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ "1": mockFeeRate }),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockUTXOs));
+            mockFetch.mockResolvedValueOnce(jsonResponse({ "1": mockFeeRate }));
 
             const wallet = await OnchainWallet.create(mockIdentity, "mutinynet");
 
@@ -341,18 +316,9 @@ describe("Wallet", () => {
         it("should send funds when change amount is below dust", async () => {
             const wallet = await OnchainWallet.create(mockIdentity, "mutinynet");
 
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockUTXOs),
-            });
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ "1": mockFeeRate }),
-            });
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                text: () => Promise.resolve(mockTxId),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockUTXOs));
+            mockFetch.mockResolvedValueOnce(jsonResponse({ "1": mockFeeRate }));
+            mockFetch.mockResolvedValueOnce(textResponse(mockTxId));
 
             expect(
                 await wallet.send({
@@ -365,18 +331,9 @@ describe("Wallet", () => {
         it("should send amount with correct fees", async () => {
             const wallet = await OnchainWallet.create(mockIdentity, "mutinynet");
 
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockUTXOs),
-            });
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ "1": mockFeeRate }),
-            });
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                text: () => Promise.resolve(mockTxId),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockUTXOs));
+            mockFetch.mockResolvedValueOnce(jsonResponse({ "1": mockFeeRate }));
+            mockFetch.mockResolvedValueOnce(textResponse(mockTxId));
 
             expect(
                 await wallet.send({
@@ -405,18 +362,9 @@ describe("Wallet", () => {
             const feeRate = 10;
 
             const mockCalls = () => {
-                mockFetch.mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve(coins),
-                });
-                mockFetch.mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve({ "1": feeRate }),
-                });
-                mockFetch.mockResolvedValueOnce({
-                    ok: true,
-                    text: () => Promise.resolve("txid_mock"),
-                });
+                mockFetch.mockResolvedValueOnce(jsonResponse(coins));
+                mockFetch.mockResolvedValueOnce(jsonResponse({ "1": feeRate }));
+                mockFetch.mockResolvedValueOnce(textResponse("txid_mock"));
             };
 
             // 1. Send to Native Segwit Address (tb1q...)
@@ -473,18 +421,9 @@ describe("Wallet", () => {
                 },
             ];
 
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(coins),
-            });
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve({ "1": feeRate }),
-            });
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                text: () => Promise.resolve("txid_mock"),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(coins));
+            mockFetch.mockResolvedValueOnce(jsonResponse({ "1": feeRate }));
+            mockFetch.mockResolvedValueOnce(textResponse("txid_mock"));
 
             await expect(
                 wallet.send({
@@ -522,14 +461,12 @@ describe("Wallet", () => {
         };
 
         it("should initialize with ark provider when configured", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () =>
-                    Promise.resolve({
-                        ...mockArkInfo,
-                        vtxoTreeExpiry: mockArkInfo.batchExpiry,
-                    }),
-            });
+            mockFetch.mockResolvedValueOnce(
+                jsonResponse({
+                    ...mockArkInfo,
+                    vtxoTreeExpiry: mockArkInfo.batchExpiry,
+                }),
+            );
 
             const wallet = await Wallet.create({
                 identity: mockIdentity,
@@ -544,10 +481,7 @@ describe("Wallet", () => {
         });
 
         it("should return intentFee config as strings", async () => {
-            mockFetch.mockResolvedValueOnce({
-                ok: true,
-                json: () => Promise.resolve(mockArkInfo),
-            });
+            mockFetch.mockResolvedValueOnce(jsonResponse(mockArkInfo));
 
             const provider = new RestArkProvider("http://localhost:7070");
             const info = await provider.getInfo();
@@ -578,14 +512,8 @@ describe("Wallet", () => {
 
         it("should convert Wallet to ReadonlyWallet", async () => {
             mockFetch
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve(mockArkInfo),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve({ vtxos: [] }),
-                });
+                .mockResolvedValueOnce(jsonResponse(mockArkInfo))
+                .mockResolvedValueOnce(jsonResponse({ vtxos: [] }));
 
             const wallet = await Wallet.create({
                 identity: mockIdentity,
@@ -611,14 +539,8 @@ describe("Wallet", () => {
 
         it("should not have sendBitcoin method on ReadonlyWallet type", async () => {
             mockFetch
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve(mockArkInfo),
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () => Promise.resolve({ vtxos: [] }),
-                });
+                .mockResolvedValueOnce(jsonResponse(mockArkInfo))
+                .mockResolvedValueOnce(jsonResponse({ vtxos: [] }));
 
             const wallet = await Wallet.create({
                 identity: mockIdentity,
@@ -657,34 +579,18 @@ describe("Wallet", () => {
             // and the background VtxoManager init doesn't matter.
             mockFetch.mockImplementation((url: string) => {
                 if (url.includes("/v1/info")) {
-                    return Promise.resolve({
-                        ok: true,
-                        json: () => Promise.resolve(mockArkInfo),
-                    });
+                    return Promise.resolve(jsonResponse(mockArkInfo));
                 }
                 if (url.includes("/script/subscribe")) {
-                    return Promise.resolve({
-                        ok: true,
-                        json: () => Promise.resolve({ subscriptionId: "sub-1" }),
-                    });
+                    return Promise.resolve(jsonResponse({ subscriptionId: "sub-1" }));
                 }
                 if (url.includes("/address/") && url.includes("/utxo")) {
-                    return Promise.resolve({
-                        ok: true,
-                        json: () => Promise.resolve(mockUTXOs),
-                    });
+                    return Promise.resolve(jsonResponse(mockUTXOs));
                 }
                 if (url.includes("/vtxos")) {
-                    return Promise.resolve({
-                        ok: true,
-                        json: () => Promise.resolve({ vtxos: [] }),
-                    });
+                    return Promise.resolve(jsonResponse({ vtxos: [] }));
                 }
-                return Promise.resolve({
-                    ok: true,
-                    json: () => Promise.resolve({}),
-                    text: () => Promise.resolve(""),
-                });
+                return Promise.resolve(jsonResponse({}));
             });
 
             const wallet = await Wallet.create({
@@ -1568,10 +1474,7 @@ describe("ReadonlyWallet", () => {
         // Create readonly identity
         const readonlyIdentity = ReadonlySingleKey.fromPublicKey(compressedPubKey);
 
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockArkInfo),
-        });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockArkInfo));
 
         const readonlyWallet = await ReadonlyWallet.create({
             identity: readonlyIdentity,
@@ -1593,10 +1496,7 @@ describe("ReadonlyWallet", () => {
         const compressedPubKey = await key.compressedPublicKey();
         const readonlyIdentity = ReadonlySingleKey.fromPublicKey(compressedPubKey);
 
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockArkInfo),
-        });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockArkInfo));
 
         const readonlyWallet = await ReadonlyWallet.create({
             identity: readonlyIdentity,
@@ -1636,34 +1536,18 @@ describe("ReadonlyWallet", () => {
         // Route by URL to keep ordering assumptions out of the test.
         mockFetch.mockImplementation((url: string) => {
             if (url.includes("/v1/info")) {
-                return Promise.resolve({
-                    ok: true,
-                    json: () => Promise.resolve(mockArkInfo),
-                });
+                return Promise.resolve(jsonResponse(mockArkInfo));
             }
             if (url.includes("/script/subscribe")) {
-                return Promise.resolve({
-                    ok: true,
-                    json: () => Promise.resolve({ subscriptionId: "sub-1" }),
-                });
+                return Promise.resolve(jsonResponse({ subscriptionId: "sub-1" }));
             }
             if (url.includes("/address/") && url.includes("/utxo")) {
-                return Promise.resolve({
-                    ok: true,
-                    json: () => Promise.resolve(mockUTXOs),
-                });
+                return Promise.resolve(jsonResponse(mockUTXOs));
             }
             if (url.includes("/vtxos")) {
-                return Promise.resolve({
-                    ok: true,
-                    json: () => Promise.resolve({ vtxos: [] }),
-                });
+                return Promise.resolve(jsonResponse({ vtxos: [] }));
             }
-            return Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve({}),
-                text: () => Promise.resolve(""),
-            });
+            return Promise.resolve(jsonResponse({}));
         });
 
         const readonlyWallet = await ReadonlyWallet.create({
@@ -1683,10 +1567,7 @@ describe("ReadonlyWallet", () => {
         const compressedPubKey = await key.compressedPublicKey();
         const readonlyIdentity = ReadonlySingleKey.fromPublicKey(compressedPubKey);
 
-        mockFetch.mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve(mockArkInfo),
-        });
+        mockFetch.mockResolvedValueOnce(jsonResponse(mockArkInfo));
 
         const readonlyWallet = await ReadonlyWallet.create({
             identity: readonlyIdentity,

--- a/packages/ts-sdk/test/wallet/unsignableBoardingInput.test.ts
+++ b/packages/ts-sdk/test/wallet/unsignableBoardingInput.test.ts
@@ -6,6 +6,7 @@ import {
     InMemoryWalletRepository,
     InMemoryContractRepository,
 } from "../../src";
+import { jsonResponse } from "../helpers/response";
 
 const MNEMONIC =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -43,8 +44,7 @@ beforeEach(() => {
     vi.stubGlobal("EventSource", MockEventSource);
     mockFetch.mockReset();
     mockFetch.mockImplementation((url: string) => {
-        const reply = (body: unknown) =>
-            Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+        const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
         if (url.includes("/info")) return reply(mockArkInfo);
         if (url.includes("subscribe") || url.includes("subscriptions"))
             return reply({ subscriptionId: "sub-1" });

--- a/packages/ts-sdk/test/walletBoardingRotation.test.ts
+++ b/packages/ts-sdk/test/walletBoardingRotation.test.ts
@@ -7,6 +7,7 @@ import {
     InMemoryContractRepository,
     toXOnlySignerHex,
 } from "../src";
+import { jsonResponse } from "./helpers/response";
 
 /**
  * Per-derivation boarding rotation (plan §6-II).
@@ -61,8 +62,7 @@ beforeEach(() => {
     vi.stubGlobal("EventSource", MockEventSource);
     mockFetch.mockReset();
     mockFetch.mockImplementation((url: string) => {
-        const reply = (body: unknown) =>
-            Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+        const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
         if (url.includes("/info")) return reply(mockArkInfo);
         if (url.includes("subscribe") || url.includes("subscriptions"))
             return reply({ subscriptionId: "sub-1" });

--- a/packages/ts-sdk/test/walletBoardingTxs.test.ts
+++ b/packages/ts-sdk/test/walletBoardingTxs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Wallet, SingleKey, InMemoryWalletRepository, InMemoryContractRepository } from "../src";
+import { jsonResponse } from "./helpers/response";
 
 /**
  * Regression for the arkade.money phantom-receive inflation (boarding sweeps).
@@ -74,8 +75,7 @@ describe("getBoardingTxs — sweep correlation without outspend txid", () => {
         };
 
         mockFetch.mockImplementation((url: string) => {
-            const reply = (body: unknown) =>
-                Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+            const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
             if (url.includes("/info")) return reply(mockArkInfo);
             if (url.includes("subscribe") || url.includes("subscriptions"))
                 return reply({ subscriptionId: "sub-1" });

--- a/packages/ts-sdk/test/walletHdRotation.test.ts
+++ b/packages/ts-sdk/test/walletHdRotation.test.ts
@@ -18,6 +18,7 @@ import {
 import { HDDescriptorProvider } from "../src/wallet/hdDescriptorProvider";
 import { WalletReceiveRotator } from "../src/wallet/walletReceiveRotator";
 import type { Contract, ContractEvent, ExtendedVirtualCoin } from "../src";
+import { jsonResponse } from "./helpers/response";
 
 /**
  * Hand-crafted integration tests for HD receive rotation against the
@@ -68,11 +69,7 @@ beforeEach(() => {
     mockFetch.mockReset();
     // Route by URL so test ordering doesn't depend on exact fetch counts.
     mockFetch.mockImplementation((url: string) => {
-        const reply = (body: unknown) =>
-            Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve(body),
-            });
+        const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
         if (url.includes("/info")) return reply(mockArkInfo);
         if (url.includes("subscribe") || url.includes("subscriptions"))
             return reply({ subscriptionId: "sub-1" });

--- a/packages/ts-sdk/test/walletNewAddresses.test.ts
+++ b/packages/ts-sdk/test/walletNewAddresses.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/wallet/serviceWorker/wallet-message-handler";
 import { ExpoWallet } from "../src/wallet/expo/wallet";
 import { ServiceWorkerWallet } from "../src/wallet/serviceWorker/wallet";
+import { jsonResponse } from "./helpers/response";
 
 /**
  * The explicit multi-type address allocator (`getNewAddresses`).
@@ -68,8 +69,7 @@ beforeEach(() => {
     vi.stubGlobal("EventSource", MockEventSource);
     mockFetch.mockReset();
     mockFetch.mockImplementation((url: string) => {
-        const reply = (body: unknown) =>
-            Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+        const reply = (body: unknown) => Promise.resolve(jsonResponse(body));
         if (url.includes("/info")) return reply(mockArkInfo);
         if (url.includes("subscribe") || url.includes("subscriptions"))
             return reply({ subscriptionId: "sub-1" });


### PR DESCRIPTION
Closes #875.

## The shape

The provider tests mocked the fetch boundary with object literals:

```js
mockFetch.mockResolvedValueOnce({
    ok: true,
    json: () => Promise.resolve({ vtxos: [] }),
});
```

81 of these across 25 files — 79 in the top-level provider tests the issue names, plus one each in `test/helpers/restoreWallet.ts` and `test/wallet/unsignableBoardingInput.test.ts`. A double with two members answers only the two its own call site reads, so production code could not reach for a third — `clone()`, `arrayBuffer()`, `headers` — without breaking two dozen files at once. That is why in-flight coalescing of identical indexer reads (#876) had to go in at a seam chosen by the test doubles rather than by the design: coalescing needs to give each waiter its own body, and neither `clone()` nor `arrayBuffer()` existed on the mocks.

`indexerFetch` already calls `res.clone().text()` on the non-ok path, so the mocks were only viable because most tests never take that branch.

## The change

`test/helpers/response.ts` builds a real `Response`:

```ts
export const jsonResponse = (body: unknown, init?: ResponseInit): Response =>
    new Response(JSON.stringify(body, wireSafe), {
        status: 200,
        headers: { "content-type": "application/json" },
        ...init,
    });
```

plus `textResponse` for the plain-text endpoints. Every `ok: true` literal now goes through one of them. `Response` is global in every runtime the SDK targets and the production code already calls `res.json()`, so this needs no polyfill.

`test/jsonResponse.test.ts` pins what the helper is for: `instanceof Response`, `clone()`, `arrayBuffer()`, a second body read rejecting, and `init` overriding the defaults.

## Two things the fakes were hiding

Both are fixed here rather than papered over, and both are exactly the failure mode the issue describes — a mock more permissive than the real thing does not merely fail to catch bugs, it makes tests green on behaviour the real object refuses.

**A single `Response` handed to every call.** `mockResolvedValue(oneResponse)` is not what a fetch does: a real body can be read once. Seven tests in `esplora-watch-addresses` and one in `rate-gate` failed on the first migration with `Body is unusable: Body has already been read` — their poll loops had been re-reading one body indefinitely, and with a real `Response` the loop dies on cycle two. 28 sites now build a fresh response per call (`mockImplementation(async () => ...)`), and the three `deferred` fetches were restructured to gate on a `deferred<void>` and construct their own response, which preserves "this fetch is suspended" without sharing a body.

**`BigInt` in a JSON body.** `mockArkInfo` carried `batchExpiry: BigInt(144)`, which `JSON.stringify` refuses and no HTTP response can contain. The helper serializes bigint as a decimal string — which is what grpc-gateway puts on the wire for int64, and what `getInfo()` already parses back with `BigInt(fromServer.batchExpiry ?? 0)`. So the fixtures are now closer to the wire, not further from it.

## Deliberately out of scope

The 21 `ok: false` doubles. They are fault injection rather than ordinary responses, and at least one of them cannot be a real `Response` at all: `arkProviderDigest.test.ts` returns a `clone()` whose `text()` throws mid-body. Worth its own pass; mixing it in would have made this one unreviewable.

Also untouched: three `{ ok: true }` literals under `test/worker/` and `test/repositories/` that are message payloads, not fetch responses.

## Gate

Run manually — the pre-commit hook selects no projects in a worktree (#872), which is visible in this branch's own commit output.

`pnpm -r build`, then `pnpm -r test:unit`:

| | Test files | Tests |
|---|---|---|
| `origin/master` baseline | ts-sdk 179, swap 33, boltz-swap 23 | 2997 + 1 skipped / 810 / 617 |
| this branch | ts-sdk 180, swap 33, boltz-swap 23 | 3001 + 1 skipped / 810 / 617 |

Delta is `+1` file and `+4` tests, all of them `test/jsonResponse.test.ts`. Zero failures either side, no type errors. `pnpm --filter=@arkade-os/sdk lint` and `biome format config` both clean.

Net `-103` lines: 269 insertions against 372 deletions.
