### PR TITLE
fix(boltz-swap): bound Boltz API reads with a deadline

### DIFF
--- a/packages/boltz-swap/src/boltz-swap-provider.ts
+++ b/packages/boltz-swap/src/boltz-swap-provider.ts
@@ -49,6 +49,48 @@ export type BoltzSwapStatus =
     | "transaction.server.mempool"
     | "transaction.server.confirmed";
 
+/**
+ * Deadline for a Boltz API read.
+ *
+ * `fetch` has no default timeout, so a connection the network dropped silently
+ * stays pending until the runtime gives up. That is not one missing safeguard
+ * among several — it is the one the others rest on: the `inflightGets`
+ * deduplication above and every retry around this client assume the call
+ * underneath them terminates.
+ */
+export const BOLTZ_READ_TIMEOUT_MS = 30_000;
+
+let warnedNoTimeoutSupport = false;
+
+/**
+ * A signal bounding a Boltz **read**, or `undefined` when the runtime offers no
+ * way to build one.
+ *
+ * Reads only. An aborted POST to Boltz has not necessarily failed — it may have
+ * created a swap — so bounding one would turn a stall into a state question the
+ * caller cannot answer, and a retry could create a second swap.
+ */
+const readDeadline = (): AbortSignal | undefined => {
+    if (typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function") {
+        return AbortSignal.timeout(BOLTZ_READ_TIMEOUT_MS);
+    }
+    // Absent on some React Native runtimes, where `AbortController` is not.
+    if (typeof AbortController === "function") {
+        const controller = new AbortController();
+        const timer: unknown = setTimeout(() => controller.abort(), BOLTZ_READ_TIMEOUT_MS);
+        (timer as { unref?: () => void })?.unref?.();
+        return controller.signal;
+    }
+    if (!warnedNoTimeoutSupport) {
+        warnedNoTimeoutSupport = true;
+        console.warn(
+            "Neither AbortSignal.timeout nor AbortController is available in this runtime: " +
+                "Boltz API reads are UNBOUNDED.",
+        );
+    }
+    return undefined;
+};
+
 /** Returns true if the status indicates a failed submarine swap. */
 export const isSubmarineFailedStatus = (status: BoltzSwapStatus): boolean => {
     return ["invoice.failedToPay", "transaction.lockupFailed", "swap.expired"].includes(status);
@@ -1741,6 +1783,8 @@ export class BoltzSwapProvider {
                 method,
                 headers: { "Content-Type": "application/json" },
                 body: body ? JSON.stringify(body) : undefined,
+                // GET only — see `readDeadline`.
+                ...(method === "GET" ? { signal: readDeadline() } : {}),
             });
 
             if (!response.ok) {

--- a/packages/boltz-swap/test/boltz-read-deadline.test.ts
+++ b/packages/boltz-swap/test/boltz-read-deadline.test.ts
@@ -69,9 +69,8 @@ describe("BoltzSwapProvider read deadline", () => {
         ) as any;
 
         try {
-            const pending = (provider() as any)
-                .request("/v2/slow", "GET")
-                .catch((e: unknown) => e);
+            const p = provider() as any;
+            const pending = p.request("/v2/slow", "GET").catch((e: unknown) => e);
             await vi.advanceTimersByTimeAsync(BOLTZ_READ_TIMEOUT_MS);
 
             expect(await pending).toBeInstanceOf(Error);

--- a/packages/boltz-swap/test/boltz-read-deadline.test.ts
+++ b/packages/boltz-swap/test/boltz-read-deadline.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BoltzSwapProvider, BOLTZ_READ_TIMEOUT_MS } from "../src/boltz-swap-provider";
+
+describe("BoltzSwapProvider read deadline", () => {
+    let seen: RequestInit[] = [];
+    const original = globalThis.fetch;
+
+    beforeEach(() => {
+        seen = [];
+        globalThis.fetch = vi.fn(async (_input: any, init?: RequestInit) => {
+            seen.push(init ?? {});
+            return new Response(JSON.stringify({}), {
+                status: 200,
+                headers: { "content-type": "application/json", "content-length": "2" },
+            });
+        }) as any;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = original;
+        vi.restoreAllMocks();
+    });
+
+    const provider = () =>
+        new BoltzSwapProvider({ network: "regtest", apiUrl: "http://localhost:9090" });
+
+    it("bounds a GET", async () => {
+        await (provider() as any).request("/v2/anything", "GET").catch(() => undefined);
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0].signal).toBeInstanceOf(AbortSignal);
+        expect(seen[0].signal?.aborted).toBe(false);
+    });
+
+    it("leaves a POST unbounded — an aborted write may already have made a swap", async () => {
+        await (provider() as any).request("/v2/anything", "POST", { a: 1 }).catch(() => undefined);
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0].signal).toBeUndefined();
+    });
+
+    it("issues a fresh deadline per request, so a later read is not born expired", async () => {
+        const p = provider();
+        await (p as any).request("/v2/a", "GET").catch(() => undefined);
+        await (p as any).request("/v2/b", "GET").catch(() => undefined);
+
+        expect(seen[1].signal).not.toBe(seen[0].signal);
+    });
+
+    // Bounded both ways: a dropped zero fails reads against a slow-but-alive
+    // API, an extra zero makes the deadline decorative.
+    it("keeps the deadline inside a defensible range", () => {
+        expect(BOLTZ_READ_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
+        expect(BOLTZ_READ_TIMEOUT_MS).toBeLessThanOrEqual(120_000);
+    });
+
+    it("still bounds the read when only AbortController is available", async () => {
+        vi.useFakeTimers();
+        const realTimeout = AbortSignal.timeout;
+        // @ts-expect-error simulating a runtime without AbortSignal.timeout
+        AbortSignal.timeout = undefined;
+        globalThis.fetch = vi.fn(
+            (_input: any, init?: RequestInit) =>
+                new Promise((_resolve, reject) => {
+                    init?.signal?.addEventListener("abort", () =>
+                        reject(new DOMException("aborted", "AbortError")),
+                    );
+                }),
+        ) as any;
+
+        try {
+            const pending = (provider() as any)
+                .request("/v2/slow", "GET")
+                .catch((e: unknown) => e);
+            await vi.advanceTimersByTimeAsync(BOLTZ_READ_TIMEOUT_MS);
+
+            expect(await pending).toBeInstanceOf(Error);
+        } finally {
+            AbortSignal.timeout = realTimeout;
+            vi.useRealTimers();
+        }
+    });
+});

--- a/packages/boltz-swap/test/boltz-swap-provider.test.ts
+++ b/packages/boltz-swap/test/boltz-swap-provider.test.ts
@@ -130,10 +130,12 @@ describe("BoltzSwapProvider", () => {
             expect(fetch).toHaveBeenCalledWith("http://localhost:9090/v2/swap/submarine", {
                 method: "GET",
                 headers: { "Content-Type": "application/json" },
+                signal: expect.any(AbortSignal),
             });
             expect(fetch).toHaveBeenCalledWith("http://localhost:9090/v2/swap/reverse", {
                 method: "GET",
                 headers: { "Content-Type": "application/json" },
+                signal: expect.any(AbortSignal),
             });
             expect(fetch).toHaveBeenCalledTimes(2);
             expect(fees).toEqual({
@@ -194,6 +196,7 @@ describe("BoltzSwapProvider", () => {
             expect(fetch).toHaveBeenCalledWith("http://localhost:9090/v2/swap/submarine", {
                 method: "GET",
                 headers: { "Content-Type": "application/json" },
+                signal: expect.any(AbortSignal),
             });
             expect(limits).toEqual({ min: 1000, max: 1000000 });
         });
@@ -368,6 +371,7 @@ describe("BoltzSwapProvider", () => {
             expect(fetch).toHaveBeenCalledWith("http://localhost:9090/v2/swap/mock-id", {
                 method: "GET",
                 headers: { "Content-Type": "application/json" },
+                signal: expect.any(AbortSignal),
             });
             expect(status).toEqual(mockResponse);
         });
@@ -461,6 +465,7 @@ describe("BoltzSwapProvider", () => {
                 {
                     method: "GET",
                     headers: { "Content-Type": "application/json" },
+                    signal: expect.any(AbortSignal),
                 },
             );
             expect(result).toEqual(mockResponse);
@@ -495,6 +500,7 @@ describe("BoltzSwapProvider", () => {
                 {
                     method: "GET",
                     headers: { "Content-Type": "application/json" },
+                    signal: expect.any(AbortSignal),
                 },
             );
             expect(result).toEqual(mockResponse);


### PR DESCRIPTION
`BoltzSwapProvider.doRequest` calls `globalThis.fetch` directly, and this package never imports the SDK's fetch utilities, so **every request to the Boltz API is unbounded**. `fetch` has no default timeout, so a connection the network dropped silently stays pending until the runtime gives up.

This is the sibling of #884, which does the same for the `ts-sdk` providers. It does nothing for this package — different module, different entry point — so the gap needs closing here.

## Why this is a correctness argument, not hygiene

**A timeout is not one resilience measure among several. It is the precondition for the others working at all.** Retry counts, circuit breakers, bounded queues and backpressure all assume the call underneath them terminates.

There is a live instance of that a few lines above the change. `request()` deduplicates concurrent GETs through `inflightGets`, joining later callers to the in-flight promise. So **a single hung GET does not stall one caller — it parks every later caller of that path behind a request that will never settle.** The deduplication is a good optimisation that becomes an amplifier without a deadline underneath it.

The same shape has now been hit three times independently across the org: `arkade-os/solver#30` (Go RPC deadlines, opened against a swap that sat pending for hours), `arkade-os/intent-solver#82` (a hung notification request meant `flush()` never resolved, so the bounded queue and bounded retries that PR had already built **were never reached**), and #884 here.

## What changed

**GET gets a deadline.** Bounded, safe to repeat, no state at risk.

**POST deliberately does not.** An aborted POST to Boltz has not necessarily failed — it may already have created a swap. Bounding it would convert a stall into a state question the caller cannot answer, and a retry could create a *second* swap. A stall is the safer failure until a reconcile path exists.

I looked for a POST here whose outcome is reconcilable from Boltz's own API and did not find one, so all of them are left alone. If someone knows of one, it is worth arguing separately rather than quietly including.

**Runtime support.** `AbortSignal.timeout` where available; `AbortController` plus a timer where it is not — this package ships `./expo` and `./expo/background`, and some React Native runtimes have the latter but not the former. If neither exists the read stays unbounded and says so once, rather than leaving `BOLTZ_READ_TIMEOUT_MS` readable and untrue.

The timer on the fallback path is deliberately not cleared, so the bound covers the body read and not merely the headers, matching what `AbortSignal.timeout` does. Aborting an already-settled request is a no-op, and `unref()` keeps it from holding a Node process open.

## Test plan

Baseline captured on `origin/master` first, then diffed:

| | files | tests | failed |
|---|---|---|---|
| baseline (`94c9a1fb`) | 23 | 617 passed | 0 |
| with change | 24 | 623 passed | 0 |

+1 file, +6 tests — the 5 added here plus the warn-path test added in `d1d26134` after review. `tsc --noEmit` clean, `biome format` clean.

Mutation-tested: applying the deadline to writes as well fails the "leaves a POST unbounded" test, alone; removing the fallback timer fails the fallback test, alone.

**One existing-test change, and it is a real behaviour change rather than a test fix.** Six assertions in `boltz-swap-provider.test.ts` pin the exact `fetch` init for GET calls, so adding `signal` broke them. They now also assert `signal: expect.any(AbortSignal)`; method and headers are still matched exactly, so the assertions are no weaker than before.

Worth noting how that surfaced: the new tests passed when run alone and the **existing** suite failed only in the full run. Running the whole package gate rather than just the new file is what caught it.

Note for reviewers: the pre-commit hook now correctly refuses to run in a git worktree (#872, fixed by #880) and instructs running the gate by hand. I did, with the numbers above, and committed with `--no-verify` as it directs.

