### PR TITLE
fix(swap): restore coverage for the covenants the scan rebuilds

### DIFF
--- a/packages/swap/src/coverage.ts
+++ b/packages/swap/src/coverage.ts
@@ -103,12 +103,16 @@ function addressOutstanding(swaps: AssetSwap[], script: string): boolean {
 export async function promoteOfferContract(
     manager: OfferContractRetirer,
     script: string,
+    /** When the address went out. A restore passes its record's funding time:
+     * that deposit has landed, and a mark dated after every record at the
+     * script pins it watched for the life of the process. */
+    issued: number = Date.now(),
 ): Promise<void> {
     await serialize(script, async () => {
         await manager.setContractWatchState(script, "watched");
         // after the write: a promotion that failed hands out no address, so
         // there is nothing outstanding to protect
-        issuedAt.set(script, Date.now());
+        issuedAt.set(script, issued);
     });
 }
 

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -1,6 +1,7 @@
 export {
     createOffer,
     cancelOffer,
+    restoreOfferCoverage,
     encodeOffer,
     decodeOffer,
     offerVtxoScript,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -40,9 +40,14 @@ import {
 
 import wantAssetProgram from "./swap-want-asset.program.json";
 import wantBtcProgram from "./swap-want-btc.program.json";
-import { promoteOfferContract, retireOfferContract } from "./coverage";
+import { promoteOfferContract, retireOfferContract, RETIRABLE } from "./coverage";
 import type { AssetSwapRepository } from "./repository";
-import { getAssetSwapsOrThrow, updateAssetSwap, updateAssetSwapBestEffort } from "./store";
+import {
+    getAssetSwapsOrThrow,
+    updateAssetSwap,
+    updateAssetSwapBestEffort,
+    type AssetSwap,
+} from "./store";
 
 // json imports widen "type": "pubkey" to string; parseArtifact validates at runtime
 type Artifact = Parameters<typeof arkade.parseArtifact>[0];
@@ -477,19 +482,22 @@ async function registerOfferContract(
     binding: Omit<Offer, "swapPkScript">,
     serverPubkey: Uint8Array,
     expectedPkScript: Uint8Array,
+    opts: { issued?: number; client?: arkade.Arkade } = {},
 ): Promise<void> {
     const { program, args, keys } = swapProgramBinding(binding, serverPubkey);
     const contractManager = await wallet.getContractManager();
-    const client = await arkade.Arkade.connect({
-        arkade: new RestArkProvider(arkServerUrl),
-        indexer: new RestIndexerProvider(arkServerUrl),
-        identity: wallet.identity,
-        // without this the row's `address` would be derived against the SDK's
-        // default network while its script is right — a row that disagrees with
-        // the address the user is about to fund
-        network: getNetwork(network),
-        contractManager,
-    });
+    const client =
+        opts.client ??
+        (await arkade.Arkade.connect({
+            arkade: new RestArkProvider(arkServerUrl),
+            indexer: new RestIndexerProvider(arkServerUrl),
+            identity: wallet.identity,
+            // without this the row's `address` would be derived against the SDK's
+            // default network while its script is right — a row that disagrees with
+            // the address the user is about to fund
+            network: getNetwork(network),
+            contractManager,
+        }));
     const contract = new arkade.ArkadeContract(client, program, args, keys);
     // the row is keyed by script: registering anything but the script being
     // funded would leave the real deposit unwatched and unmarked, which is the
@@ -501,7 +509,62 @@ async function registerOfferContract(
         label: OFFER_CONTRACT_LABEL,
         metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
     });
-    await promoteOfferContract(contractManager, hex.encode(expectedPkScript));
+    await promoteOfferContract(contractManager, hex.encode(expectedPkScript), opts.issued);
+}
+
+/**
+ * Put the covenants of restored swap records back in the watched set.
+ *
+ * {@link restoreAssetSwaps} rebuilds the *record* and nothing else, so a
+ * restored wallet holds swaps with no contract row behind them — never
+ * subscribed, never emitting `vtxo_spent`, unresolvable by the watcher. The
+ * restore-scan backstop three modules lean on restores records, not coverage. A
+ * separate call rather than an option on that scan, which is indexer-only and
+ * whose records must survive a coverage failure.
+ *
+ * A script whose every record is {@link RETIRABLE} is skipped, or this undoes
+ * {@link retireSettledOfferContracts} and re-subscribes settled scripts.
+ *
+ * One client for the batch, so `/v1/info` is a constant cost rather than one per
+ * script: this runs on wallet boot, already under latency pressure.
+ */
+export async function restoreOfferCoverage(
+    wallet: IWallet,
+    arkServerUrl: string,
+    swaps: AssetSwap[],
+): Promise<void> {
+    const live = swaps.filter((s) => !RETIRABLE.includes(s.status));
+    if (live.length === 0) return;
+
+    const arkProvider = new RestArkProvider(arkServerUrl);
+    const info = await arkProvider.getInfo();
+    const serverPubKey = hex.decode(toXOnlySignerHex(info.signerPubkey));
+    const client = await arkade.Arkade.connect({
+        arkade: arkProvider,
+        indexer: new RestIndexerProvider(arkServerUrl),
+        identity: wallet.identity,
+        network: getNetwork(info.network as NetworkName),
+        contractManager: await wallet.getContractManager(),
+    });
+    const done = new Set<string>();
+    for (const swap of live) {
+        if (done.has(swap.swapPkScript)) continue;
+        done.add(swap.swapPkScript);
+        try {
+            const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(swap.offerHex));
+            await registerOfferContract(
+                wallet,
+                arkServerUrl,
+                info.network as NetworkName,
+                binding,
+                serverPubKey,
+                hex.decode(swap.swapPkScript),
+                { issued: swap.createdAt, client },
+            );
+        } catch (err) {
+            console.warn(`[swap] could not restore coverage for ${swap.swapPkScript}`, err);
+        }
+    }
 }
 
 // ── User operations ─────────────────────────────────────────────────────────

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -33,6 +33,7 @@ import {
     getNetwork,
     resolveEmulatorPubkey,
     toXOnlySignerHex,
+    type IContractManager,
     type IWallet,
     type NetworkName,
     type RelativeTimelock,
@@ -482,10 +483,12 @@ async function registerOfferContract(
     binding: Omit<Offer, "swapPkScript">,
     serverPubkey: Uint8Array,
     expectedPkScript: Uint8Array,
-    opts: { issued?: number; client?: arkade.Arkade } = {},
+    opts: { issued?: number; client?: arkade.Arkade; contractManager?: IContractManager } = {},
 ): Promise<void> {
     const { program, args, keys } = swapProgramBinding(binding, serverPubkey);
-    const contractManager = await wallet.getContractManager();
+    // the caller's when it has one: `register` goes through `opts.client`'s
+    // manager, so a second fetch here splits one registration across two
+    const contractManager = opts.contractManager ?? (await wallet.getContractManager());
     const client =
         opts.client ??
         (await arkade.Arkade.connect({
@@ -518,16 +521,12 @@ async function registerOfferContract(
  * {@link restoreAssetSwaps} rebuilds the *record* and nothing else, so a
  * restored wallet holds swaps with no contract row behind them — never
  * subscribed, never emitting `vtxo_spent`, unresolvable by the watcher. The
- * restore-scan backstop three modules lean on restores records, not coverage. A
- * separate call rather than an option on that scan, which is indexer-only and
- * whose records must survive a coverage failure.
- *
- * A script whose every record is {@link RETIRABLE} is skipped, or this undoes
- * {@link retireSettledOfferContracts} and re-subscribes settled scripts.
- *
- * One client for the batch, so `/v1/info` is a constant cost rather than one per
- * script. Setup rejects rather than being caught: one bad record is skipped, but
- * a server it could not reach covered nothing, and a caller told so never retries.
+ * restore-scan backstop three modules lean on restores records, not coverage.
+ * Separate from that scan, which is indexer-only and whose records must survive
+ * a coverage failure. A script whose every record is {@link RETIRABLE} is
+ * skipped, or this undoes {@link retireSettledOfferContracts}. One client and
+ * one contract manager for the batch; setup rejects rather than being caught,
+ * because a server it could not reach covered nothing.
  */
 export async function restoreOfferCoverage(
     wallet: IWallet,
@@ -540,12 +539,13 @@ export async function restoreOfferCoverage(
     const arkProvider = new RestArkProvider(arkServerUrl);
     const info = await arkProvider.getInfo();
     const serverPubKey = hex.decode(toXOnlySignerHex(info.signerPubkey));
+    const contractManager = await wallet.getContractManager();
     const client = await arkade.Arkade.connect({
         arkade: arkProvider,
         indexer: new RestIndexerProvider(arkServerUrl),
         identity: wallet.identity,
         network: getNetwork(info.network as NetworkName),
-        contractManager: await wallet.getContractManager(),
+        contractManager,
     });
     const done = new Set<string>();
     for (const swap of live) {
@@ -560,7 +560,7 @@ export async function restoreOfferCoverage(
                 binding,
                 serverPubKey,
                 hex.decode(swap.swapPkScript),
-                { issued: swap.createdAt, client },
+                { issued: swap.createdAt, client, contractManager },
             );
         } catch (err) {
             console.warn(`[swap] could not restore coverage for ${swap.swapPkScript}`, err);

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -526,7 +526,8 @@ async function registerOfferContract(
  * {@link retireSettledOfferContracts} and re-subscribes settled scripts.
  *
  * One client for the batch, so `/v1/info` is a constant cost rather than one per
- * script: this runs on wallet boot, already under latency pressure.
+ * script. Setup rejects rather than being caught: one bad record is skipped, but
+ * a server it could not reach covered nothing, and a caller told so never retries.
  */
 export async function restoreOfferCoverage(
     wallet: IWallet,

--- a/packages/swap/test/restoreCoverage.test.ts
+++ b/packages/swap/test/restoreCoverage.test.ts
@@ -134,7 +134,6 @@ describe("restoreOfferCoverage", () => {
     });
 
     it("costs the same /v1/info whether it covers one script or many", async () => {
-        // one round trip per script is 110-215ms each, sequential, on boot
         const many = [50_000, 60_000, 70_000, 80_000].map((n, i) =>
             restored(makeOffer(BigInt(n)), {
                 id: `0${i}`.repeat(32),

--- a/packages/swap/test/restoreCoverage.test.ts
+++ b/packages/swap/test/restoreCoverage.test.ts
@@ -25,6 +25,7 @@ const state = vi.hoisted(() => ({
     created: [] as Record<string, unknown>[],
     watched: [] as [string, string][],
     getInfoCalls: 0,
+    managerCalls: 0,
 }));
 
 vi.mock("@arkade-os/sdk", async (importOriginal) => {
@@ -73,7 +74,10 @@ const contractManager = {
 const wallet = {
     identity: { xOnlyPublicKey: async () => makerKey },
     getAddress: async () => makerAddress,
-    getContractManager: async () => contractManager,
+    getContractManager: async () => {
+        state.managerCalls++;
+        return contractManager;
+    },
 } as unknown as IWallet;
 
 const testAsset = asset.AssetId.fromString("aa".repeat(32) + "0000");
@@ -110,6 +114,7 @@ beforeEach(() => {
     state.created = [];
     state.watched = [];
     state.getInfoCalls = 0;
+    state.managerCalls = 0;
 });
 
 describe("restoreOfferCoverage", () => {
@@ -144,10 +149,14 @@ describe("restoreOfferCoverage", () => {
         await restoreOfferCoverage(wallet, "http://ark", [many[0]]);
         const forOne = state.getInfoCalls;
         state.getInfoCalls = 0;
+        state.managerCalls = 0;
         await restoreOfferCoverage(wallet, "http://ark", many);
 
+        // 5 = 1 from the single-script call above, 4 from the batch
         expect(state.created).toHaveLength(5);
         expect(state.getInfoCalls).toBe(forOne);
+        // one manager for the whole batch, or a registration spans two
+        expect(state.managerCalls).toBe(1);
     });
 
     it("leaves a script whose every record has settled alone", async () => {

--- a/packages/swap/test/restoreCoverage.test.ts
+++ b/packages/swap/test/restoreCoverage.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { hex } from "@scure/base";
+import { ArkAddress, asset, type IWallet } from "@arkade-os/sdk";
+import {
+    encodeOffer,
+    offerVtxoScript,
+    restoreOfferCoverage,
+    OFFER_CONTRACT_KIND,
+    OFFER_CONTRACT_LABEL,
+    type Offer,
+} from "../src/offer";
+import { retireSettledOfferContracts } from "../src/coverage";
+import type { AssetSwap, AssetSwapStatus } from "../src/store";
+
+// real derivation and register(); its own file because `coverage.ts` keeps the
+// issuance mark in module state, which a createOffer promotion would decide.
+const makerKey = hex.decode("3c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1");
+const makerAddress =
+    "tark1qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc65wq0wnmwgr4nglzx999xqx7xahllp4gfh6638wkrjt5tl3k7c8vy6frzj2";
+const SERVER_KEY = hex.decode("4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa");
+const EMULATOR_KEY = hex.decode("466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27");
+const FUNDING_TXID = "ab".repeat(32);
+
+const state = vi.hoisted(() => ({
+    created: [] as Record<string, unknown>[],
+    watched: [] as [string, string][],
+    getInfoCalls: 0,
+}));
+
+vi.mock("@arkade-os/sdk", async (importOriginal) => {
+    const mod = await importOriginal<typeof import("@arkade-os/sdk")>();
+    const { hex } = await import("@scure/base");
+    const checkpointTapscript = hex.encode(
+        mod.CSVMultisigTapscript.encode({
+            timelock: { type: "blocks", value: 10n },
+            pubkeys: [
+                hex.decode("4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa"),
+            ],
+        }).script,
+    );
+    return {
+        ...mod,
+        RestArkProvider: class {
+            async getInfo() {
+                state.getInfoCalls++;
+                return {
+                    signerPubkey:
+                        "02" + "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+                    checkpointTapscript,
+                    network: "regtest",
+                    unilateralExitDelay: BigInt(4096),
+                };
+            }
+        },
+        RestIndexerProvider: class {
+            async getVtxos() {
+                return { vtxos: [] };
+            }
+        },
+    };
+});
+
+const contractManager = {
+    createContract: async (params: Record<string, unknown>) => {
+        state.created.push(params);
+        return { ...params, state: "active", createdAt: 0 };
+    },
+    setContractWatchState: async (script: string, watch: string) => {
+        state.watched.push([script, watch]);
+    },
+};
+
+const wallet = {
+    identity: { xOnlyPublicKey: async () => makerKey },
+    getAddress: async () => makerAddress,
+    getContractManager: async () => contractManager,
+} as unknown as IWallet;
+
+const testAsset = asset.AssetId.fromString("aa".repeat(32) + "0000");
+
+const makeOffer = (wantAmount = BigInt(50_000)): Offer => {
+    const binding: Omit<Offer, "swapPkScript"> = {
+        wantAmount,
+        wantAsset: testAsset,
+        makerPkScript: ArkAddress.decode(makerAddress).pkScript,
+        makerPublicKey: makerKey,
+        emulatorPubkey: EMULATOR_KEY,
+        exitDelay: { type: "seconds", value: BigInt(4096) },
+    };
+    return { ...binding, swapPkScript: offerVtxoScript(binding, SERVER_KEY).pkScript };
+};
+
+/** A record exactly as `restoreAssetSwaps` writes one: `swapAddress: ""`. */
+const restored = (offer: Offer, overrides: Partial<AssetSwap> = {}): AssetSwap => ({
+    id: FUNDING_TXID,
+    fromAsset: "btc",
+    toAsset: testAsset.toString(),
+    fromAmount: "10000",
+    toAmount: offer.wantAmount.toString(),
+    swapAddress: "",
+    swapPkScript: hex.encode(offer.swapPkScript),
+    offerHex: hex.encode(encodeOffer(offer)),
+    fundingTxid: FUNDING_TXID,
+    status: "pending",
+    createdAt: 1_700_000_000_000,
+    ...overrides,
+});
+
+beforeEach(() => {
+    state.created = [];
+    state.watched = [];
+    state.getInfoCalls = 0;
+});
+
+describe("restoreOfferCoverage", () => {
+    it("registers the covenant behind a record the scan rebuilt", async () => {
+        const offer = makeOffer();
+        const record = restored(offer);
+
+        await restoreOfferCoverage(wallet, "http://ark", [record]);
+
+        expect(state.created).toHaveLength(1);
+        const row = state.created[0];
+        expect(row.type).toBe("arkade");
+        expect(row.script).toBe(record.swapPkScript);
+        expect(row.label).toBe(OFFER_CONTRACT_LABEL);
+        expect(row.metadata).toEqual({ genericallySpendable: false, kind: OFFER_CONTRACT_KIND });
+    });
+
+    it("puts the restored script back in the watched set", async () => {
+        const offer = makeOffer();
+        await restoreOfferCoverage(wallet, "http://ark", [restored(offer)]);
+        expect(state.watched).toEqual([[hex.encode(offer.swapPkScript), "watched"]]);
+    });
+
+    it("costs the same /v1/info whether it covers one script or many", async () => {
+        // one round trip per script is 110-215ms each, sequential, on boot
+        const many = [50_000, 60_000, 70_000, 80_000].map((n, i) =>
+            restored(makeOffer(BigInt(n)), {
+                id: `0${i}`.repeat(32),
+                fundingTxid: `0${i}`.repeat(32),
+            }),
+        );
+
+        await restoreOfferCoverage(wallet, "http://ark", [many[0]]);
+        const forOne = state.getInfoCalls;
+        state.getInfoCalls = 0;
+        await restoreOfferCoverage(wallet, "http://ark", many);
+
+        expect(state.created).toHaveLength(5);
+        expect(state.getInfoCalls).toBe(forOne);
+    });
+
+    it("leaves a script whose every record has settled alone", async () => {
+        for (const status of ["fulfilled", "cancelled"] as AssetSwapStatus[]) {
+            state.created = [];
+            state.watched = [];
+            await restoreOfferCoverage(wallet, "http://ark", [restored(makeOffer(), { status })]);
+            expect(state.created).toEqual([]);
+            expect(state.watched).toEqual([]);
+        }
+    });
+
+    it("promotes a script a live record holds once, settled sibling or not", async () => {
+        const offer = makeOffer();
+        await restoreOfferCoverage(wallet, "http://ark", [
+            restored(offer, { status: "fulfilled" }),
+            restored(offer, { id: "ee".repeat(32), fundingTxid: "ee".repeat(32) }),
+            restored(offer, { id: "ff".repeat(32), fundingTxid: "ff".repeat(32) }),
+        ]);
+        expect(state.watched).toEqual([[hex.encode(offer.swapPkScript), "watched"]]);
+        expect(state.created).toHaveLength(1);
+    });
+
+    it("still lets the restored script retire once its record settles", async () => {
+        // a mark dated later than every record at the script blocks the retire
+        const offer = makeOffer();
+        const script = hex.encode(offer.swapPkScript);
+        const record = restored(offer);
+
+        await restoreOfferCoverage(wallet, "http://ark", [record]);
+        await retireSettledOfferContracts(contractManager, [{ ...record, status: "fulfilled" }]);
+
+        expect(state.watched).toEqual([
+            [script, "watched"],
+            [script, "retained"],
+        ]);
+    });
+
+    it("skips a record whose covenant no longer derives, and keeps going", async () => {
+        // a server key rotated since funding: the rebuilt script is not this one
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const good = makeOffer();
+        const stale = restored(makeOffer(BigInt(77)), { swapPkScript: "51" + "00".repeat(32) });
+
+        await restoreOfferCoverage(wallet, "http://ark", [stale, restored(good)]);
+
+        expect(state.watched).toEqual([[hex.encode(good.swapPkScript), "watched"]]);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+});


### PR DESCRIPTION
Closes #877.

## The bug

`createOffer` registers an offer's covenant as a wallet contract (`offer.ts:633`). `restoreAssetSwaps` writes records and nothing else — grep `restore.ts` for `register`, `createContract` or a contract manager and the only hit is a comment.

So a record the restore scan rebuilt has **no contract row behind it**. `ContractManager` never subscribes to the script, no `vtxo_spent` is ever emitted for it, and `watchOfferSwaps` — a pure sink on `onContractEvent` — can never resolve that swap. No amount of waiting helps.

The evidence in the issue is a mainnet wallet restored from seed: 35 asset-swap records spanning three weeks, every one with `swapAddress: ""` (only the scan writes that), and zero contract rows for any of their covenant scripts — in a store holding six healthy unrelated rows.

### The backstop three modules lean on does not catch this

`coverage.ts`'s docblock excuses two other best-effort gaps on the grounds that both "leave a funded-but-unwatched row that the restore scan still finds — the same backstop every other best-effort step here relies on."

That backstop restores the **record**, not the **coverage**. It does not hold here, and it does not hold for the two gaps it was written to excuse.

## The fix

`restoreOfferCoverage(wallet, arkServerUrl, swaps)` re-registers and promotes each rebuilt covenant, deriving it from the record's own `offerHex` against the server's current signer key, once per script.

A separate export rather than an option on `restoreAssetSwaps`: that scan is deliberately indexer-only, and a coverage failure must not cost a caller the records it just recovered. Best-effort per script — a covenant that no longer derives, because the server key rotated since funding, is skipped rather than registered at the wrong script.

## Three things it must not do

All three are tested, and each mutation is caught by exactly one test.

**1. Promote a script whose every record is already `RETIRABLE`.** Named in the issue. That would undo `retireSettledOfferContracts` and put settled scripts back in the subscription and the failsafe poll.

**2. Leave the restored script pinned watched.** Not in the issue; found while building this. `promoteOfferContract` records an issuance mark so a script whose address is out but not yet funded is never retired, and `addressOutstanding` clears it only when a record at the script is *newer* than the mark. A restored record is older than `Date.now()` by construction — so marking now blocks every later retire **for the life of the process**. `promoteOfferContract` now takes the issuance time as a parameter, defaulting to `Date.now()`, and restore passes the record's own funding time.

**3. Cost a round trip per script.** `Arkade.connect` does a live `/v1/info` with no cache, so building a client per record puts N sequential requests on the **boot path** — at 110-215 ms each that is seconds for a wallet with the history this bug was found on. One client is built for the batch and handed to each registration, making `/v1/info` a constant cost. A test pins it; reverting the hoist turns it red.

## Test plan

- `packages/swap/test/restoreCoverage.test.ts`, 7 tests. Its own file because `coverage.ts` keeps the issuance mark in module state — a `createOffer` promotion in the same file would decide the retire assertion.
- As in `register.test.ts`, the covenant derivation, `Arkade.connect`, `ArkadeContract` and `register()` are all real; only the network seam and the contract manager are stubbed.
- Gate on this branch: `pnpm -r lint`, `pnpm -r build`, `pnpm -r test:unit` all exit 0. swap `33 files / 811 tests` -> `34 / 818`; ts-sdk `183 / 3047 +1 skipped` and boltz-swap `23 / 617` unchanged.

## Notes for review

- The pre-commit hook refuses to run in a git worktree (#880) — its filter selects no projects, so lint and `test:unit` would test nothing. The gate above was run manually and the commit uses `--no-verify`, as that hook's own message instructs.
- Independent of #864 and #878, not stacked. Merge order does not matter, though #877 and #878 are what make a restored wallet's swaps resolvable at all.
- Conflict risk: the export list in `packages/swap/src/index.ts`, against the in-flight onchain-receive work. One line; keep both sides.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic restoration of coverage for eligible, unsettled swap records.
  * Restored swaps are tracked using their original funding time.
  * Added support for reusing an existing connection during swap registration.
  * Exposed swap coverage restoration through the package API.

* **Bug Fixes**
  * Prevented restored deposits that have already landed from being incorrectly marked as watched.
  * Settled and stale swap records are skipped safely during restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Failure contract (added after review)

Setup for the batch — `getInfo`, `Arkade.connect`, `getContractManager` — **rejects** rather than being caught, and the docblock now says so. A server it could not reach covered *nothing*, which is exactly the unwatched-covenant state this issue is about, and a caller told it succeeded never retries. `promoteOfferContract` already draws the same line ("Throws, unlike retiring..."). A single unusable record — a covenant that no longer derives — is skipped instead, so one bad record cannot block the other thirty-four. Guard the call if your boot path must survive an outage.
