### PR TITLE
perf(contracts): let an embedder set a staleness budget for the pre-send sync

### DIFF
--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -2224,6 +2224,11 @@ export class ContractManager implements IContractManager {
                     // is monotonic so this never rewinds the cursor. The refill
                     // first, so catch-up-pending window entries retry their
                     // full-history sync without waiting for a restart.
+                    //
+                    // Freshness is dropped before that, not after: it is a claim
+                    // that events were arriving, and a reset says they were not
+                    // for an unknown stretch. The reconcile below re-earns it.
+                    this.syncedAtByScript.clear();
                     await this.scheduleLookAheadDrain();
                     await this.reconcileWatched();
                     this.markSyncOnline();

--- a/packages/ts-sdk/src/contracts/contractManager.ts
+++ b/packages/ts-sdk/src/contracts/contractManager.ts
@@ -690,6 +690,15 @@ export interface ContractManagerConfig {
      * and a path query is not worth failing over a provider hiccup.
      */
     chainTip?: () => Promise<{ height: number; time: number } | undefined>;
+
+    /**
+     * How stale {@link ContractManager.getContractsWithVtxos} may let its
+     * opportunistic sync be before repeating it. `0` (default) repeats it every
+     * call. A send syncs, selects, then submits, so its coins are already one
+     * submit latency stale; this widens that bound by this value, and is
+     * therefore a budget rather than a free saving.
+     */
+    vtxoSyncMaxAgeMs?: number;
 }
 
 /**
@@ -801,6 +810,7 @@ export class ContractManager implements IContractManager {
     private syncDegradedReason?: string;
     /** Epoch-ms of the last successful provider sync, if any. */
     private lastSyncedAt?: number;
+    private syncedAtByScript = new Map<string, number>();
     /** Last chain tip read, with the epoch-ms it was read at. @see currentChainTip */
     private chainTipCache?: { height: number; time: number; at: number };
     /** In-flight chain tip read, so concurrent cache misses share one. */
@@ -860,6 +870,11 @@ export class ContractManager implements IContractManager {
                   reason: this.syncDegradedReason,
                   lastSyncedAt: this.lastSyncedAt,
               };
+    }
+
+    /** @see ContractManagerConfig.vtxoSyncMaxAgeMs — for factory-built managers. */
+    setVtxoSyncMaxAge(maxAgeMs: number): void {
+        this.config.vtxoSyncMaxAgeMs = maxAgeMs;
     }
 
     private markSyncOnline(): void {
@@ -1645,12 +1660,19 @@ export class ContractManager implements IContractManager {
         // failure, serve repository state rather than failing the read. The
         // failed sync writes no partial state and does not advance the cursor
         // (targeted subset queries never do). Terminal failures still propagate.
-        try {
-            await this.syncContracts({ contracts, pageSize });
-            this.markSyncOnline();
-        } catch (err) {
-            if (!isRetryableProviderError(err)) throw err;
-            this.markSyncDegraded(err);
+        if (this.syncedWithin(contracts, this.config.vtxoSyncMaxAgeMs ?? 0)) {
+            // Skipping the fetch must not skip the demotion it carries: that
+            // half is repository-only, and an `awaiting-funds` contract left
+            // undemoted keeps a watch it no longer needs.
+            await this.demoteFundedAwaitingContracts(contracts);
+        } else {
+            try {
+                await this.syncContracts({ contracts, pageSize });
+                this.markSyncOnline();
+            } catch (err) {
+                if (!isRetryableProviderError(err)) throw err;
+                this.markSyncDegraded(err);
+            }
         }
         const vtxos = await this.getVtxosForContracts(contracts);
         return contracts.map((contract) => ({
@@ -2282,9 +2304,25 @@ export class ContractManager implements IContractManager {
             await advanceSyncCursor(this.config.walletRepository, cutoff);
         }
 
+        // A narrowed window saw less than a normal sync would have, so claiming
+        // freshness from it would let a later read skip on evidence never held.
+        if (options.window === undefined) {
+            for (const contract of contracts) {
+                this.syncedAtByScript.set(contract.script, requestStartedAt);
+            }
+        }
+
         await this.demoteFundedAwaitingContracts(contracts);
 
         return result;
+    }
+
+    private syncedWithin(contracts: Contract[], maxAgeMs: number): boolean {
+        if (maxAgeMs <= 0) return false;
+        const floor = Date.now() - maxAgeMs;
+        return contracts.every(
+            (contract) => (this.syncedAtByScript.get(contract.script) ?? 0) >= floor,
+        );
     }
 
     /**

--- a/packages/ts-sdk/test/contract-manager-sync-ttl.test.ts
+++ b/packages/ts-sdk/test/contract-manager-sync-ttl.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    ContractManager,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    type IndexerProvider,
+} from "../src";
+import type { Contract } from "../src/contracts";
+import {
+    createMockIndexerProvider,
+    createDefaultContractParams,
+    TEST_DEFAULT_SCRIPT,
+    TEST_DELEGATE_SCRIPT,
+} from "./contracts/helpers";
+
+const watcherConfig = { failsafePollIntervalMs: 1_000_000, reconnectDelayMs: 1_000_000 };
+
+describe("ContractManager vtxoSyncMaxAgeMs", () => {
+    const managers: ContractManager[] = [];
+    const track = (m: ContractManager) => {
+        managers.push(m);
+        return m;
+    };
+
+    afterEach(async () => {
+        while (managers.length) await managers.pop()!.dispose();
+    });
+
+    const seeded = (script: string, address: string): Contract => ({
+        type: "default",
+        params: createDefaultContractParams(),
+        script,
+        address,
+        state: "active",
+        createdAt: 1,
+    });
+
+    const setup = async (vtxoSyncMaxAgeMs?: number) => {
+        const contractRepository = new InMemoryContractRepository();
+        const walletRepository = new InMemoryWalletRepository();
+        await contractRepository.saveContract(seeded(TEST_DEFAULT_SCRIPT, "addr"));
+        const indexer: IndexerProvider = createMockIndexerProvider();
+        const manager = await ContractManager.create({
+            indexerProvider: indexer,
+            contractRepository,
+            walletRepository,
+            watcherConfig,
+            vtxoSyncMaxAgeMs,
+        }).then(track);
+        return { manager, indexer, contractRepository, walletRepository };
+    };
+
+    const reads = (indexer: IndexerProvider) => (indexer.getVtxos as any).mock.calls.length;
+
+    it("without a budget, every read syncs — unchanged behaviour", async () => {
+        const { manager, indexer } = await setup();
+        (indexer.getVtxos as any).mockClear();
+
+        await manager.getContractsWithVtxos();
+        const afterFirst = reads(indexer);
+        await manager.getContractsWithVtxos();
+
+        expect(afterFirst).toBeGreaterThan(0);
+        expect(reads(indexer)).toBeGreaterThan(afterFirst);
+    });
+
+    it("an explicit 0 budget is the same as none", async () => {
+        const { manager, indexer } = await setup(0);
+        (indexer.getVtxos as any).mockClear();
+
+        await manager.getContractsWithVtxos();
+        const afterFirst = reads(indexer);
+        await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBeGreaterThan(afterFirst);
+    });
+
+    it("within the budget, a repeated read serves the repository without a round trip", async () => {
+        const { manager, indexer } = await setup(60_000);
+        await manager.getContractsWithVtxos();
+        (indexer.getVtxos as any).mockClear();
+
+        const result = await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBe(0);
+        expect(result).toHaveLength(1);
+    });
+
+    it("past the budget, the read syncs again", async () => {
+        const { manager, indexer } = await setup(1);
+        await manager.getContractsWithVtxos();
+        (indexer.getVtxos as any).mockClear();
+        await new Promise((r) => setTimeout(r, 5));
+
+        await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBeGreaterThan(0);
+    });
+
+    it("a contract the last sync did not cover is never fresh", async () => {
+        const { manager, indexer, contractRepository } = await setup(60_000);
+        await manager.getContractsWithVtxos();
+        // Registered behind the manager's back, so no sync has ever covered it.
+        await contractRepository.saveContract(seeded(TEST_DELEGATE_SCRIPT, "addr2"));
+        (indexer.getVtxos as any).mockClear();
+
+        const result = await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBeGreaterThan(0);
+        expect(result).toHaveLength(2);
+    });
+
+    it("a narrowed-window sync confers no freshness", async () => {
+        const { manager, indexer } = await setup(50);
+        await manager.getContractsWithVtxos();
+        await new Promise((r) => setTimeout(r, 60));
+
+        // Had this refreshed the budget, the read below would skip.
+        await manager.refreshVtxos({ after: Date.now() - 1000 });
+        (indexer.getVtxos as any).mockClear();
+
+        await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBeGreaterThan(0);
+    });
+
+    it("a full-window refresh does confer freshness — the contrast", async () => {
+        const { manager, indexer } = await setup(50);
+        await manager.getContractsWithVtxos();
+        await new Promise((r) => setTimeout(r, 60));
+
+        await manager.refreshVtxos();
+        (indexer.getVtxos as any).mockClear();
+
+        await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBe(0);
+    });
+
+    it("setVtxoSyncMaxAge turns the budget on for a manager built without one", async () => {
+        const { manager, indexer } = await setup();
+        await manager.getContractsWithVtxos();
+
+        manager.setVtxoSyncMaxAge(60_000);
+        await manager.getContractsWithVtxos();
+        (indexer.getVtxos as any).mockClear();
+        await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBe(0);
+    });
+});

--- a/packages/ts-sdk/test/contract-manager-sync-ttl.test.ts
+++ b/packages/ts-sdk/test/contract-manager-sync-ttl.test.ts
@@ -3,6 +3,7 @@ import {
     ContractManager,
     InMemoryContractRepository,
     InMemoryWalletRepository,
+    ProviderUnavailableError,
     type IndexerProvider,
 } from "../src";
 import type { Contract } from "../src/contracts";
@@ -130,6 +131,38 @@ describe("ContractManager vtxoSyncMaxAgeMs", () => {
         await new Promise((r) => setTimeout(r, 60));
 
         await manager.refreshVtxos();
+        (indexer.getVtxos as any).mockClear();
+
+        await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBe(0);
+    });
+
+    it("a connection reset whose recovery fails leaves nothing fresh", async () => {
+        const { manager, indexer } = await setup(60_000);
+        await manager.getContractsWithVtxos();
+
+        (indexer.getVtxos as any).mockRejectedValue(new ProviderUnavailableError("down"));
+        await (manager as any).handleContractEvent({
+            type: "connection_reset",
+            timestamp: Date.now(),
+        });
+
+        (indexer.getVtxos as any).mockResolvedValue({ vtxos: [] });
+        (indexer.getVtxos as any).mockClear();
+        await manager.getContractsWithVtxos();
+
+        expect(reads(indexer)).toBeGreaterThan(0);
+    });
+
+    it("a connection reset that recovers re-earns freshness, so the drop is not a penalty", async () => {
+        const { manager, indexer } = await setup(60_000);
+        await manager.getContractsWithVtxos();
+
+        await (manager as any).handleContractEvent({
+            type: "connection_reset",
+            timestamp: Date.now(),
+        });
         (indexer.getVtxos as any).mockClear();
 
         await manager.getContractsWithVtxos();


### PR DESCRIPTION
`getContractsWithVtxos` syncs against the indexer on every call, so every spend carries one `GET /v1/indexer/vtxos` on its critical path before it has selected anything. This adds an opt-in staleness budget so an embedder that has already synced does not pay for a second identical round trip.

**Default is `0`, which is byte-for-byte today's behaviour.** Nothing changes for any existing caller.

## What the request costs

Measured from Node against `mutinynet.arkade.sh` and a local regtest `arkd`, same SDK, n=4:

| | mutinynet | local regtest |
|---|---|---|
| HTTP calls issued | 1 | 1 |
| time to headers | 509–585 ms | 6 ms |
| body | 223–517 ms | 1 ms |
| client CPU (event-loop active) | 7–21 ms | 7–11 ms |
| **total** | **758–1,100 ms** (p50 830) | **12–15 ms** |

The client is not doing anything expensive — the whole phase costs 7–21 ms of CPU. The cost is the origin, which is filed separately as arkade-os/arkd#1187 and is not addressable from here. The only lever the SDK has is to not make the request when it does not need to.

## Measured effect

Toggling only the budget, with a prefetch standing in for what a send screen would do on mount:

| | local regtest | mutinynet |
|---|---|---|
| budget `0` (today) | p50 58 ms, **1 vtxo read/send** | p50 3,407 ms, **1 read/send** |
| budget set + prefetch | p50 45 ms, **0 vtxo reads/send** | p50 917 ms, **0 reads/send** |

**The claim this supports is the read count: 1 → 0.** The pre-send sync leaves the tap window entirely.

I am deliberately **not** quoting the 2,491 ms p50 difference that table implies. At n=8 the mutinynet arm contains a 15,294 ms draw and the spread swamps the effect; that number is variance, not signal. The defensible figure is the independently measured cost of the removed request, **~830 ms p50** — and **12 ms locally**, because when the server is fast there is nothing to save. This is a latency-amplification fix, not an efficiency one.

## Why this is a budget and not a free saving

The read already returns data that is not current when its caller acts on it. A send syncs, selects, and only then submits, so the coin set it spends is one submit latency stale however fresh the fetch was. The budget widens that bound by its own value rather than introducing staleness where there was none — but it does widen it, which is why the default is off and the number belongs to the embedder.

## Freshness is revoked by the transport, not only by the clock

The budget stands in for "events were arriving". A wall clock is a weaker thing than that property, so a `connection_reset` now clears the freshness map before the recovery runs. `reconcileWatched()` re-earns it on success; when it fails retryably, nothing is fresh and the next read syncs. Both directions are tested.

That narrows the exposure to a **silent** stall only — the detected-drop class is gone, and freshness is now aligned with a signal the manager already acts on.

## The remaining gap, stated rather than glossed

I expected the watcher's failsafe poll (`failsafePollIntervalMs: 20_000`, started unconditionally at `contractWatcher.ts:412`) to bound the budget independently. **It does not, and the code says so.**

`pollAllContracts` has two arms. The contract arm calls `getContractVtxos`, which reads `getVtxosForContract(repo, ...)` — the **wallet repository** (`contractWatcher.ts:358-392`). It is a local diff against the watcher's in-memory `lastKnownVtxos` that re-emits events; it makes no network call. Only `pollWatchedScripts` reaches the indexer, and it is scoped to raw `watchedScripts` entries that are explicitly *not* watched contracts.

So for the wallet's own contracts the repository is kept current by the SSE subscription and by this sync — the one the budget skips. After the change above, what remains is the case where the subscription stops delivering **without** surfacing an error.

That case is currently undetectable: the indexer SSE carries no heartbeat, so there is no signal a consumer could key on. That is not fixable from here and is filed as arkade-os/arkd#1188.

Not done, deliberately: a permanently-unavailable EventSource (`reportEventSourceUnavailable`) is only a private `eventSourceReported` flag on the watcher with no accessor, so honouring it would mean opening the watcher's boundary. That is a larger change than this one and is left out on purpose — happy to do it as a follow-up if a reviewer would rather have it here.

## Scope

Two invariants the skip must not lose, both covered:

- Freshness is recorded **only for the cursor-derived window**. A caller that narrowed the window saw less than a normal sync would have, so claiming freshness from it would let a later read skip on evidence it never held.
- The skip path still runs `demoteFundedAwaitingContracts`. That half is repository-only and costs no round trip, and a contract left `awaiting-funds` keeps a watch it no longer needs.

## This is a mechanism with no reachable consumer yet — two independent blockers

Landing it is still worth it: the default is `0`, nothing changes for anyone, and the other work builds on it. But nobody can adopt it today, for two unrelated reasons, and both have to clear first.

**Blocker 1 — it is not reachable from the browser wallet.** `setVtxoSyncMaxAge` lives on the concrete `ContractManager`. `Wallet.getContractManager()` returns that, but `IWallet.getContractManager()` returns `IContractManager` (`wallet/index.ts:1209`) and so does `ServiceWorkerWallet.getContractManager()` (`serviceWorker/wallet.ts:1207`) — a `postMessage` proxy object that does not carry the setter. So the intended consumer **cannot set a budget from the page side at all.** Adoption means either setting it worker-side, where the concrete `Wallet` lives, or adding a `SET_VTXO_SYNC_MAX_AGE` message to the worker protocol. I have not grown the protocol for a consumer that should not adopt yet. (Found by `arkana-ai-bot` in review; I had missed it.)

**Blocker 2 — the safety argument cannot be verified.** The budget's residual exposure is a silent SSE stall, and the indexer subscription carries no heartbeat, so a stall is currently undetectable by any consumer (arkade-os/arkd#1188). Separately, adopting a budget removes the every-send sync that today self-heals a missed VTXO transition, which is what makes arkade-os/ts-sdk#885 persistent rather than transient.

So: land the mechanism, leave the budget at `0`, and revisit adoption when #1188 and #885 are answered and the reachability question above is decided.

## Test plan

Baseline recorded on clean `master` before the change, and diffed:

| | files | tests | failed |
|---|---|---|---|
| baseline | 179 | 2997 passed, 1 skipped | 0 |
| with change | 180 | 3007 passed, 1 skipped | 0 |

+1 file, +10 tests — exactly the 10 added. `tsc --noEmit` clean, `biome format` clean.

Mutation-tested, because a green suite does not prove a test bites:

- disable the budget check → the 3 skip assertions fail
- let a narrowed window confer freshness → the isolating test fails, alone
- stop clearing freshness on `connection_reset` → the failed-recovery test fails, alone

One of these tests failed on first run and **the test was wrong, not the code** — it re-recorded freshness before asserting, so it never isolated what it claimed. Rewritten, with a contrast case asserting that a *full*-window refresh does confer freshness.

Note for reviewers: this repo's pre-commit hook printed `No projects matched the filters` and ran nothing (arkade-os/ts-sdk#872). The gate above was run manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable freshness intervals for contract VTXO synchronization.
  - Recently synchronized contracts can now be read without repeating provider synchronization until the configured interval expires.
  - Added the ability to update the freshness interval at runtime.
  - Synchronization freshness is restored after successful connection recovery and cleared when recovery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->