### PR TITLE
fix(providers): bound reads with a deadline so the retries above them can run

### DIFF
--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -538,7 +538,7 @@ import type {
 import type { ScanResult, ScanContractsOptions, HandlerError } from "./contracts/contractManager";
 import { timelockToSequence, sequenceToTimelock } from "./utils/timelock";
 import { toXOnly } from "./utils/keys";
-import { buildVersion, sdkVersion, FetchError } from "./utils/fetch";
+import { buildVersion, sdkVersion, FetchError, READ_TIMEOUT_MS } from "./utils/fetch";
 import {
     closeDatabase,
     openDatabase,
@@ -638,6 +638,7 @@ export {
     CachingArkProvider,
     DigestMismatchError,
     FetchError,
+    READ_TIMEOUT_MS,
     RestIndexerProvider,
     RestEmulatorProvider,
     DEFAULT_VTXO_PAGE_SIZE,

--- a/packages/ts-sdk/src/providers/expoUtils.ts
+++ b/packages/ts-sdk/src/providers/expoUtils.ts
@@ -61,6 +61,9 @@ export async function* sseStreamIterator<T>(
                 Accept: "text/event-stream",
                 ...headers,
             },
+            // Required, not just for cancellation: `getExpoFetch` falls back to
+            // `baseFetch`, which bounds any read that brings no signal of its
+            // own. Drop this and the stream is truncated at READ_TIMEOUT_MS.
             signal: fetchController.signal,
         });
 

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -65,8 +65,14 @@ function readDeadline(input: RequestInfo | URL, init?: RequestInit): AbortSignal
  * preflight.
  *
  * Reads without a caller-supplied signal are bounded by {@link READ_TIMEOUT_MS}.
- * Long-lived streams do not come through here — they are `EventSource` — so the
- * deadline cannot truncate a subscription.
+ *
+ * **A long-lived request opts out by supplying its own signal — that is the only
+ * thing keeping this deadline off a stream.** On web, SSE happens to use
+ * `EventSource` and never arrives here at all; on Expo it does arrive here
+ * whenever `expo/fetch` fails to import and `getExpoFetch` falls back to this
+ * module, and `sseStreamIterator` passing `signal: fetchController.signal` is
+ * what prevents a 30-second truncation. That signal is load-bearing, not
+ * incidental: a streaming caller that omits one gets cut off here.
  *
  * Transport-level rejections are re-thrown as a {@link FetchError}.
  */

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -27,10 +27,46 @@ export class FetchError extends Error {
 }
 
 /**
+ * Deadline applied to a read that carries no `AbortSignal` of its own.
+ *
+ * `fetch` has no default timeout, so a connection the network dropped silently
+ * stays pending until the runtime gives up — and every bound built on top of it
+ * waits with it. A retry ladder, a bounded queue or a mutex only work if the
+ * call underneath them terminates.
+ */
+export const READ_TIMEOUT_MS = 30_000;
+
+/**
+ * A deadline for this request, or `undefined` to leave it unbounded.
+ *
+ * Only GET and HEAD get one. A write that is aborted has not necessarily failed
+ * — its outcome is unknown — so bounding one converts a stall into a state
+ * question its caller may have no way to answer.
+ *
+ * A `Request` input is always left alone. Every `Request` carries a `signal`
+ * whether or not its author supplied one, so "did the caller bring a signal?"
+ * cannot be read back off it, and guessing wrong would cancel someone's
+ * lifetime for them.
+ */
+function readDeadline(input: RequestInfo | URL, init?: RequestInit): AbortSignal | undefined {
+    if (init?.signal || input instanceof Request) return undefined;
+    const { method } = describeRequest(input, init);
+    const verb = method.toUpperCase();
+    if (verb !== "GET" && verb !== "HEAD") return undefined;
+    return typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+        ? AbortSignal.timeout(READ_TIMEOUT_MS)
+        : undefined;
+}
+
+/**
  * Guarded passthrough to the platform `fetch` with no Arkade-specific headers.
  * Use for any service that is NOT the Ark server (delegate, Esplora, …): those
  * origins reject unknown request headers such as `X-Build-Version` in the CORS
  * preflight.
+ *
+ * Reads without a caller-supplied signal are bounded by {@link READ_TIMEOUT_MS}.
+ * Long-lived streams do not come through here — they are `EventSource` — so the
+ * deadline cannot truncate a subscription.
  *
  * Transport-level rejections are re-thrown as a {@link FetchError}.
  */
@@ -38,7 +74,8 @@ export function baseFetch(input: RequestInfo | URL, init?: RequestInit): Promise
     if (typeof globalThis.fetch !== "function") {
         throw new Error("Fetch API is not available in this environment.");
     }
-    return globalThis.fetch(input, init).catch((cause) => {
+    const signal = readDeadline(input, init);
+    return globalThis.fetch(input, signal ? { ...init, signal } : init).catch((cause) => {
         const { url, method } = describeRequest(input, init);
         throw new FetchError(`Network request failed: ${method} ${url}`, { url, method, cause });
     });

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -36,8 +36,10 @@ export class FetchError extends Error {
  */
 export const READ_TIMEOUT_MS = 30_000;
 
+let warnedNoTimeoutSupport = false;
+
 /**
- * A deadline for this request, or `undefined` to leave it unbounded.
+ * The signal bounding this request, or `undefined` to leave it unbounded.
  *
  * Only GET and HEAD get one. A write that is aborted has not necessarily failed
  * — its outcome is unknown — so bounding one converts a stall into a state
@@ -53,9 +55,31 @@ function readDeadline(input: RequestInfo | URL, init?: RequestInit): AbortSignal
     const { method } = describeRequest(input, init);
     const verb = method.toUpperCase();
     if (verb !== "GET" && verb !== "HEAD") return undefined;
-    return typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
-        ? AbortSignal.timeout(READ_TIMEOUT_MS)
-        : undefined;
+    if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
+        return AbortSignal.timeout(READ_TIMEOUT_MS);
+    }
+
+    // `AbortSignal.timeout` is absent on some React Native runtimes while
+    // `AbortController` is not, so fall back rather than silently leaving the
+    // read unbounded — which is the exact state this exists to prevent.
+    if (typeof AbortController === "function") {
+        const controller = new AbortController();
+        // Deliberately never cleared, so the bound covers the body read and not
+        // just the headers, matching the native path. Aborting an already
+        // settled request is a no-op; `unref` keeps it from holding Node open.
+        const timer: unknown = setTimeout(() => controller.abort(), READ_TIMEOUT_MS);
+        (timer as { unref?: () => void })?.unref?.();
+        return controller.signal;
+    }
+
+    if (!warnedNoTimeoutSupport) {
+        warnedNoTimeoutSupport = true;
+        console.warn(
+            "Neither AbortSignal.timeout nor AbortController is available in this runtime: " +
+                "provider reads are UNBOUNDED and READ_TIMEOUT_MS is not being applied.",
+        );
+    }
+    return undefined;
 }
 
 /**

--- a/packages/ts-sdk/test/fetch-read-deadline.test.ts
+++ b/packages/ts-sdk/test/fetch-read-deadline.test.ts
@@ -69,8 +69,62 @@ describe("baseFetch read deadline", () => {
         expect(isRetryableProviderError(err)).toBe(true);
     });
 
-    it("states a deadline rather than leaving it implicit", () => {
-        expect(READ_TIMEOUT_MS).toBeGreaterThan(0);
+    // Bounded both ways: a dropped zero makes reads fail on a slow-but-alive
+    // server, an extra zero makes the deadline decorative.
+    it("keeps the deadline inside a defensible range", () => {
+        expect(READ_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
+        expect(READ_TIMEOUT_MS).toBeLessThanOrEqual(120_000);
+    });
+
+    // Without `AbortSignal.timeout` (some React Native runtimes) the bound has
+    // to come from `AbortController` + a timer, and this proves it actually
+    // fires rather than merely being attached.
+    it("still bounds the read when only AbortController is available", async () => {
+        vi.useFakeTimers();
+        const realTimeout = AbortSignal.timeout;
+        // @ts-expect-error simulating a runtime without AbortSignal.timeout
+        AbortSignal.timeout = undefined;
+        globalThis.fetch = vi.fn(
+            (_input: any, init?: RequestInit) =>
+                new Promise((_resolve, reject) => {
+                    init?.signal?.addEventListener("abort", () =>
+                        reject(new DOMException("aborted", "AbortError")),
+                    );
+                }),
+        ) as any;
+
+        try {
+            const pending = baseFetch("https://example.test/slow").catch((e) => e);
+            await vi.advanceTimersByTimeAsync(READ_TIMEOUT_MS);
+            const err = await pending;
+
+            expect(err).toBeInstanceOf(FetchError);
+            expect(isRetryableProviderError(err)).toBe(true);
+        } finally {
+            AbortSignal.timeout = realTimeout;
+            vi.useRealTimers();
+        }
+    });
+
+    it("says so loudly when the runtime cannot bound a read at all", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const realTimeout = AbortSignal.timeout;
+        const realController = globalThis.AbortController;
+        // @ts-expect-error simulating a runtime with neither primitive
+        AbortSignal.timeout = undefined;
+        // @ts-expect-error same
+        globalThis.AbortController = undefined;
+        try {
+            await baseFetch("https://example.test/a");
+            await baseFetch("https://example.test/b");
+        } finally {
+            AbortSignal.timeout = realTimeout;
+            globalThis.AbortController = realController;
+        }
+
+        expect(seen?.signal).toBeUndefined();
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0][0])).toContain("UNBOUNDED");
     });
 
     // On Expo, `getExpoFetch` falls back to `baseFetch`, so this signal is what

--- a/packages/ts-sdk/test/fetch-read-deadline.test.ts
+++ b/packages/ts-sdk/test/fetch-read-deadline.test.ts
@@ -106,7 +106,7 @@ describe("baseFetch read deadline", () => {
         }
     });
 
-    it("says so loudly when the runtime cannot bound a read at all", async () => {
+    it("says so loudly when the runtime cannot bound a read at all — and only once", async () => {
         const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
         const realTimeout = AbortSignal.timeout;
         const realController = globalThis.AbortController;
@@ -115,8 +115,13 @@ describe("baseFetch read deadline", () => {
         // @ts-expect-error same
         globalThis.AbortController = undefined;
         try {
-            await baseFetch("https://example.test/a");
-            await baseFetch("https://example.test/b");
+            // Fresh module: the "warned once" flag is module-level, so asserting
+            // it from a shared instance would depend on nothing else having
+            // tripped it first.
+            vi.resetModules();
+            const fresh = await import("../src/utils/fetch");
+            await fresh.baseFetch("https://example.test/a");
+            await fresh.baseFetch("https://example.test/b");
         } finally {
             AbortSignal.timeout = realTimeout;
             globalThis.AbortController = realController;

--- a/packages/ts-sdk/test/fetch-read-deadline.test.ts
+++ b/packages/ts-sdk/test/fetch-read-deadline.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { baseFetch, FetchError, READ_TIMEOUT_MS } from "../src/utils/fetch";
 import { isRetryableProviderError } from "../src/providers/availability";
+import { sseStreamIterator } from "../src/providers/expoUtils";
 
 describe("baseFetch read deadline", () => {
     let seen: RequestInit | undefined;
@@ -70,5 +71,26 @@ describe("baseFetch read deadline", () => {
 
     it("states a deadline rather than leaving it implicit", () => {
         expect(READ_TIMEOUT_MS).toBeGreaterThan(0);
+    });
+
+    // On Expo, `getExpoFetch` falls back to `baseFetch`, so this signal is what
+    // keeps the deadline off a long-lived stream. Guard it against removal.
+    it("sseStreamIterator supplies a signal, which is what opts a stream out", async () => {
+        let received: RequestInit | undefined;
+        const fetchFn = (async (_url: string, init?: RequestInit) => {
+            received = init;
+            return new Response(null, { status: 500 });
+        }) as unknown as typeof globalThis.fetch;
+
+        const stream = sseStreamIterator(
+            "https://example.test/stream",
+            new AbortController().signal,
+            fetchFn,
+            {},
+            (d) => d,
+        );
+        await stream.next().catch(() => undefined);
+
+        expect(received?.signal).toBeInstanceOf(AbortSignal);
     });
 });

--- a/packages/ts-sdk/test/fetch-read-deadline.test.ts
+++ b/packages/ts-sdk/test/fetch-read-deadline.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { baseFetch, FetchError, READ_TIMEOUT_MS } from "../src/utils/fetch";
+import { isRetryableProviderError } from "../src/providers/availability";
+
+describe("baseFetch read deadline", () => {
+    let seen: RequestInit | undefined;
+    const original = globalThis.fetch;
+
+    beforeEach(() => {
+        seen = undefined;
+        globalThis.fetch = vi.fn(async (_input: any, init?: RequestInit) => {
+            seen = init;
+            return new Response("{}", { status: 200 });
+        }) as any;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = original;
+        vi.restoreAllMocks();
+    });
+
+    it("bounds a GET that carries no signal of its own", async () => {
+        await baseFetch("https://example.test/v1/thing");
+        expect(seen?.signal).toBeInstanceOf(AbortSignal);
+        expect(seen?.signal?.aborted).toBe(false);
+    });
+
+    it("bounds a HEAD too", async () => {
+        await baseFetch("https://example.test/v1/thing", { method: "HEAD" });
+        expect(seen?.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("leaves a POST unbounded — an aborted write has an unknown outcome", async () => {
+        await baseFetch("https://example.test/v1/thing", { method: "POST", body: "{}" });
+        expect(seen?.signal).toBeUndefined();
+    });
+
+    it("never overrides a caller's own signal", async () => {
+        const controller = new AbortController();
+        await baseFetch("https://example.test/v1/thing", { signal: controller.signal });
+        expect(seen?.signal).toBe(controller.signal);
+    });
+
+    // Every Request has a `signal` whether or not its author supplied one, so a
+    // Request input is left to its own lifetime rather than guessed at.
+    it("leaves a Request input unbounded, GET or not", async () => {
+        await baseFetch(new Request("https://example.test/a"));
+        expect(seen?.signal).toBeUndefined();
+        await baseFetch(new Request("https://example.test/b", { method: "POST", body: "{}" }));
+        expect(seen?.signal).toBeUndefined();
+    });
+
+    it("issues a fresh deadline per call, so a retry is not born expired", async () => {
+        await baseFetch("https://example.test/a");
+        const first = seen?.signal;
+        await baseFetch("https://example.test/b");
+        expect(seen?.signal).not.toBe(first);
+    });
+
+    it("surfaces a fired deadline as a retryable failure, so the retry ladder is reachable", async () => {
+        globalThis.fetch = vi.fn(async () => {
+            throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+        }) as any;
+
+        const err = await baseFetch("https://example.test/v1/thing").catch((e) => e);
+
+        expect(err).toBeInstanceOf(FetchError);
+        expect(isRetryableProviderError(err)).toBe(true);
+    });
+
+    it("states a deadline rather than leaving it implicit", () => {
+        expect(READ_TIMEOUT_MS).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
There is no `AbortSignal.timeout` anywhere in `packages/ts-sdk/src`, and `fetch` has no default timeout. Every provider read — indexer, Esplora, delegate, emulator, `getInfo` — is unbounded. This gives reads a deadline at the one chokepoint they all share.

## Why this is a correctness argument, not hygiene

**A timeout is not one resilience measure among several. It is the precondition for the others working at all.** Retry counts, circuit breakers, bounded queues and backpressure all assume the call underneath them terminates.

This repo has a live instance of that. `indexerFetch` already carries `INDEXER_MAX_ATTEMPTS = 3` with exponential backoff — and **that ladder is unreachable if the first attempt never settles.** The retry logic reads as though the case is handled; it is not.

The blast radius is not confined to the hung call. `_withTxLock` (`wallet/wallet.ts:3224`) is a bare promise-chain mutex with no timeout and no abort, and `send` (:5467), `settle` (:3898) and two further spend paths (:3802, :5831) all serialize through it. The pre-send contract sync is a **read** that runs inside `_sendImpl`, inside that lock. So one hung indexer GET stalls **every subsequent send and settle on that wallet**, not just its own caller.

## Prior art, same defect class, three independent arrivals

- **arkade-os/solver#30** (Go) adds `rpcTimeout`/`submitTimeout` to fulfillment RPCs, opened against a production symptom — a swap pending for hours with `read tcp ...: connection timed out` after the call had already blocked.
- **arkade-os/intent-solver#82** fixes the notification sink with `AbortSignal.timeout`. Its failure mode is the sharpest illustration of the argument above: a hung request meant the drain never resolved, so **the bounded queue and the bounded retries it had already built were never reached.** That work is not touched here.
- This PR: the TypeScript SDK's provider reads.

## What changed

One chokepoint. `baseFetch` is what the indexer, Esplora, the delegate provider and the Ark-server `fetch` wrapper (and therefore `getInfo`) all funnel through, so a default deadline there covers those without touching each provider.

**Reads only, and deliberately so:**

- **GET and HEAD get a deadline.** Bounded, retry-eligible, no state at risk. The scope matches `indexerFetch`'s existing retry eligibility exactly — the methods already considered safe to send twice are the ones bounded here, which is also why the subscribe/unsubscribe POSTs keep their current behaviour and cannot be orphaned by an abort.
- **Every write is left unbounded.** Aborting `submitTx` or `finalizeTx` does **not** mean the submission did not land — it means the outcome is now unknown. A caller with no reconcile path would have to choose between re-sending (double-submit) and marking a spend failed that actually succeeded. A stall is the safer failure until that reconcile path exists, and pretending otherwise would turn a wasted wait into a potential loss of funds. **This is a stated gap, not an oversight.**
- **A caller's own signal always wins.**
- **A `Request` input is left alone — and this rule must not be "tidied up" later.** The tempting version is `input instanceof Request && input.signal`, i.e. "only skip if the caller brought a signal". That condition is **always true**: the WHATWG spec gives every `Request` a `signal`, populated whether or not its author passed one. So the property "did this caller bring a lifetime?" is **unfalsifiable by inspection** — there is no observation that distinguishes a caller-supplied signal from the default one. The only safe reading is to treat any `Request` as owning its own lifetime and leave it unbounded. A future reader who re-adds the `.signal` check will not be making it stricter; they will be writing a condition that can never be false, and the tests will not tell them, which is exactly how this got in.

**Long-lived streams are unaffected, but not for the reason I first wrote**, and the correction is in the diff.

On web, `getEventStream` (`providers/ark.ts:746`), `getTransactionsStream` (:835) and `getSubscription` (`providers/indexer.ts:550`) run on `EventSource` and never reach `baseFetch`. **On Expo they can.** `getExpoFetch` (`providers/expoUtils.ts:7-35`) falls back to this module's `fetch` whenever `expo/fetch` will not import, and on that path an SSE stream does come through `baseFetch`.

What actually protects it is that `sseStreamIterator` passes `signal: fetchController.signal` (`expoUtils.ts:64`) and `readDeadline` bails on a caller-supplied signal. So the invariant is **"a long-lived request opts out by bringing its own signal"**, not "streams are EventSource". My original docstring said the latter, which would have told the next reader that dropping that signal is safe — it would truncate the subscription at 30 s. The docstring now states the real rule, the signal is marked as required where it is passed, and a test fails if it is removed.

Same class as the `Request.prototype.signal` catch below: a claim that reads as true and is not falsifiable by looking at the line it describes.

### Not covered: the emulator

I claimed in the first revision that the emulator's read was covered. **It is not.** `providers/emulator.ts` imports only `Intent` — its five `fetch(...)` calls (`:60, :81, :118, :154, :198`) resolve to the **global** `fetch`, never `baseFetch`. So `RestEmulatorProvider.getInfo()` is still unbounded after this PR.

Left out on purpose rather than fixed in-flight: the right move is `baseFetch` (not the Ark-server `fetch` wrapper, whose `X-Build-Version` / `X-SDK-VERSION` headers would fail CORS preflight against a non-arkd origin), and it changes the emulator's error type from a raw `TypeError` to `FetchError`. That is a behaviour change worth its own review rather than an amendment to a PR already being looked at. Happy to fold it in here if a reviewer would rather.

## Effect on failure handling

A fired deadline rejects with `TimeoutError`, which `baseFetch` wraps as `FetchError`, which `toProviderUnavailable` maps to `ProviderUnavailableError`, which `isRetryableProviderError` already treats as retryable. So a timed-out indexer read now **enters** the existing ladder instead of hanging. Worst case for an indexer read becomes roughly three attempts plus backoff (~91 s) rather than unbounded — still long, but bounded, and the lock is released.

`READ_TIMEOUT_MS` is exported so the value is inspectable rather than implicit.

## On `_withTxLock` itself

I considered giving the lock its own bound and **recommend against it.** A lock timeout would let a second spend begin while the first is still in flight — the same double-submit hazard in different clothing, and worse than the stall it replaces because the first spend may yet succeed. Bounding the calls *inside* the lock is the safe half of the problem; bounding the lock is not, and should not be bundled here.

## Test plan

Baseline captured on clean `master` first, then diffed:

| | files | tests | failed |
|---|---|---|---|
| baseline (`origin/master` @ `5ea42a35`) | 180 | 3004 passed, 1 skipped | 0 |
| with change | 181 | 3013 passed, 1 skipped | 0 |

+1 file, +9 tests — exactly the 9 added. Rebased onto current master after #876 and #881 landed, and re-baselined against it rather than reusing the pre-merge numbers. `tsc --noEmit` clean, `biome format` clean.

Mutation-tested:

- remove the GET/HEAD gate → the "leaves a POST unbounded" test fails
- ignore the caller's signal → the "never overrides a caller's own signal" test fails
- drop `sseStreamIterator`'s signal → the stream-opt-out guard fails

Mutation also caught a bug in my own first draft, and it is the kind review does not catch. I had written `input instanceof Request && input.signal` to mean "the caller brought their own signal". Because `Request.prototype.signal` is always populated, that condition is always true, so **no `Request` ever received a deadline** — and my test named "reads the method off a Request" passed for entirely the wrong reason. Removing the GET/HEAD gate failed the plain-POST test but *not* the Request-POST test, which is what exposed it. The failure was a DOM invariant, not a logic slip, so it read as correct on the page. The rule is now stated with its reason, and the test asserts the real behaviour.

Note for reviewers: this repo's pre-commit hook printed `No projects matched the filters` and ran nothing (#872). The gate above was run manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 30-second read deadline for SDK GET and HEAD requests when no cancellation signal is provided.
  - Exposed the read-timeout value for applications that need to reference or configure related behavior.
  - Preserved caller-provided cancellation signals and uninterrupted streaming behavior.

- **Reliability**
  - Requests that exceed the read deadline now surface a retryable fetch error, helping applications recover from stalled reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->