### PR TITLE
fix(emulator): route the info read through the SDK's shared fetch boundary

### DIFF
--- a/packages/ts-sdk/src/providers/emulator.ts
+++ b/packages/ts-sdk/src/providers/emulator.ts
@@ -3,9 +3,16 @@
  *
  * The emulator is a signing service that executes Arkade scripts
  * and co-signs transactions when the scripts pass validation.
+ *
+ * The read here goes through `baseFetch`, the SDK's shared fetch boundary, so
+ * it picks up whatever policy that boundary carries. The four submit calls
+ * deliberately do not: aborting a submit would not tell the caller whether the
+ * emulator signed, and none of them has a way to find out, so they stay on the
+ * global `fetch` with their transport-error type unchanged.
  */
 
 import { Intent } from "../intent";
+import { baseFetch } from "../utils/fetch";
 
 export interface EmulatorInfo {
     signerPubkey: string;
@@ -57,7 +64,9 @@ export class RestEmulatorProvider implements EmulatorProvider {
 
     async getInfo(): Promise<EmulatorInfo> {
         const url = `${this.serverUrl}/v1/info`;
-        const response = await fetch(url);
+        // `baseFetch`, not the Ark-server `fetch`: the emulator is a distinct
+        // origin and rejects `X-Build-Version` / `X-SDK-VERSION` in preflight.
+        const response = await baseFetch(url);
         if (!response.ok) {
             const errorText = await response.text();
             throw new Error(`Failed to get emulator info: ${errorText}`);

--- a/packages/ts-sdk/test/emulator-read-deadline.test.ts
+++ b/packages/ts-sdk/test/emulator-read-deadline.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RestEmulatorProvider } from "../src/providers/emulator";
+import { FetchError } from "../src/utils/fetch";
+
+describe("RestEmulatorProvider fetch boundary", () => {
+    let seen: { url: string; init?: RequestInit }[] = [];
+    const original = globalThis.fetch;
+
+    const ok = () =>
+        new Response(JSON.stringify({ signerPubkey: "ab", signedArkTx: "x" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+        });
+
+    beforeEach(() => {
+        seen = [];
+        globalThis.fetch = vi.fn(async (input: any, init?: RequestInit) => {
+            seen.push({ url: String(input), init });
+            return ok();
+        }) as any;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = original;
+        vi.restoreAllMocks();
+    });
+
+    it("routes the info read through the shared boundary, typing its transport failures", async () => {
+        globalThis.fetch = vi.fn(async () => {
+            throw new TypeError("Failed to fetch");
+        }) as any;
+
+        const err = await new RestEmulatorProvider("https://emulator.test")
+            .getInfo()
+            .catch((e) => e);
+
+        expect(err).toBeInstanceOf(FetchError);
+    });
+
+    // The emulator is a distinct origin from arkd, so it must not receive the
+    // Ark-server compatibility headers — `baseFetch` is the wrapper that omits
+    // them, and swapping it for `fetch` would break preflight, not a test.
+    it("sends no Arkade-specific headers to the emulator origin", async () => {
+        await new RestEmulatorProvider("https://emulator.test").getInfo();
+
+        const headers = new Headers(seen[0].init?.headers);
+        expect(headers.get("X-Build-Version")).toBeNull();
+        expect(headers.get("X-SDK-VERSION")).toBeNull();
+    });
+
+    it("leaves a submit on the global fetch — an aborted co-sign has an unknown outcome", async () => {
+        globalThis.fetch = vi.fn(async () => {
+            throw new TypeError("Failed to fetch");
+        }) as any;
+
+        const err = await new RestEmulatorProvider("https://emulator.test")
+            .submitTx("arktx", ["cp"])
+            .catch((e) => e);
+
+        expect(err).not.toBeInstanceOf(FetchError);
+        expect(err).toBeInstanceOf(TypeError);
+    });
+});


### PR DESCRIPTION
`providers/emulator.ts` never reaches the SDK's shared fetch boundary. Its only import is `Intent`, so all five `fetch(...)` calls (`:60`, `:81`, `:118`, `:154`, `:198`) resolve to the **global** `fetch`. This points the one read at `baseFetch`.

## How this survived

The file reads as though it uses the SDK's wrapper, because it uses the word. `await fetch(url)` in a module that imports from the SDK looks identical whether `fetch` is the global or the local import — and grepping for `baseFetch` finds only the honest cases, so the gap is invisible from the direction anyone would search.

I found it while auditing the coverage claim I had made in #884, which said the emulator was covered. **It was not, and I have corrected that PR's body.**

## What changes

`getInfo` — the provider's only GET — now goes through `baseFetch`. Today that means its transport failures arrive as a typed `FetchError` instead of a raw `TypeError`; once #884 lands, the read also inherits that PR's deadline, which is the reason this gap mattered.

`baseFetch` and **not** the Ark-server `fetch` wrapper: **the emulator is a distinct origin from arkd**, and the wrapper adds `X-Build-Version` and `X-SDK-VERSION`, which a non-arkd origin rejects in CORS preflight. That is precisely the case `baseFetch`'s own docstring exists to warn about, and a reviewer who does not know the emulator is a separate service would reasonably ask why the "better" wrapper was not used.

## What deliberately does not change

The four submit calls — `submitTx`, `submitIntent`, `submitFinalization`, `submitOnchainTx` — stay on the global `fetch`.

Same rule as #884: **a deadline on a read is free, a deadline on a write is not.** Aborting a submit does not mean the emulator did not sign it; it means the outcome is unknown, and none of these calls has a way to find out. An unbounded wait is the safer failure. Leaving them untouched also keeps their transport-error type exactly as it is, so nothing that catches an emulator error changes shape.

That leaves the file mixed — one call on `baseFetch`, four on the global — which is intentional rather than half-finished, and the class docstring says so.

## Test plan

Baseline captured on `origin/master` first, then diffed:

| | files | tests | failed |
|---|---|---|---|
| baseline (`94c9a1fb`) | 180 | 3023 passed, 1 skipped | 0 |
| with change | 181 | 3026 passed, 1 skipped | 0 |

+1 file, +3 tests — exactly the 3 added. `tsc --noEmit` clean, `biome format` clean.

The tests assert what is observable **today**, not what arrives with #884:

- `getInfo` surfaces a transport failure as `FetchError` — i.e. it really is going through the shared boundary;
- `getInfo` sends **no** Arkade-specific headers, so swapping `baseFetch` for `fetch` later would fail this test rather than an emulator preflight in production;
- `submitTx` still throws the raw `TypeError`, pinning the write path as untouched.

Note for reviewers: the pre-commit hook now correctly refuses to run in a git worktree (#872, fixed by #880) and instructs running the gate by hand. I did, with the numbers above, and committed with `--no-verify` as it directs.
