### PR TITLE
docs(providers): name the wrapper the Expo fallback actually returns

### DIFF
--- a/packages/ts-sdk/src/providers/expoUtils.ts
+++ b/packages/ts-sdk/src/providers/expoUtils.ts
@@ -62,8 +62,9 @@ export async function* sseStreamIterator<T>(
                 ...headers,
             },
             // Required, not just for cancellation: `getExpoFetch` falls back to
-            // `baseFetch`, which bounds any read that brings no signal of its
-            // own. Drop this and the stream is truncated at READ_TIMEOUT_MS.
+            // the Ark `fetch` wrapper, which routes through `baseFetch` and so
+            // bounds any read that brings no signal of its own. Drop this and
+            // the stream is truncated at READ_TIMEOUT_MS.
             signal: fetchController.signal,
         });
 


### PR DESCRIPTION
`sseStreamIterator`'s comment (`expoUtils.ts:64-66`) says `getExpoFetch` falls back to `baseFetch`. It falls back to `fetch` — the **Ark-server wrapper** — which reaches `baseFetch` one layer further down.

```ts
// what the comment claims
// `getExpoFetch` falls back to `baseFetch`, which bounds any read …

// what getExpoFetch actually does (expoUtils.ts:1, :33)
import { fetch, buildVersion, sdkVersion } from "../utils/fetch";
...
return fetch;   // the Ark wrapper
```

Comment-only. No behaviour change, no test change.

## Why this is worth a PR: the comment asserts #889 is already fixed

**#889 is the open issue arguing that this fallback should be `baseFetch`. The comment says it already is.**

So the failure is not that the comment is vague. A reader auditing the Expo path — the reader most likely to be here, because this is where a distinct-origin subscription would break — finds a note stating the very fix that has not been made. It does not merely fail to warn them. **It closes the question.**

That is the general shape, and it is why this earns a PR rather than a drive-by: **a comment that is 90% right is worse than no comment, because it reads as a question already asked and answered.** An absent comment invites the reader to go look. A confident, slightly wrong one ends the enquiry before it starts.

## The elided layer is the one that matters

The difference between `fetch` and `baseFetch` is not incidental — it is the whole of it, and it is the security-relevant part. `fetch` sets `X-Build-Version` and `X-SDK-VERSION`; `baseFetch` exists precisely to omit them, because a non-arkd origin rejects unknown request headers in CORS preflight. `baseFetch`'s own docstring says so.

So the comment is wrong in exactly the place a reader would be checking, three lines from the fallback most likely to be audited.

## The same shape, once more, elsewhere

There is a second instance in one of our corridors this week, which is what makes it a pattern rather than a one-off. A comment opened with a genuinely correct and non-obvious warning — that a thrown error is not proof nothing was sent — and then asserted that a particular check owned that ambiguity. It did not; the check was an indexer read and could not settle the question. The *correct* first clause is what carried the wrong second clause past review, and the pairing was then copied into another corridor. Being mostly right is what gave it the range.

## Provenance

Found by `arkana-ai-bot` reviewing #884, in the sync posted after that PR had already been squash-merged, so it did not make the merge. I verified it independently before acting: `getExpoFetch`'s catch branch is `return fetch`, and line 1 imports `fetch` from `../utils/fetch`.

Related: **#889** — same class, *the wrong fetch wrapper for what may be a distinct origin*, in this same function. #889 changes the behaviour; this only stops the comment from claiming that change is already made. Independent, and they can land in either order.

## Test plan

Comment-only, so the bar is that nothing moved. Gate run by hand against `ab87f555`:

| | files | tests |
|---|---|---|
| master `ab87f555` (from CI) | ts-sdk 183 · swap 33 · boltz-swap 23 | 3047 passed, 1 skipped · 811 · 617 |
| this branch | ts-sdk 183 · swap 33 · boltz-swap 23 | 3047 passed, 1 skipped · 811 · 617 |

Identical across all three packages, zero failures. `pnpm -r lint`, `pnpm -r build`, `pnpm -r test:unit` all clean.

The pre-commit hook refuses to run in a git worktree (#872, fixed by #880) and directs running the gate by hand and committing with `--no-verify`. I did both.
