### PR TITLE
feat(swap): drive the onchain-receive corridor, L1 refund included

### DIFF
--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -63,7 +63,7 @@
         "prepack": "pnpm run build",
         "test": "vitest run --exclude test/e2e",
         "test:unit": "vitest run --exclude test/e2e",
-        "test:integration": "vitest run test/e2e/** --exclude test/e2e/rfq*.test.ts",
+        "test:integration": "vitest run test/e2e/** --exclude 'test/e2e/rfq*.test.ts'",
         "test:integration:rfq": "vitest run test/e2e/rfq*.test.ts",
         "smoke:dist": "node scripts/smoke-dist.mjs"
     },

--- a/packages/swap/src/activity.ts
+++ b/packages/swap/src/activity.ts
@@ -36,6 +36,7 @@ const LABELS: Record<SwapActivityInput["kind"], string> = {
     lightning_send: "Lightning send",
     lightning_receive: "Lightning receive",
     onchain_send: "Onchain send",
+    onchain_receive: "Onchain receive",
 };
 
 /**

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -44,9 +44,11 @@ export { IndexedDbAssetSwapRepository } from "./indexedDbRepository";
 // The two readers are how they come back — `rfqSignerOf` for the refund signer
 // on any leg, `rfqClaimSecretOf` for the preimage on a leg we claim.
 export {
+    onchainReceiveProfile,
     onchainSendProfile,
     type LightningReceiveProfile,
     type LightningSendProfile,
+    type OnchainReceiveProfile,
     type OnchainSendProfile,
 } from "./rfqCorridors";
 export {
@@ -221,16 +223,21 @@ export {
 } from "./lockupContract";
 export {
     RFQ_SWAP_TERMINAL_STATES,
+    OnchainReceiveNeedsChainSource,
     RfqSwapManager,
     RfqSwapOriginRequired,
     isRfqSwapTerminal,
     nextOnchainAction,
+    nextOnchainReceiveAction,
     type ArkadeRefundResult,
     type AvailableRfqSwapManagerCallbacks,
     type LightningReceiveSwap,
     type LightningSendSwap,
+    type OnchainReceiveAction,
+    type OnchainReceiveSwap,
     type OnchainSendAction,
     type OnchainSendSwap,
+    type ReceiveLockupSwap,
     type RfqRestoreFailure,
     type RfqRestoreOptions,
     type RfqRestoreResult,

--- a/packages/swap/src/onchainHtlc.ts
+++ b/packages/swap/src/onchainHtlc.ts
@@ -359,8 +359,12 @@ export interface ChainUtxo extends HtlcUtxo {
 export interface ChainSource {
     /** Confirmed+mempool outputs paying a script; used to detect the fill. */
     getScriptUtxos(pkScript: Uint8Array): Promise<ChainUtxo[]>;
-    /** The spend of an outpoint, if any — where P is extracted from. A
-     * provider omitting the spender txid still lists it in `pkScript`'s history. */
+    /**
+     * The spend of an outpoint, if any — where P is extracted from. A provider
+     * omitting the spender txid still lists it in `pkScript`'s history.
+     *
+     * **`txHex` MUST carry the witness**: a legacy serialization parses
+     * cleanly without one, so a stripped claim classifies as `swept`. */
     getSpendingTx(
         txid: string,
         vout: number,
@@ -454,21 +458,21 @@ export async function claimOnchainFill(
     return { txid, payoutAmount: spend.payoutAmount };
 }
 
-/** Where an onchain HTLC stands, for crash recovery (see the store docs:
+/**
+ * Where an onchain HTLC stands, for crash recovery (see the store docs:
  * persisting the record BEFORE funding is what makes this classification —
- * and the claim — possible after a restart). */
+ * and the claim — possible after a restart).
+ *
+ * **Each phase names which leaf moved, never whose turn it is** — the key
+ * roles swap between the legs (module header). `refundable` is the trap: the
+ * SOLVER's leaf on `arkade->onchain`, where THE CLAIM WINDOW IS CLOSED and
+ * `claimOnchainFill` throws by design; the TRADER's OWN on `onchain->arkade`,
+ * where it is the act-now signal and stays spendable.
+ */
 export type OnchainHtlcPhase =
     | { phase: "unfunded" }
     | { phase: "awaiting_confirmations"; utxo: ChainUtxo }
     | { phase: "claimable"; utxo: ChainUtxo }
-    /**
-     * The refund leaf has matured, which means the CLAIM WINDOW IS CLOSED —
-     * `claimOnchainFill` throws `claim_window_closed` from here, by design.
-     * A recovery caller reading this phase must not try to claim: the correct
-     * action is to let the counterparty's L1 refund settle and take the
-     * Arkade-side covenant refund. Reaching this phase on a swap you expected
-     * to claim means the claim was missed, not that it is still available.
-     */
     | { phase: "refundable"; utxo: ChainUtxo }
     | { phase: "claimed"; txid: string; preimage: Uint8Array }
     | { phase: "swept"; txid: string };
@@ -479,7 +483,7 @@ export type OnchainHtlcPhase =
  * already spent": without it a spent HTLC looks unfunded.
  *
  * `claimed` carries the preimage read from the spend's witness — the receipt;
- * `swept` is a spend that reveals no preimage (the counterparty's refund).
+ * `swept` is a spend that reveals no matching preimage.
  */
 export async function classifyOnchainHtlc(
     chain: ChainSource,

--- a/packages/swap/src/rfqCorridors.ts
+++ b/packages/swap/src/rfqCorridors.ts
@@ -18,7 +18,12 @@ import {
     type OnchainHtlcParams,
     type OnchainNetwork,
 } from "./onchainHtlc";
-import type { LightningReceiveSwap, OnchainSendSwap, RfqSwap } from "./swapManager";
+import type {
+    LightningReceiveSwap,
+    OnchainReceiveSwap,
+    OnchainSendSwap,
+    RfqSwap,
+} from "./swapManager";
 
 /**
  * `arkade:BTC->lightning:BTC`. Nothing beyond its keys and the covenant: the
@@ -46,7 +51,6 @@ export const LightningSendCorridor: RfqCorridorHandler<LightningSendProfile> = {
 export interface LightningReceiveProfile extends Record<string, unknown> {
     signer: RfqSignerProjection;
     hashlock: RfqHashlockProjection;
-    /** The quote's `to_amount`, captured at REQUEST time. */
     expectedAmount: number;
     /** Where the claim pays. */
     payoutAddress: string;
@@ -276,6 +280,127 @@ export const OnchainSendCorridor: RfqCorridorHandler<OnchainSendProfile> = {
     activityTxids: (profile) => (profile.claimTxid ? [profile.claimTxid] : []),
 };
 
+/** `onchain:BTC->arkade:BTC`: a receive Arkade half and a send L1 half, L1 key roles swapped. */
+export interface OnchainReceiveProfile extends Record<string, unknown> {
+    signer: RfqSignerProjection;
+    hashlock: RfqHashlockProjection;
+    /** The quote's `to_amount`, captured at REQUEST time. */
+    expectedAmount: number;
+    payoutAddress: string;
+    claimArkTxid?: string;
+    /** The SOLVER's L1 key; `refundKey` is the TRADER's own. */
+    claimKey: string;
+    refundKey: string;
+    /** The trader's L1 deadline, not the lockup's. */
+    htlcLocktime: number;
+    network: OnchainNetwork;
+    htlcAddress: string;
+    minConfirmations: number;
+    /** Where the L1 REFUND pays, hex — nothing else gives it back. */
+    refundPkScript: string;
+    funding?: { txid: string; vout: number };
+    refundTxid?: string;
+}
+
+/** The L1 half of what `requestOnchainReceive` returned. Exists for
+ * {@link onchainSendProfile}'s reason: `refundLocktime` becomes `htlcLocktime`,
+ * the record's own being the lockup's. */
+export function onchainReceiveProfile(result: {
+    htlc: Pick<OnchainHtlc, "address">;
+    htlcParams: OnchainHtlcParams;
+    l1Network: OnchainNetwork;
+    minConfirmations: number;
+    refundPkScript: Uint8Array;
+}): Omit<
+    OnchainReceiveProfile,
+    "signer" | "hashlock" | "expectedAmount" | "payoutAddress" | "claimArkTxid"
+> {
+    return {
+        claimKey: hex.encode(result.htlcParams.claimKey),
+        refundKey: hex.encode(result.htlcParams.refundKey),
+        htlcLocktime: result.htlcParams.refundLocktime,
+        network: result.l1Network,
+        htlcAddress: result.htlc.address,
+        minConfirmations: result.minConfirmations,
+        refundPkScript: hex.encode(result.refundPkScript),
+    };
+}
+
+export const OnchainReceiveCorridor: RfqCorridorHandler<OnchainReceiveProfile> = {
+    kind: "onchain_receive",
+
+    project: (swap: RfqSwap) => {
+        const receive = swap as OnchainReceiveSwap;
+        return {
+            expectedAmount: receive.expectedAmount,
+            ...(receive.claimArkTxid ? { claimArkTxid: receive.claimArkTxid } : {}),
+            ...(receive.funding ? { funding: receive.funding } : {}),
+            ...(receive.refundTxid ? { refundTxid: receive.refundTxid } : {}),
+        };
+    },
+
+    hydrate(profile) {
+        const { paymentHash } = hydrateHashlock(profile);
+        if (
+            typeof profile.expectedAmount !== "number" ||
+            !Number.isFinite(profile.expectedAmount)
+        ) {
+            throw new Error("onchain_receive record carries no expectedAmount; it cannot claim");
+        }
+        if (!profile.claimKey || !profile.refundKey) {
+            throw new Error(
+                "onchain_receive record carries no L1 keys; its HTLC cannot be rebuilt and the " +
+                    "trader's own funding could never be taken back",
+            );
+        }
+        if (!Number.isInteger(profile.minConfirmations) || profile.minConfirmations < 1) {
+            throw new Error(
+                `onchain_receive record carries no usable minConfirmations ` +
+                    `(${String(profile.minConfirmations)}); the confirmation gate cannot be checked`,
+            );
+        }
+        // Required where the send leg's `payoutPkScript` is optional: no
+        // record predates this one, and without it no refund can be built.
+        if (!profile.refundPkScript) {
+            throw new Error(
+                "onchain_receive record carries no refundPkScript; its L1 refund could not be " +
+                    "built, so the trader's funding would be stranded",
+            );
+        }
+        const htlc = onchainHtlcScript(
+            {
+                paymentHash,
+                claimKey: hex.decode(profile.claimKey),
+                refundKey: hex.decode(profile.refundKey),
+                refundLocktime: profile.htlcLocktime,
+            },
+            profile.network,
+        );
+        if (htlc.address !== profile.htlcAddress) {
+            throw new Error(
+                `onchain_receive record's L1 inputs derive ${htlc.address}, but the funding went ` +
+                    `to ${String(profile.htlcAddress)} — these are not this swap's`,
+            );
+        }
+        return {
+            paymentHash,
+            htlc,
+            expectedAmount: profile.expectedAmount,
+            minConfirmations: profile.minConfirmations,
+            refundPkScript: hex.decode(profile.refundPkScript),
+            ...(profile.claimArkTxid ? { claimArkTxid: profile.claimArkTxid } : {}),
+            ...(profile.funding ? { funding: profile.funding } : {}),
+            ...(profile.refundTxid ? { refundTxid: profile.refundTxid } : {}),
+        };
+    },
+
+    claimSecret: (profile) => ({ ...profile.signer, ...profile.hashlock }),
+
+    activityTxids: (profile) =>
+        [profile.claimArkTxid, profile.refundTxid].filter((txid): txid is string => !!txid),
+};
+
 rfqCorridorHandlers.register(LightningSendCorridor as RfqCorridorHandler);
 rfqCorridorHandlers.register(LightningReceiveCorridor as RfqCorridorHandler);
 rfqCorridorHandlers.register(OnchainSendCorridor as RfqCorridorHandler);
+rfqCorridorHandlers.register(OnchainReceiveCorridor as RfqCorridorHandler);

--- a/packages/swap/src/rfqCorridors.ts
+++ b/packages/swap/src/rfqCorridors.ts
@@ -51,6 +51,7 @@ export const LightningSendCorridor: RfqCorridorHandler<LightningSendProfile> = {
 export interface LightningReceiveProfile extends Record<string, unknown> {
     signer: RfqSignerProjection;
     hashlock: RfqHashlockProjection;
+    /** The quote's `to_amount`, captured at REQUEST time. */
     expectedAmount: number;
     /** Where the claim pays. */
     payoutAddress: string;

--- a/packages/swap/src/rfqRecord.ts
+++ b/packages/swap/src/rfqRecord.ts
@@ -37,7 +37,12 @@
  */
 import { ArkAddress, VHTLCV2ContractHandler, type VHTLC } from "@arkade-os/sdk";
 import { hex } from "@scure/base";
-import type { LightningReceiveSwap, LightningSendSwap, OnchainSendSwap } from "./swapManager";
+import type {
+    LightningReceiveSwap,
+    LightningSendSwap,
+    OnchainReceiveSwap,
+    OnchainSendSwap,
+} from "./swapManager";
 // From the vocabulary module, not from `swapManager`: the manager persists
 // through this file, so a runtime edge back to it would close a cycle.
 import { isRfqSwapTerminal, type RfqSwapState } from "./rfqSwapState";
@@ -45,7 +50,7 @@ import { rfqCorridorHandlers } from "./rfqCorridor";
 import "./rfqCorridors";
 
 /**
- * The swap kinds this projection covers — all three the manager monitors.
+ * The swap kinds this projection covers — all four the manager monitors.
  *
  * `onchain_send` carries an L1 half nothing else can rebuild. Its Arkade lockup
  * has a contract row like the others, but the HTLC is Bitcoin L1, not an Arkade
@@ -55,7 +60,11 @@ import "./rfqCorridors";
  * that corridor's {@link RfqSwapOrigin.profile}, and without them a restored
  * swap would let its L1 refund window pass unwatched.
  */
-export type PersistableRfqSwap = LightningSendSwap | LightningReceiveSwap | OnchainSendSwap;
+export type PersistableRfqSwap =
+    | LightningSendSwap
+    | LightningReceiveSwap
+    | OnchainSendSwap
+    | OnchainReceiveSwap;
 
 /**
  * The serialized covenant parameters a rebuild is given.

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -288,18 +288,35 @@ export interface LightningReceiveSwap extends RfqSwapCommon {
  * `receiveVtxoScript` / `onchainHtlcScript` over the quote's binding fields —
  * and hands the result to {@link RfqSwapManager.start}.
  *
- * **`onchain:BTC->arkade:BTC` is deliberately not a member yet.** Its Arkade
- * half is the same solver-funded lockup as {@link LightningReceiveSwap}'s, but
- * it also has an L1 half the trader funds and must take back itself
- * (`buildHtlcRefund` at the HTLC's own `htlc_locktime`), which is a second
- * deadline, a second observation seam and a second action callback. Adding the
- * lockup half alone would produce a manager that silently lets that L1 refund
- * window pass — the one failure mode {@link RfqSwapManager} refuses elsewhere
- * by name (see `driveOnchain`'s missing-`ChainSource` check). Until the L1
- * refund is driven too, that corridor is better served by the request and claim
- * functions directly than by a monitor that covers half of it.
  */
-export type RfqSwap = LightningSendSwap | OnchainSendSwap | LightningReceiveSwap;
+export type RfqSwap =
+    | LightningSendSwap
+    | OnchainSendSwap
+    | LightningReceiveSwap
+    | OnchainReceiveSwap;
+
+/**
+ * `onchain:BTC->arkade:BTC`. A {@link LightningReceiveSwap}'s lockup plus an L1
+ * HTLC the trader funds and must take back itself. That refund leaf does not
+ * expire, so the failure to drive against is the manager finishing the swap
+ * while the output still holds the trader's money.
+ */
+export interface OnchainReceiveSwap extends RfqSwapCommon {
+    kind: "onchain_receive";
+    expectedAmount: number;
+    /** Its `refundLocktime` is the trader's own, NOT {@link RfqSwapCommon}'s. */
+    htlc: OnchainHtlc;
+    minConfirmations: number;
+    /** Required, unlike the send leg's optional `payoutPkScript`: without it
+     * the refund cannot be built at all. */
+    refundPkScript: Uint8Array;
+    funding?: { txid: string; vout: number };
+    claimArkTxid?: string;
+    refundTxid?: string;
+}
+
+/** The two legs sharing one claim path, `expectedAmount` gate included. */
+export type ReceiveLockupSwap = LightningReceiveSwap | OnchainReceiveSwap;
 
 // ── The onchain state machine ───────────────────────────────────────────────
 
@@ -361,6 +378,34 @@ export function nextOnchainAction(input: {
     }
 }
 
+/** {@link OnchainSendAction}'s mirror, minus `refund_window_closed`: an
+ * `nLockTime` refund leaf does not close. */
+export type OnchainReceiveAction = "wait" | "refund" | "refunded" | "taken";
+
+/**
+ * Off the SAME phases the send leg reads (see {@link OnchainHtlcPhase}); no
+ * clock or margin, `refundable` being the median-time-past verdict itself. */
+export function nextOnchainReceiveAction(input: {
+    phase: OnchainHtlcPhase;
+    settled: boolean;
+}): OnchainReceiveAction {
+    switch (input.phase.phase) {
+        case "unfunded":
+        case "awaiting_confirmations":
+        case "claimable":
+            return "wait";
+        case "claimed":
+            return "taken";
+        case "swept":
+            return "refunded";
+        case "refundable":
+            // Refusal, not an omission: the trader took the lockup, so this
+            // output is the solver's payment and refunding it too would be
+            // taking both sides of the trade.
+            return input.settled ? "taken" : "refund";
+    }
+}
+
 // ── Callbacks, events, configuration ─────────────────────────────────────────
 
 /** What the trader's own `refundWithoutReceiver` push returned, or `null` when
@@ -388,6 +433,12 @@ export interface RfqSwapManagerCallbacks {
     /** Build and broadcast the L1 claim. See `claimOnchainFill`. */
     claimOnchain: (swap: OnchainSendSwap, utxo: ChainUtxo) => Promise<{ txid: string }>;
     /**
+     * `buildHtlcRefund` over `swap.refundPkScript`, then `chain.broadcast`.
+     * Required for {@link claimOnchain}'s reason: monitoring one of these
+     * unwired strands the trader's funding. A throw is retried indefinitely.
+     */
+    refundOnchain: (swap: OnchainReceiveSwap, utxo: ChainUtxo) => Promise<{ txid: string }>;
+    /**
      * Claim the solver-funded lockup on a receive leg, revealing `P`. Wire it
      * to `pushClaim` — the outputs are supplied, so `findLockupVtxos` has
      * already been called and `claimReceiveLockup`'s wait would only sit on a
@@ -408,7 +459,7 @@ export interface RfqSwapManagerCallbacks {
      * refusal in its place.
      */
     claimLockup: (
-        swap: LightningReceiveSwap,
+        swap: ReceiveLockupSwap,
         vtxos: readonly LockupVtxo[],
         options: {
             /** A claim of ours is already out, so `P` is public and the value
@@ -488,12 +539,14 @@ export interface RfqSwapManagerCallbacks {
  */
 export type AvailableRfqSwapManagerCallbacks = Omit<
     RfqSwapManagerCallbacks,
-    "claimOnchain" | "claimLockup" | "saveSwap"
+    "claimOnchain" | "claimLockup" | "refundOnchain" | "saveSwap"
 > &
-    Partial<Pick<RfqSwapManagerCallbacks, "claimOnchain" | "claimLockup" | "saveSwap">>;
+    Partial<
+        Pick<RfqSwapManagerCallbacks, "claimOnchain" | "claimLockup" | "refundOnchain" | "saveSwap">
+    >;
 
 /** The actions the manager executes on a caller's behalf. */
-export type RfqSwapActionName = "claimOnchain" | "claimLockup" | "refundArkade";
+export type RfqSwapActionName = "claimOnchain" | "claimLockup" | "refundArkade" | "refundOnchain";
 
 export interface RfqSwapManagerEvents {
     /** Every state change, including ones that read as going backwards.
@@ -585,6 +638,22 @@ export class RfqSwapOriginRequired extends Error {
                 `written`,
         );
         this.name = "RfqSwapOriginRequired";
+        this.rfqId = rfqId;
+    }
+}
+
+/** An `onchain_receive` swap reached a manager with no
+ * {@link RfqSwapManagerDeps.chain}, so it could watch only half the corridor.
+ * Thrown from `addSwap` — normally the last moment before the trader funds. */
+export class OnchainReceiveNeedsChainSource extends Error {
+    readonly rfqId: string;
+    constructor(rfqId: string) {
+        super(
+            `rfq swap ${rfqId} is an onchain_receive swap and this manager has no ChainSource; ` +
+                `its L1 refund could be neither seen nor made, so it is refused rather than ` +
+                `monitored blind`,
+        );
+        this.name = "OnchainReceiveNeedsChainSource";
         this.rfqId = rfqId;
     }
 }
@@ -1108,6 +1177,9 @@ export class RfqSwapManager {
      * and only when the first two are absent.
      */
     private async admit(swap: RfqSwap, origin?: RfqSwapOrigin): Promise<void> {
+        if (swap.kind === "onchain_receive" && !this.deps.chain) {
+            throw new OnchainReceiveNeedsChainSource(swap.rfqId);
+        }
         if (origin) {
             // Checked here, not left to the first write. A `kind` or
             // `lockupAddress` that disagrees is a programming error either way,
@@ -1456,6 +1528,12 @@ export class RfqSwapManager {
             // that do not care whether the indexer is up.
             fate = { fate: "unknown" };
         }
+        // Before the terminal shortcut, and that order is the whole safety
+        // argument: `returned` means the SOLVER took the lockup back, which is
+        // when the trader's L1 funding must come home. Ending there would
+        // unwatch a funded HTLC forever.
+        if (swap.kind === "onchain_receive") return this.driveOnchainReceive(swap, fate);
+
         if (fate.fate === "claimed" || fate.fate === "returned") {
             // Stamped before the state change, so the write that `setState`
             // makes dirty carries the spend with it — one write, not two, and
@@ -1540,7 +1618,7 @@ export class RfqSwapManager {
      * back, so once the window shuts the swap is the solver's to resolve and
      * this manager's job is to watch it happen and then stop.
      */
-    private async driveReceiveClaim(swap: LightningReceiveSwap): Promise<void> {
+    private async driveReceiveClaim(swap: ReceiveLockupSwap): Promise<void> {
         const now = this.config.now();
 
         if (now < swap.refundLocktime) {
@@ -1600,7 +1678,7 @@ export class RfqSwapManager {
      * relax it.
      */
     private async claimIfFunded(
-        swap: LightningReceiveSwap,
+        swap: ReceiveLockupSwap,
         vtxos: readonly LockupVtxo[],
     ): Promise<void> {
         if (vtxos.length === 0) return this.unblock(swap);
@@ -1691,6 +1769,88 @@ export class RfqSwapManager {
             this.lastClaimError.set(swap.rfqId, errorMessage(error));
             this.emitFailed(swap, error);
         }
+    }
+
+    /** `settled` ends the swap; `returned` does NOT, signalling their L1
+     * funding is stranded. */
+    private async driveOnchainReceive(swap: OnchainReceiveSwap, fate: LockupFate): Promise<void> {
+        const settled = fate.fate === "claimed";
+        if (settled || fate.fate === "returned") this.stampLockupSpends(swap, fate.spends);
+
+        if (settled) {
+            this.setState(swap, "settled");
+            return;
+        }
+
+        const l1 = await this.driveOnchainRefund(swap, settled);
+
+        if (fate.fate === "returned") {
+            if (l1 === "resolved") this.setState(swap, "refunded");
+            return;
+        }
+        if (fate.fate === "exited") return this.blockExitedLockup(swap, fate);
+        return this.driveReceiveClaim(swap);
+    }
+
+    /** `resolved`: the HTLC can hold nothing more. No give-up branch. */
+    private async driveOnchainRefund(
+        swap: OnchainReceiveSwap,
+        settled: boolean,
+    ): Promise<"resolved" | "live"> {
+        // `admit` refuses this kind without one; never drive blind if that changes.
+        if (!this.deps.chain) return "live";
+
+        let phase: OnchainHtlcPhase;
+        try {
+            phase = await classifyOnchainHtlc(this.deps.chain, {
+                htlc: swap.htlc,
+                minConfirmations: swap.minConfirmations,
+                funding: swap.funding,
+            });
+        } catch {
+            return "live";
+        }
+        if ("utxo" in phase && !swap.funding) {
+            swap.funding = { txid: phase.utxo.txid, vout: phase.utxo.vout };
+            this.touch(swap);
+        }
+        if (phase.phase === "unfunded" && !swap.funding) return "resolved";
+
+        switch (nextOnchainReceiveAction({ phase, settled })) {
+            case "taken":
+                return "resolved";
+            case "refunded":
+                if (phase.phase === "swept" && !swap.refundTxid) {
+                    swap.refundTxid = phase.txid;
+                    this.touch(swap);
+                }
+                return "resolved";
+            case "wait":
+                return "live";
+            case "refund":
+                break;
+        }
+        if (phase.phase !== "refundable") return "live";
+        if (swap.refundTxid) return "live";
+
+        // Blocked, not failed: `setCallbacks` exists so this can arrive late.
+        if (this.callbacks && !this.callbacks.refundOnchain) {
+            this.block(
+                swap,
+                "no refundOnchain callback is wired, so this wallet cannot take the L1 funding back",
+            );
+            return "live";
+        }
+        if (!this.config.enableAutoActions || !this.callbacks?.refundOnchain) return "live";
+        try {
+            const { txid } = await this.callbacks.refundOnchain(swap, phase.utxo);
+            swap.refundTxid = txid;
+            this.touch(swap);
+            this.emitAction(swap, "refundOnchain");
+        } catch (error) {
+            this.emitFailed(swap, error);
+        }
+        return "live";
     }
 
     /** `handled` ends the pass; `continue` falls through to the refund gate. */
@@ -2130,6 +2290,7 @@ const traderClaimTxid = (swap: RfqSwap): string | undefined => {
         case "onchain_send":
             return swap.claimTxid;
         case "lightning_receive":
+        case "onchain_receive":
             return swap.claimArkTxid;
         default:
             return undefined;
@@ -2158,6 +2319,9 @@ const outcomeOf = (swap: RfqSwap): RfqSwapOutcome => {
     // has nothing — the single combination in which `txid` present would not
     // mean an action that landed. The record still carries it for diagnosis.
     const lostReceive = swap.kind === "lightning_receive" && swap.state === "refunded";
+    if (swap.kind === "onchain_receive" && swap.state === "refunded") {
+        return { state: swap.state, txid: swap.refundTxid };
+    }
     return {
         state: swap.state,
         txid: lostReceive ? swap.refundArkTxid : (traderClaimTxid(swap) ?? swap.refundArkTxid),

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -1786,7 +1786,7 @@ export class RfqSwapManager {
             return;
         }
 
-        const l1 = await this.driveOnchainRefund(swap);
+        const l1 = await this.driveOnchainRefund(swap, swap.claimArkTxid !== undefined);
 
         if (fate.fate === "returned") {
             if (l1.verdict === "resolved") this.setState(swap, "refunded");
@@ -1808,6 +1808,16 @@ export class RfqSwapManager {
                         "holding the swap open until its refund leaf opens",
             );
         }
+        // The mirror of the `settled` refusal: whichever leg the trader takes
+        // first forecloses the other. Reachable only when the quote leaves both
+        // legs live at once, which `assertFundable` does not gate here.
+        if (swap.refundTxid) {
+            return this.block(
+                swap,
+                "the L1 funding was refunded, so claiming the lockup too would take both " +
+                    "sides of the trade — the solver's reclaim ends this swap",
+            );
+        }
         await this.driveReceiveClaim(swap);
         // After that arm, never before: it `unblock`s an empty lockup, which
         // would erase the refusal the L1 half just reported.
@@ -1818,6 +1828,9 @@ export class RfqSwapManager {
      * caller applies once the Arkade arm has run. No give-up branch. */
     private async driveOnchainRefund(
         swap: OnchainReceiveSwap,
+        /** A claim of ours is out, so this output is the solver's. Cannot ride
+         * on `settled`, whose early return would skip the refund entirely. */
+        claimSubmitted: boolean,
     ): Promise<{ verdict: "resolved" | "live"; blocked?: string }> {
         // `admit` refuses this kind without one; never drive blind if that changes.
         if (!this.deps.chain) return { verdict: "live" };
@@ -1838,8 +1851,7 @@ export class RfqSwapManager {
         }
         if (phase.phase === "unfunded" && !swap.funding) return { verdict: "resolved" };
 
-        // Always `false`: `driveOnchainReceive` returns first when settled.
-        switch (nextOnchainReceiveAction({ phase, settled: false })) {
+        switch (nextOnchainReceiveAction({ phase, settled: claimSubmitted })) {
             case "taken":
                 return { verdict: "resolved" };
             case "refunded":

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -1811,7 +1811,7 @@ export class RfqSwapManager {
         // The mirror of the `settled` refusal: whichever leg the trader takes
         // first forecloses the other. Reachable only when the quote leaves both
         // legs live at once, which `assertFundable` does not gate here.
-        if (swap.refundTxid) {
+        if (swap.refundTxid || l1.attempted) {
             return this.block(
                 swap,
                 "the L1 funding was refunded, so claiming the lockup too would take both " +
@@ -1831,7 +1831,7 @@ export class RfqSwapManager {
         /** A claim of ours is out, so this output is the solver's. Cannot ride
          * on `settled`, whose early return would skip the refund entirely. */
         claimSubmitted: boolean,
-    ): Promise<{ verdict: "resolved" | "live"; blocked?: string }> {
+    ): Promise<{ verdict: "resolved" | "live"; blocked?: string; attempted?: boolean }> {
         // `admit` refuses this kind without one; never drive blind if that changes.
         if (!this.deps.chain) return { verdict: "live" };
 
@@ -1892,7 +1892,9 @@ export class RfqSwapManager {
         } catch (error) {
             this.emitFailed(swap, error);
         }
-        return { verdict: "live" };
+        // `attempted`, not just `refundTxid`: a callback that broadcast then
+        // threw leaves no txid, and claiming this pass would take both legs.
+        return { verdict: "live", attempted: true };
     }
 
     /** `handled` ends the pass; `continue` falls through to the refund gate. */

--- a/packages/swap/src/swapManager.ts
+++ b/packages/swap/src/swapManager.ts
@@ -989,6 +989,10 @@ export class RfqSwapManager {
             let swap: RfqSwap;
             try {
                 swap = rebuildRfqSwap(record, await params(record));
+                // Inside the try so it lands in `failed` and the record stays.
+                if (swap.kind === "onchain_receive" && !this.deps.chain) {
+                    throw new OnchainReceiveNeedsChainSource(swap.rfqId);
+                }
             } catch (error) {
                 failed.push({
                     rfqId: record.rfqId,
@@ -1782,23 +1786,41 @@ export class RfqSwapManager {
             return;
         }
 
-        const l1 = await this.driveOnchainRefund(swap, settled);
+        const l1 = await this.driveOnchainRefund(swap);
 
         if (fate.fate === "returned") {
-            if (l1 === "resolved") this.setState(swap, "refunded");
+            if (l1.verdict === "resolved") this.setState(swap, "refunded");
+            else if (l1.blocked) this.block(swap, l1.blocked);
             return;
         }
         if (fate.fate === "exited") return this.blockExitedLockup(swap, fate);
-        return this.driveReceiveClaim(swap);
+        // `driveReceiveClaim` ends a receive swap at its own deadline, which
+        // this leg cannot afford: the trader's refund leaf opens AFTER it, and
+        // an unfunded lockup — what a defaulting solver leaves — reaches here.
+        if (
+            l1.verdict === "live" &&
+            this.config.now() >= swap.refundLocktime + REFUND_MTP_LAG_SECONDS
+        ) {
+            return this.block(
+                swap,
+                l1.blocked ??
+                    "the Arkade claim window closed unclaimed and the L1 HTLC is still funded — " +
+                        "holding the swap open until its refund leaf opens",
+            );
+        }
+        await this.driveReceiveClaim(swap);
+        // After that arm, never before: it `unblock`s an empty lockup, which
+        // would erase the refusal the L1 half just reported.
+        if (l1.blocked && !isRfqSwapTerminal(swap.state)) this.block(swap, l1.blocked);
     }
 
-    /** `resolved`: the HTLC can hold nothing more. No give-up branch. */
+    /** `resolved`: the HTLC can hold nothing more. `blocked` is a refusal the
+     * caller applies once the Arkade arm has run. No give-up branch. */
     private async driveOnchainRefund(
         swap: OnchainReceiveSwap,
-        settled: boolean,
-    ): Promise<"resolved" | "live"> {
+    ): Promise<{ verdict: "resolved" | "live"; blocked?: string }> {
         // `admit` refuses this kind without one; never drive blind if that changes.
-        if (!this.deps.chain) return "live";
+        if (!this.deps.chain) return { verdict: "live" };
 
         let phase: OnchainHtlcPhase;
         try {
@@ -1808,40 +1830,48 @@ export class RfqSwapManager {
                 funding: swap.funding,
             });
         } catch {
-            return "live";
+            return { verdict: "live" };
         }
         if ("utxo" in phase && !swap.funding) {
             swap.funding = { txid: phase.utxo.txid, vout: phase.utxo.vout };
             this.touch(swap);
         }
-        if (phase.phase === "unfunded" && !swap.funding) return "resolved";
+        if (phase.phase === "unfunded" && !swap.funding) return { verdict: "resolved" };
 
-        switch (nextOnchainReceiveAction({ phase, settled })) {
+        // Always `false`: `driveOnchainReceive` returns first when settled.
+        switch (nextOnchainReceiveAction({ phase, settled: false })) {
             case "taken":
-                return "resolved";
+                return { verdict: "resolved" };
             case "refunded":
                 if (phase.phase === "swept" && !swap.refundTxid) {
                     swap.refundTxid = phase.txid;
                     this.touch(swap);
                 }
-                return "resolved";
+                return { verdict: "resolved" };
             case "wait":
-                return "live";
+                return { verdict: "live" };
             case "refund":
                 break;
         }
-        if (phase.phase !== "refundable") return "live";
-        if (swap.refundTxid) return "live";
+        if (phase.phase !== "refundable") return { verdict: "live" };
+        if (swap.refundTxid) return { verdict: "live" };
 
-        // Blocked, not failed: `setCallbacks` exists so this can arrive late.
-        if (this.callbacks && !this.callbacks.refundOnchain) {
-            this.block(
-                swap,
-                "no refundOnchain callback is wired, so this wallet cannot take the L1 funding back",
-            );
-            return "live";
+        // Reported, not silent: no `claimable` manual mode exists here.
+        if (!this.callbacks?.refundOnchain) {
+            return {
+                verdict: "live",
+                blocked: this.callbacks
+                    ? "no refundOnchain callback is wired, so this wallet cannot take the L1 funding back"
+                    : "no callbacks are wired, so this wallet cannot take the L1 funding back",
+            };
         }
-        if (!this.config.enableAutoActions || !this.callbacks?.refundOnchain) return "live";
+        if (!this.config.enableAutoActions) {
+            return {
+                verdict: "live",
+                blocked:
+                    "automatic actions are disabled, so this wallet will not push the L1 refund",
+            };
+        }
         try {
             const { txid } = await this.callbacks.refundOnchain(swap, phase.utxo);
             swap.refundTxid = txid;
@@ -1850,7 +1880,7 @@ export class RfqSwapManager {
         } catch (error) {
             this.emitFailed(swap, error);
         }
-        return "live";
+        return { verdict: "live" };
     }
 
     /** `handled` ends the pass; `continue` falls through to the refund gate. */

--- a/packages/swap/test/e2e/rfqOnchainReceive.test.ts
+++ b/packages/swap/test/e2e/rfqOnchainReceive.test.ts
@@ -1,0 +1,247 @@
+/**
+ * The onchain-receive corridor's L1 half against the real stack. The trader
+ * funds L1 and the solver funds the Arkade lockup, so the branch that matters
+ * is `refundable`: refunding the L1 output after the Arkade side settled takes
+ * BOTH sides of the trade. A unit test reaches it by handing in a phase; only
+ * chain state proves the phase is the one the corridor will see. Solver stubbed
+ * as in `rfqRegister.test.ts`.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { execSync } from "child_process";
+import { hex } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import {
+    ArkAddress,
+    EsploraProvider,
+    InMemoryContractRepository,
+    InMemoryWalletRepository,
+    REGTEST_EMULATOR_PUBKEY,
+    RestArkProvider,
+    SingleKey,
+    Wallet,
+} from "@arkade-os/sdk";
+import {
+    ONCHAIN_RECEIVE_PAIR,
+    chainSourceFrom,
+    classifyOnchainHtlc,
+    nextOnchainReceiveAction,
+    onchainHtlcScript,
+    receiveVtxoScript,
+    requestOnchainReceive,
+    unilateralClaimDelay,
+    type RfqQuote,
+    type RfqTransport,
+} from "../../src";
+
+const ARK_URL = "http://localhost:7070";
+const ESPLORA_API_URL = "http://localhost:3000/api";
+const arkdExec = "docker exec -t arkd";
+const bccli = "docker exec -t bitcoin bitcoin-cli -regtest -rpcuser=admin1 -rpcpassword=123";
+
+const FAUCET_SATS = 30_000;
+const SWAP_SATS = 20_000;
+const MIN_CONFIRMATIONS = 1;
+/** Comfortably inside the fundable window `assertFundable` enforces. */
+const HTLC_LOCKTIME_OFFSET = 6 * 3600;
+
+const xOnly = (key: Uint8Array): Uint8Array => {
+    if (key.length === 32) return key;
+    if (key.length !== 33 || (key[0] !== 0x02 && key[0] !== 0x03)) {
+        throw new Error("not a compressed or x-only public key");
+    }
+    return key.slice(1);
+};
+
+const execCommand = (command: string): string => {
+    const result = execSync(command, { encoding: "utf8" })
+        .replace(/\r/g, "")
+        .split("\n")
+        .filter((line) => !line.includes("WARN"))
+        .join("\n")
+        .trim();
+    if (result.startsWith("error:")) throw new Error(result);
+    return result;
+};
+
+const mine = (blocks: number) => execCommand(`node regtest/regtest.mjs mine ${blocks}`);
+
+const chainInfo = (): { blocks: number; mediantime: number } =>
+    JSON.parse(execCommand("node regtest/regtest.mjs rpc getblockchaininfo"));
+
+const waitFor = async (
+    fn: () => Promise<boolean>,
+    { timeout = 60_000, interval = 1000 } = {},
+): Promise<void> => {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+        if (await fn()) return;
+        await new Promise((r) => setTimeout(r, interval));
+    }
+    throw new Error("timeout in waitFor");
+};
+
+const SOLVER = schnorr.getPublicKey(new Uint8Array(32).fill(7));
+const SOLVER_L1_CLAIM = schnorr.getPublicKey(new Uint8Array(32).fill(9));
+const NOW = () => Math.floor(Date.now() / 1000);
+
+let wallet: Wallet;
+let traderRefundKey: Uint8Array;
+let solverRefundPkScript: Uint8Array;
+let htlcLocktime: number;
+let operatorPubkey: Uint8Array;
+let emulatorPubkey: Uint8Array;
+let claimDelay: number;
+let hrp: string;
+
+/**
+ * Built from the same inputs the trader will use, so the address comparison in
+ * `deriveOnchainReceive` runs for real and cannot fail for solver reasons.
+ */
+const stubTransport = (): RfqTransport => ({
+    async requestQuote(payload) {
+        const profile = (payload as { profile: Record<string, unknown> }).profile;
+        htlcLocktime = NOW() + HTLC_LOCKTIME_OFFSET;
+        const refundLocktime = htlcLocktime + 3600;
+        const paymentHash = profile.payment_hash as string;
+        const htlc = onchainHtlcScript(
+            {
+                paymentHash,
+                claimKey: SOLVER_L1_CLAIM,
+                refundKey: hex.decode(profile.refund_pubkey as string),
+                refundLocktime: htlcLocktime,
+            },
+            "regtest",
+        );
+        const lockup = receiveVtxoScript({
+            solverPubkey: SOLVER,
+            refundLocktime,
+            serverPubkey: operatorPubkey,
+            paymentHash,
+            claimDelay,
+            emulatorPubkey,
+            solverRefundPkScript,
+            payoutPubkey: hex.decode(profile.payout_pubkey as string),
+            payoutPkScript: ArkAddress.decode(profile.payout_address as string).pkScript,
+        });
+        return {
+            v: 1,
+            type: "rfq_quote",
+            rfq_id: payload.rfq_id as string,
+            pair: ONCHAIN_RECEIVE_PAIR,
+            from_amount: SWAP_SATS,
+            to_amount: SWAP_SATS,
+            solver_pubkey: hex.encode(SOLVER),
+            valid_until: NOW() + 3600,
+            refund_locktime: refundLocktime,
+            profile: {
+                claim_pubkey: hex.encode(SOLVER_L1_CLAIM),
+                htlc_locktime: htlcLocktime,
+                htlc_address: htlc.address,
+                min_confirmations: MIN_CONFIRMATIONS,
+                solver_refund_pk_script: hex.encode(solverRefundPkScript),
+                lockup_address: lockup.address(hrp, operatorPubkey).encode(),
+            },
+        } as unknown as RfqQuote;
+    },
+    async status() {
+        return null;
+    },
+    async close() {},
+});
+
+beforeAll(async () => {
+    wallet = await Wallet.create({
+        identity: SingleKey.fromRandomBytes(),
+        arkServerUrl: ARK_URL,
+        onchainProvider: new EsploraProvider(ESPLORA_API_URL, {
+            forcePolling: true,
+            pollingInterval: 2000,
+        }),
+        storage: {
+            walletRepository: new InMemoryWalletRepository(),
+            contractRepository: new InMemoryContractRepository(),
+        },
+        settlementConfig: false,
+    });
+
+    const note = execCommand(`${arkdExec} arkd note --amount 200000`);
+    execCommand(`${arkdExec} ark redeem-notes -n ${note} --password secret`);
+    const address = await wallet.getAddress();
+    execCommand(`${arkdExec} ark send --to ${address} --amount ${FAUCET_SATS} --password secret`);
+    await waitFor(async () => (await wallet.getVtxos()).length > 0);
+
+    traderRefundKey = schnorr.getPublicKey(new Uint8Array(32).fill(11));
+    solverRefundPkScript = ArkAddress.decode(address).pkScript;
+
+    const info = await new RestArkProvider(ARK_URL).getInfo();
+    operatorPubkey = xOnly(hex.decode(info.signerPubkey));
+    claimDelay = unilateralClaimDelay(Number(info.unilateralExitDelay));
+    hrp = ArkAddress.decode(address).hrp;
+    emulatorPubkey = xOnly(hex.decode(REGTEST_EMULATOR_PUBKEY));
+}, 180_000);
+
+const chainSource = () =>
+    chainSourceFrom(
+        new EsploraProvider(ESPLORA_API_URL, { forcePolling: true, pollingInterval: 2000 }),
+        "regtest",
+    );
+
+const classifier = (htlc: Parameters<typeof classifyOnchainHtlc>[1]["htlc"]) => {
+    const chain = chainSource();
+    return () => classifyOnchainHtlc(chain, { htlc, minConfirmations: MIN_CONFIRMATIONS });
+};
+
+describe("onchain-receive corridor L1 half (regtest)", () => {
+    it("walks the corridor's OWN htlc from unfunded to claimable on real chain state", async () => {
+        const received = await requestOnchainReceive(wallet, ARK_URL, stubTransport(), {
+            amount: SWAP_SATS,
+            amountSide: "from",
+            refundPubkey: traderRefundKey,
+        });
+        const classify = classifier(received.htlc);
+
+        expect((await classify()).phase).toBe("unfunded");
+        expect(nextOnchainReceiveAction({ phase: await classify(), settled: false })).toBe("wait");
+
+        execCommand(`${bccli} sendtoaddress ${received.htlc.address} ${SWAP_SATS / 1e8}`);
+        await waitFor(async () => (await classify()).phase !== "unfunded");
+        expect((await classify()).phase).toBe("awaiting_confirmations");
+        expect(nextOnchainReceiveAction({ phase: await classify(), settled: false })).toBe("wait");
+
+        mine(MIN_CONFIRMATIONS);
+        await waitFor(async () => (await classify()).phase === "claimable");
+        // still `wait`: the solver has until the locktime to fund the lockup
+        expect(nextOnchainReceiveAction({ phase: await classify(), settled: false })).toBe("wait");
+    }, 300_000);
+
+    /**
+     * Built directly, and that is forced: `assertFundable` refuses a locktime
+     * under `minConfirmations * 600 + 5400` away — 100 minutes at one
+     * confirmation — so no quote reaching `refundable` can exist inside a test.
+     * Same derivation; only the funding gate is skipped.
+     */
+    it("refuses to refund a settled swap once the htlc is refundable", async () => {
+        const matured = Math.min(chainInfo().mediantime, Math.floor(Date.now() / 1000)) - 3600;
+        const htlc = onchainHtlcScript(
+            {
+                paymentHash: "cd".repeat(32),
+                claimKey: SOLVER_L1_CLAIM,
+                refundKey: traderRefundKey,
+                refundLocktime: matured,
+            },
+            "regtest",
+        );
+        const classify = classifier(htlc);
+
+        execCommand(`${bccli} sendtoaddress ${htlc.address} ${SWAP_SATS / 1e8}`);
+        mine(MIN_CONFIRMATIONS);
+        await waitFor(async () => (await classify()).phase === "refundable");
+
+        const refundable = await classify();
+        expect(refundable.phase).toBe("refundable");
+        // the money branch, off chain state: refunding a settled swap takes the
+        // lockup AND the L1 output the solver paid for it
+        expect(nextOnchainReceiveAction({ phase: refundable, settled: false })).toBe("refund");
+        expect(nextOnchainReceiveAction({ phase: refundable, settled: true })).toBe("taken");
+    }, 300_000);
+});

--- a/packages/swap/test/rfqRecord.test.ts
+++ b/packages/swap/test/rfqRecord.test.ts
@@ -558,3 +558,108 @@ describe("the spend that ended the swap", () => {
         expect(updateRfqSwapRecord(record, swapOf(sendOrigin)).lockupSpendArkTxids).toBeUndefined();
     });
 });
+
+describe("an onchain-receive record carries BOTH halves", () => {
+    // The L1 HTLC has no contract row anywhere, so every input is stored here.
+    const HTLC_LOCKTIME = REFUND_LOCKTIME + 7_200;
+    const REFUND_PK_SCRIPT = hex.encode(new Uint8Array([0x51, 0x20, ...key(21)]));
+    const L1_HTLC = onchainHtlcScript(
+        {
+            paymentHash: PAYMENT_HASH,
+            claimKey: key(15),
+            refundKey: key(11),
+            refundLocktime: HTLC_LOCKTIME,
+        },
+        "regtest",
+    );
+
+    const origin: RfqSwapOrigin = {
+        kind: "onchain_receive",
+        lockupAddress: RECEIVE_LOCKUP.address,
+        profile: {
+            signer: { signingDescriptor: `tr(${hex.encode(key(7))})` },
+            hashlock: { paymentHash: PAYMENT_HASH },
+            expectedAmount: 100_000,
+            payoutAddress: "ark1payout",
+            claimKey: hex.encode(key(15)),
+            refundKey: hex.encode(key(11)),
+            htlcLocktime: HTLC_LOCKTIME,
+            network: "regtest" as const,
+            htlcAddress: L1_HTLC.address,
+            minConfirmations: 2,
+            refundPkScript: REFUND_PK_SCRIPT,
+        },
+        amount: 100_000,
+    };
+
+    const live = (over: Record<string, unknown> = {}) =>
+        ({
+            kind: "onchain_receive",
+            rfqId: "rfq-1",
+            state: "pending",
+            lockupPkScript: RECEIVE_LOCKUP.pkScript,
+            paymentHash: PAYMENT_HASH,
+            refundLocktime: REFUND_LOCKTIME,
+            expectedAmount: 100_000,
+            htlc: {},
+            minConfirmations: 2,
+            refundPkScript: new Uint8Array(),
+            createdAt: 1_000,
+            updatedAt: 1_000,
+            ...over,
+        }) as unknown as Parameters<typeof createRfqSwapRecord>[1];
+
+    const rebuiltFrom = (over: Record<string, unknown> = {}) =>
+        rebuildRfqSwap(createRfqSwapRecord(origin, live(over)), RECEIVE_LOCKUP.params) as {
+            htlc: { address: string; refundLocktime: number };
+            refundPkScript: Uint8Array;
+            expectedAmount: number;
+            refundTxid?: string;
+            funding?: { txid: string; vout: number };
+        };
+
+    it("rebuilds the L1 htlc and the script its refund pays to", () => {
+        const rebuilt = rebuiltFrom();
+        expect(rebuilt.htlc.address).toBe(L1_HTLC.address);
+        expect(rebuilt.htlc.refundLocktime).toBe(HTLC_LOCKTIME);
+        expect(rebuilt.htlc.refundLocktime).not.toBe(REFUND_LOCKTIME);
+        expect(hex.encode(rebuilt.refundPkScript)).toBe(REFUND_PK_SCRIPT);
+        expect(rebuilt.expectedAmount).toBe(100_000);
+    });
+
+    it("refuses a record with no refundPkScript rather than stranding the funding", () => {
+        const record = createRfqSwapRecord(origin, live());
+        const { refundPkScript: _dropped, ...profile } = record.profile;
+        expect(() => rebuildRfqSwap({ ...record, profile }, RECEIVE_LOCKUP.params)).toThrow(
+            /refundPkScript/,
+        );
+    });
+
+    it("refuses L1 inputs that derive some other HTLC", () => {
+        const record = createRfqSwapRecord(origin, live());
+        const swapped = {
+            ...record.profile,
+            claimKey: hex.encode(key(11)),
+            refundKey: hex.encode(key(15)),
+        };
+        expect(() =>
+            rebuildRfqSwap({ ...record, profile: swapped }, RECEIVE_LOCKUP.params),
+        ).toThrow(/not this swap's/);
+    });
+
+    it("refuses a record whose value gate cannot be checked", () => {
+        const record = createRfqSwapRecord(origin, live());
+        const { expectedAmount: _dropped, ...profile } = record.profile;
+        expect(() => rebuildRfqSwap({ ...record, profile }, RECEIVE_LOCKUP.params)).toThrow(
+            /expectedAmount/,
+        );
+    });
+
+    it("carries the funding outpoint and our own L1 refund back", () => {
+        // Without these a restart re-broadcasts, or reads a spent HTLC as unfunded.
+        const funding = { txid: "ab".repeat(32), vout: 1 };
+        const rebuilt = rebuiltFrom({ funding, refundTxid: "fa".repeat(32) });
+        expect(rebuilt.funding).toEqual(funding);
+        expect(rebuilt.refundTxid).toBe("fa".repeat(32));
+    });
+});

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -919,6 +919,26 @@ describe("RfqSwapManager — the onchain-receive L1 half", () => {
         expect(swap.claimArkTxid).toBeUndefined();
     });
 
+    it("does not claim after a refund ATTEMPT, which may have broadcast before throwing", async () => {
+        const s = spies({
+            refundOnchain: () => Promise.reject(new Error("broadcast ok, parse failed")),
+        });
+        const { swap } = await drive({
+            swap: onchainReceiveSwap({ htlc: invertedHtlc() }),
+            spies: s,
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }],
+            }),
+            chain: fakeChain({ utxos: [FILL], mtp: REFUND_LOCKTIME - 3600 }),
+            now: SAFE_NOW,
+        });
+
+        expect(s.onchainRefunds).toHaveLength(1);
+        expect(s.lockupClaims).toHaveLength(0);
+        expect(swap.refundTxid).toBeUndefined();
+    });
+
     it("does not refund the L1 half once a claim of ours is out", async () => {
         const s = spies();
         await drive({

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -54,9 +54,11 @@ import {
     RfqSwapOriginRequired,
     isRfqSwapTerminal,
     nextOnchainAction,
+    nextOnchainReceiveAction,
     type ArkadeRefundResult,
     type LightningReceiveSwap,
     type LightningSendSwap,
+    type OnchainReceiveSwap,
     type OnchainSendSwap,
     type RfqSwap,
     type RfqSwapActionName,
@@ -362,11 +364,43 @@ const receiveSwap = (over: Partial<LightningReceiveSwap> = {}): LightningReceive
     ...over,
 });
 
+/** The MIRROR of the send leg's order: the Arkade claim window shuts first. */
+const RECEIVE_HTLC_LOCKTIME = REFUND_LOCKTIME + ONCHAIN_ORDER_MARGIN_SECONDS;
+
+/** The same HTLC with the roles swapped: the solver claims, we refund. */
+const receiveHtlcOf = () =>
+    onchainHtlcScript(
+        {
+            paymentHash: PAYMENT_HASH,
+            claimKey: key(1),
+            refundKey: key(3),
+            refundLocktime: RECEIVE_HTLC_LOCKTIME,
+        },
+        "regtest",
+    );
+
+const onchainReceiveSwap = (over: Partial<OnchainReceiveSwap> = {}): OnchainReceiveSwap => ({
+    kind: "onchain_receive",
+    rfqId: RFQ_ID,
+    state: "pending",
+    lockupPkScript: RECEIVE_LOCKUP.pkScript,
+    paymentHash: PAYMENT_HASH,
+    refundLocktime: REFUND_LOCKTIME,
+    expectedAmount: LOCKUP_VALUE,
+    htlc: receiveHtlcOf(),
+    minConfirmations: 2,
+    refundPkScript: PAYOUT,
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+});
+
 interface Spies {
     callbacks: RfqSwapManagerCallbacks;
     claims: { rfqId: string; utxo: ChainUtxo }[];
     lockupClaims: { vtxos: readonly LockupVtxo[]; partiallyClaimed: boolean }[];
     refunds: string[];
+    onchainRefunds: { rfqId: string; utxo: ChainUtxo }[];
     saved: RfqSwapState[];
     actions: RfqSwapActionName[];
 }
@@ -376,10 +410,12 @@ const spies = (
         claim?: () => Promise<{ txid: string }>;
         claimLockup?: () => Promise<{ arkTxid: string; amount: number }>;
         refund?: () => Promise<ArkadeRefundResult>;
+        refundOnchain?: () => Promise<{ txid: string }>;
         probe?: () => Promise<{ ok: true } | { ok: false; reason: string }>;
     } = {},
 ): Spies => {
     const claims: { rfqId: string; utxo: ChainUtxo }[] = [];
+    const onchainRefunds: { rfqId: string; utxo: ChainUtxo }[] = [];
     const lockupClaims: { vtxos: readonly LockupVtxo[]; partiallyClaimed: boolean }[] = [];
     const refunds: string[] = [];
     const saved: RfqSwapState[] = [];
@@ -387,12 +423,17 @@ const spies = (
         claims,
         lockupClaims,
         refunds,
+        onchainRefunds,
         saved,
         actions: [],
         callbacks: {
             async claimOnchain(swap, utxo) {
                 claims.push({ rfqId: swap.rfqId, utxo });
                 return over.claim ? over.claim() : { txid: "dd".repeat(32) };
+            },
+            async refundOnchain(swap, utxo) {
+                onchainRefunds.push({ rfqId: swap.rfqId, utxo });
+                return over.refundOnchain ? over.refundOnchain() : { txid: "fa".repeat(32) };
             },
             async claimLockup(_swap, vtxos, options) {
                 lockupClaims.push({ vtxos, partiallyClaimed: options.partiallyClaimed });
@@ -539,7 +580,7 @@ const manager = (input: {
 /** The spy set minus one claim. */
 const without = (
     s: Spies,
-    key: "claimOnchain" | "claimLockup",
+    key: "claimOnchain" | "claimLockup" | "refundOnchain",
 ): AvailableRfqSwapManagerCallbacks => {
     const relaxed: AvailableRfqSwapManagerCallbacks = { ...s.callbacks };
     delete relaxed[key];
@@ -582,6 +623,210 @@ describe("nextOnchainAction", () => {
             "claimed",
         );
         expect(at({ phase: "swept", txid: "ab".repeat(32) }, SAFE_NOW)).toBe("swept");
+    });
+});
+
+describe("nextOnchainReceiveAction", () => {
+    const at = (phase: Parameters<typeof nextOnchainReceiveAction>[0]["phase"], settled = false) =>
+        nextOnchainReceiveAction({ phase, settled });
+    const utxo = FILL;
+
+    it("waits while the fill is missing or shallow", () => {
+        expect(at({ phase: "unfunded" })).toBe("wait");
+        expect(at({ phase: "awaiting_confirmations", utxo })).toBe("wait");
+    });
+
+    it("waits while the HTLC is only claimable — that leaf is the SOLVER's here", () => {
+        expect(at({ phase: "claimable", utxo })).toBe("wait");
+    });
+
+    it("refunds once the refund leaf has matured — the same phase the send leg reads as a miss", () => {
+        expect(at({ phase: "refundable", utxo })).toBe("refund");
+    });
+
+    it("reads a preimage-revealing spend as the solver taking the fill, not as our claim", () => {
+        expect(at({ phase: "claimed", txid: ARK_TXID, preimage: PREIMAGE })).toBe("taken");
+    });
+
+    it("reads a preimage-less spend as OUR refund landing, not as a sweep against us", () => {
+        expect(at({ phase: "swept", txid: ARK_TXID })).toBe("refunded");
+    });
+
+    it("never refunds once the Arkade half settled — that money is the solver's payment", () => {
+        expect(at({ phase: "refundable", utxo }, true)).toBe("taken");
+    });
+});
+
+describe("RfqSwapManager — the onchain-receive L1 half", () => {
+    const lockupSpentBySolver = () => {
+        const spend = spendOfLockup({ leaf: "refundWithoutReceiver", script: RECEIVE_LOCKUP });
+        return fakeIndexer({ vtxos: spentBy(spend.txid), txs: [spend] });
+    };
+    const lockupClaimed = () => {
+        const spend = spendOfLockup({ conditionWitness: [PREIMAGE], script: RECEIVE_LOCKUP });
+        return fakeIndexer({ vtxos: spentBy(spend.txid), txs: [spend] });
+    };
+
+    const drive = async (input: {
+        swap?: OnchainReceiveSwap;
+        chain: ChainSource;
+        indexer?: LockupSpendIndexer;
+        now?: number;
+        spies?: Spies;
+        install?: AvailableRfqSwapManagerCallbacks;
+        enableAutoActions?: boolean;
+    }) => {
+        const s = input.spies ?? spies();
+        const swap = input.swap ?? onchainReceiveSwap();
+        const m = manager({
+            indexer: input.indexer ?? fakeIndexer({ vtxos: unspent(), funded: [] }),
+            chain: input.chain,
+            now: input.now ?? SAFE_NOW,
+            spies: s,
+            install: input.install,
+            enableAutoActions: input.enableAutoActions,
+        });
+        await m.addSwap(swap);
+        await m.poll();
+        return { swap, s, m };
+    };
+
+    it("keeps driving the L1 refund after the solver reclaimed the Arkade lockup", async () => {
+        // THE crux: `returned` ends every other leg terminally, and here it is
+        // the moment the trader's L1 money must come back.
+        const { swap, s } = await drive({
+            indexer: lockupSpentBySolver(),
+            chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME }),
+        });
+
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+        expect(s.onchainRefunds).toHaveLength(1);
+        expect(s.actions).toContain("refundOnchain");
+    });
+
+    it("waits while the L1 refund leaf has not matured, even with the lockup gone", async () => {
+        const { swap, s } = await drive({
+            indexer: lockupSpentBySolver(),
+            chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME - 1 }),
+        });
+
+        expect(s.onchainRefunds).toHaveLength(0);
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+    });
+
+    it("ends refunded once our own L1 refund is seen on chain", async () => {
+        const refundSpend = await buildHtlcRefund({
+            htlc: receiveHtlcOf(),
+            utxo: FILL,
+            payoutPkScript: PAYOUT,
+            feeRateSatVb: 2,
+            sign: async (sighash) => schnorr.sign(sighash, priv(3)),
+        });
+        const { swap } = await drive({
+            swap: onchainReceiveSwap({ funding: { txid: FILL.txid, vout: FILL.vout } }),
+            indexer: lockupSpentBySolver(),
+            chain: fakeChain({ utxos: [], spend: { txHex: refundSpend.txHex }, mtp: 0 }),
+        });
+
+        expect(swap.state).toBe("refunded");
+        expect(isRfqSwapTerminal(swap.state)).toBe(true);
+    });
+
+    it("reads the solver's L1 claim as the fill being taken, not as our refund", async () => {
+        const claimSpend = await buildHtlcClaim({
+            htlc: receiveHtlcOf(),
+            utxo: FILL,
+            preimage: PREIMAGE,
+            payoutPkScript: PAYOUT,
+            feeRateSatVb: 2,
+            sign: async (sighash) => schnorr.sign(sighash, priv(1)),
+        });
+        const { swap, s } = await drive({
+            swap: onchainReceiveSwap({ funding: { txid: FILL.txid, vout: FILL.vout } }),
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }],
+            }),
+            chain: fakeChain({ utxos: [], spend: { txHex: claimSpend.txHex }, mtp: 0 }),
+        });
+
+        expect(s.onchainRefunds).toHaveLength(0);
+        expect(s.lockupClaims).toHaveLength(1);
+        expect(swap.state).toBe("claimed");
+    });
+
+    it("never refunds the L1 half once the Arkade claim settled", async () => {
+        const { swap, s } = await drive({
+            indexer: lockupClaimed(),
+            chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME }),
+        });
+
+        expect(swap.state).toBe("settled");
+        expect(s.onchainRefunds).toHaveLength(0);
+    });
+
+    it("settles without waiting on an L1 half the trader never funded", async () => {
+        const { swap } = await drive({
+            indexer: lockupSpentBySolver(),
+            chain: fakeChain({ utxos: [], mtp: RECEIVE_HTLC_LOCKTIME }),
+        });
+
+        expect(swap.state).toBe("refunded");
+    });
+
+    it("refuses at the door without a ChainSource, before the trader funds anything", async () => {
+        const m = manager({ now: SAFE_NOW, spies: spies() });
+        await expect(m.addSwap(onchainReceiveSwap())).rejects.toThrow(/ChainSource/);
+        expect(await m.hasSwap(RFQ_ID)).toBe(false);
+    });
+
+    it("blocks rather than fails when only the refund callback is missing", async () => {
+        const s = spies();
+        const { swap } = await drive({
+            install: without(s, "refundOnchain"),
+            spies: s,
+            indexer: lockupSpentBySolver(),
+            chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME }),
+        });
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/refundOnchain/);
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+    });
+
+    it("records the fill outpoint so a restart does not read a spent HTLC as unfunded", async () => {
+        const { swap } = await drive({
+            chain: fakeChain({ utxos: [FILL], mtp: 0 }),
+        });
+
+        expect(swap.funding).toEqual({ txid: FILL.txid, vout: FILL.vout });
+    });
+
+    it("does not re-broadcast a refund it already made", async () => {
+        const s = spies();
+        const { swap } = await drive({
+            swap: onchainReceiveSwap({ refundTxid: "fa".repeat(32) }),
+            spies: s,
+            indexer: lockupSpentBySolver(),
+            chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME }),
+        });
+
+        expect(s.onchainRefunds).toHaveLength(0);
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+    });
+
+    it("still claims the Arkade lockup while the L1 half is being driven", async () => {
+        const s = spies();
+        await drive({
+            spies: s,
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }],
+            }),
+            chain: fakeChain({ utxos: [FILL], mtp: 0 }),
+        });
+
+        expect(s.lockupClaims).toHaveLength(1);
     });
 });
 

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -794,6 +794,39 @@ describe("RfqSwapManager — the onchain-receive L1 half", () => {
         expect(isRfqSwapTerminal(swap.state)).toBe(false);
     });
 
+    it("reports a refundable HTLC nobody is wired to take back", async () => {
+        // No `claimable` manual mode here, so silence strands a live refund.
+        const s = spies();
+        const m = new RfqSwapManager(
+            {
+                indexer: fakeIndexer({ vtxos: [], funded: [] }),
+                chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME }),
+            },
+            { now: () => SAFE_NOW },
+        );
+        const swap = onchainReceiveSwap();
+        await m.addSwap(swap);
+        await m.poll();
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/no callbacks are wired/);
+        expect(s.onchainRefunds).toHaveLength(0);
+    });
+
+    it("reports a refundable HTLC when automatic actions are disabled", async () => {
+        const s = spies();
+        const { swap } = await drive({
+            spies: s,
+            enableAutoActions: false,
+            indexer: fakeIndexer({ vtxos: [], funded: [] }),
+            chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME }),
+        });
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/automatic actions are disabled/);
+        expect(s.onchainRefunds).toHaveLength(0);
+    });
+
     it("records the fill outpoint so a restart does not read a spent HTLC as unfunded", async () => {
         const { swap } = await drive({
             chain: fakeChain({ utxos: [FILL], mtp: 0 }),
@@ -812,6 +845,48 @@ describe("RfqSwapManager — the onchain-receive L1 half", () => {
         });
 
         expect(s.onchainRefunds).toHaveLength(0);
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+    });
+
+    it("never finalizes on the Arkade deadline while the L1 half is still funded", async () => {
+        // Mainline failure: trader funded L1, solver never funded the lockup
+        // (`unknown`), and this leg's refund leaf opens after that deadline.
+        const s = spies();
+        const { swap, m } = await drive({
+            spies: s,
+            indexer: fakeIndexer({ vtxos: [], funded: [] }),
+            chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME - 1 }),
+            now: REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS + 1,
+        });
+
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+        expect(await m.hasSwap(RFQ_ID)).toBe(true);
+        expect(s.onchainRefunds).toHaveLength(0);
+    });
+
+    it("refunds that same swap once its own refund leaf opens", async () => {
+        const s = spies();
+        const { swap } = await drive({
+            spies: s,
+            indexer: fakeIndexer({ vtxos: [], funded: [] }),
+            chain: fakeChain({ utxos: [FILL], mtp: RECEIVE_HTLC_LOCKTIME }),
+            now: REFUND_LOCKTIME + REFUND_MTP_LAG_SECONDS + 1,
+        });
+
+        expect(s.onchainRefunds).toHaveLength(1);
+        expect(isRfqSwapTerminal(swap.state)).toBe(false);
+    });
+
+    it("blocks rather than drives when the lockup was unilaterally exited", async () => {
+        const s = spies();
+        const { swap } = await drive({
+            spies: s,
+            indexer: fakeIndexer({ vtxos: exited() }),
+            chain: fakeChain({ utxos: [FILL], mtp: 0 }),
+        });
+
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/unilaterally exited/);
         expect(isRfqSwapTerminal(swap.state)).toBe(false);
     });
 
@@ -3074,6 +3149,24 @@ describe("RfqSwapManager — manager-owned persistence", () => {
         ...over,
     });
 
+    const onchainReceiveOrigin = (): RfqSwapOrigin => ({
+        kind: "onchain_receive",
+        lockupAddress: RECEIVE_ADDRESS,
+        profile: {
+            signer: { signingDescriptor: `tr(${hex.encode(key(13))})` },
+            hashlock: { paymentHash: PAYMENT_HASH },
+            expectedAmount: LOCKUP_VALUE,
+            payoutAddress: "tark1payout",
+            claimKey: hex.encode(key(1)),
+            refundKey: hex.encode(key(3)),
+            htlcLocktime: RECEIVE_HTLC_LOCKTIME,
+            network: "regtest",
+            htlcAddress: receiveHtlcOf().address,
+            minConfirmations: 2,
+            refundPkScript: hex.encode(PAYOUT),
+        },
+    });
+
     const receiveOrigin = (): RfqSwapOrigin => ({
         kind: "lightning_receive",
         lockupAddress: RECEIVE_ADDRESS,
@@ -3349,6 +3442,30 @@ describe("RfqSwapManager — manager-owned persistence", () => {
     describe("restoreFromRepository", () => {
         const contractsFor = (...rows: CreateContractParams[]) =>
             fakeContracts({ preexisting: rows });
+
+        it("refuses a restored onchain_receive swap that has no ChainSource", async () => {
+            // Rebuilds and tracks directly, bypassing `addSwap`'s refusal.
+            const store = fakeStore([
+                createRfqSwapRecord(onchainReceiveOrigin(), onchainReceiveSwap()),
+            ]);
+            const m = manager({
+                indexer: settlingIndexer(),
+                repository: store,
+                now: SAFE_NOW,
+                spies: spies(),
+            });
+
+            const result = await m.restoreFromRepository({
+                params: async () => VHTLCV2ContractHandler.serializeParams(RECEIVE_LOCKUP.options),
+            });
+
+            expect(result.restored).toHaveLength(0);
+            expect(result.failed).toHaveLength(1);
+            expect(result.failed[0]!.error.name).toBe("OnchainReceiveNeedsChainSource");
+            expect(await m.hasSwap(RFQ_ID)).toBe(false);
+            // the record is KEPT: it is restorable once a chain is wired
+            expect(store.records.has(RFQ_ID)).toBe(true);
+        });
 
         it("rebuilds every stored record and drives it", async () => {
             const store = fakeStore([storedSend()]);

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -890,6 +890,51 @@ describe("RfqSwapManager — the onchain-receive L1 half", () => {
         expect(isRfqSwapTerminal(swap.state)).toBe(false);
     });
 
+    const invertedHtlc = () =>
+        onchainHtlcScript(
+            {
+                paymentHash: PAYMENT_HASH,
+                claimKey: key(1),
+                refundKey: key(3),
+                refundLocktime: REFUND_LOCKTIME - 3600,
+            },
+            "regtest",
+        );
+
+    it("does not claim the lockup once it has refunded the L1 half", async () => {
+        const s = spies();
+        const { swap } = await drive({
+            swap: onchainReceiveSwap({ htlc: invertedHtlc() }),
+            spies: s,
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE }],
+            }),
+            chain: fakeChain({ utxos: [FILL], mtp: REFUND_LOCKTIME - 3600 }),
+            now: SAFE_NOW,
+        });
+
+        expect(s.onchainRefunds).toHaveLength(1);
+        expect(s.lockupClaims).toHaveLength(0);
+        expect(swap.claimArkTxid).toBeUndefined();
+    });
+
+    it("does not refund the L1 half once a claim of ours is out", async () => {
+        const s = spies();
+        await drive({
+            swap: onchainReceiveSwap({
+                htlc: invertedHtlc(),
+                claimArkTxid: CLAIM_ARK_TXID,
+            }),
+            spies: s,
+            indexer: fakeIndexer({ vtxos: unspent(), funded: [] }),
+            chain: fakeChain({ utxos: [FILL], mtp: REFUND_LOCKTIME - 3600 }),
+            now: SAFE_NOW,
+        });
+
+        expect(s.onchainRefunds).toHaveLength(0);
+    });
+
     it("keeps the value gate on a restored record that never claimed", async () => {
         // `claimArkTxid` is written only from a live `claimLockup` return, so a
         // restore cannot manufacture `partiallyClaimed` and skip the gate on a

--- a/packages/swap/test/swapManager.test.ts
+++ b/packages/swap/test/swapManager.test.ts
@@ -815,6 +815,41 @@ describe("RfqSwapManager — the onchain-receive L1 half", () => {
         expect(isRfqSwapTerminal(swap.state)).toBe(false);
     });
 
+    it("keeps the value gate on a restored record that never claimed", async () => {
+        // `claimArkTxid` is written only from a live `claimLockup` return, so a
+        // restore cannot manufacture `partiallyClaimed` and skip the gate on a
+        // FIRST claim of an underfunded lockup.
+        const s = spies();
+        const { swap } = await drive({
+            spies: s,
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE - 1 }],
+            }),
+            chain: fakeChain({ utxos: [FILL], mtp: 0 }),
+        });
+
+        expect(s.lockupClaims).toHaveLength(0);
+        expect(swap.state).toBe("needs_counterparty");
+        expect(swap.blockedReason).toMatch(/below the agreed/);
+    });
+
+    it("skips that gate only once a claim of ours has published P", async () => {
+        const s = spies();
+        await drive({
+            swap: onchainReceiveSwap({ claimArkTxid: CLAIM_ARK_TXID }),
+            spies: s,
+            indexer: fakeIndexer({
+                vtxos: unspent(),
+                funded: [{ ...LOCKUP_OUTPOINT, value: LOCKUP_VALUE - 1 }],
+            }),
+            chain: fakeChain({ utxos: [FILL], mtp: 0 }),
+        });
+
+        expect(s.lockupClaims).toHaveLength(1);
+        expect(s.lockupClaims[0]!.partiallyClaimed).toBe(true);
+    });
+
     it("still claims the Arkade lockup while the L1 half is being driven", async () => {
         const s = spies();
         await drive({


### PR DESCRIPTION
## Summary

`onchain:BTC->arkade:BTC` was excluded from `RfqSwap` by name (`swapManager.ts:291` on master). Its Arkade half is a `LightningReceiveSwap`'s solver-funded lockup, but it adds an L1 HTLC **the trader funds and must take back themselves** — a second deadline, a second observation seam and a second action callback. The comment's own argument was that wiring the lockup half alone would be worse than refusing. This wires both halves and removes the refusal.

## The failure mode is not the one the old comment described

The comment said the manager could "silently let that L1 refund window pass". **That window does not close.** `buildHtlcRefund` sets `nLockTime` (`onchainHtlc.ts`), which consensus reads as a *floor*, and the only spend that can remove the leaf is the solver's claim — which needs `P`, held by the trader.

So the hazard is not a missed deadline but **the manager finishing the swap while that output still holds the trader's money**, and `runPass` step 1 is what would cause it: on this leg `LockupFate.returned` means the *solver reclaimed the lockup*, which is precisely when the trader's funding must come home — yet it maps to the terminal state `refunded` and finalizes, which unwatches the HTLC forever.

The receive arm is therefore dispatched **before** that terminal shortcut, and a record here is terminal only once **both** halves have a verdict:

| Arkade half | L1 half | terminal? |
|---|---|---|
| `claimed` | — (the output is the solver's payment) | `settled` |
| `returned` | our refund landed, or solver took it | `refunded` |
| `returned` | never funded, never seen funded | `refunded` |
| `returned` | **still funded** | **no — keep driving the refund** |

A mutation moving the dispatch back after the shortcut turns four tests red on `isRfqSwapTerminal`.

**The Arkade arm must not finalize either.** `driveReceiveClaim` ends a receive swap at `refundLocktime + REFUND_MTP_LAG_SECONDS` — right for the lightning leg, which owes nothing else, and wrong here because this leg's own refund leaf opens *after* that moment. The reachable trigger is the mainline default rather than an outage: `readLockupFate` returns `unknown` for a lockup with no VTXOs (`refund.ts:446`), which is what a solver that never funds leaves behind. So the swap is held open until the L1 half reports `resolved`. That refusal is applied *after* the Arkade arm, because that arm calls `unblock` on an empty lockup and would otherwise erase it.

## No new constant, and no clock

`nextOnchainReceiveAction` mirrors `nextOnchainAction` with one member fewer — there is no `refund_window_closed` — and takes **neither a clock nor a margin**. `refundable` *is* the median-time-past verdict `classifyOnchainHtlc` already computed, so a second time source could only disagree with the phase it was handed. A refund publishes nothing and races nobody, so there is no counterpart to `ONCHAIN_CLAIM_MARGIN_SECONDS`. Correspondingly there is **no give-up branch**, unlike `driveArkadeRefund` — the safety property expressed structurally rather than as a number.

## Nothing about the phases is inverted

`claimed` versus `swept` turns purely on whether the spending witness revealed a preimage, **never on who spent**. What differs between the legs is which leaf the trader owns, so the same fact calls for a different actor. `OnchainHtlcPhase`'s docs carried only the send leg's reading — a receive-leg reader arrived at `refundable` and was told *"must not try to claim… the claim was missed"*, which is the opposite of what to do there. Amended to name both directions.

## Refusing to drive blind

Following `driveOnchain`'s missing-`ChainSource` precedent, split by whether the gap can be closed later:

- **No `ChainSource` → `addSwap` throws `OnchainReceiveNeedsChainSource`.** `chain` is constructor-injected and can never arrive late, and `addSwap` normally precedes the trader's L1 funding — the last moment refusing costs nothing.
- **No `refundOnchain` callback → `needs_counterparty`, non-terminal, re-checked every pass.** Exactly `claimOnchain`'s precedent: `setCallbacks` exists so a callback *can* arrive late, and nothing is expiring while it does. Auto-actions-off reports the same way, because unlike the send leg there is no `claimable` state to fall back on and silence would strand a live refund.
- **`restoreFromRepository` gets the same refusal.** It rebuilds and `track`s directly rather than going through `addSwap`, so without its own check a restored swap could be monitored with no way to see or make its refund. Inside the existing `try`, so it lands in `RfqRestoreResult.failed` and the record stays.

## Neither leg may be taken twice

Whichever leg the trader takes first forecloses the other, and both directions are explicit refusals rather than missing arms — so neither is later "fixed" into a theft.

| pairing | what closes it |
|---|---|
| claim, then refund (later pass) | `claimArkTxid` suppresses the refund |
| refund, then claim (either pass) | `refundTxid` blocks the claim |
| refund **attempted**, then claim | the attempt itself blocks the claim |
| restored record, either order | `hydrate` carries both txids |

The attempt case is the subtle one: a `refundOnchain` that broadcasts and then throws — a parse failure on the response suffices — leaves no txid, so keying on the txid alone let the same pass go on and claim. Being wrong about an attempt costs one poll interval on a claim whose window is hours.

A claim that throws is deliberately **not** symmetric: it leaves the trader with nothing on the Arkade side, so the L1 refund is still owed and must stay available.

`claimArkTxid` cannot ride on the `settled` flag, which drives the terminal early return — folding it in would skip the refund entirely and strand the funding if the claim never landed.

This matters here and not on the send leg because `assertFundable` applies its timelock-order gate to `direction === "send"` only (`rfq.ts:539`), so on this corridor both legs can be live at once.

## Restore

`OnchainReceiveCorridor` makes the record round-trip — a handler plus one `register()` call, as `rfqCorridors.ts` documents. `hydrate` throws rather than defaults on missing L1 keys, an uncheckable `minConfirmations`, a non-finite `expectedAmount`, and inputs deriving a different HTLC address.

`refundPkScript` is **required**, where the send leg's `payoutPkScript` is optional: no record predates this corridor, and without it no refund can be built at all.

## Breaking changes

Two, for consumers typing against the strict `RfqSwapManagerCallbacks`:

1. **`refundOnchain` is a new required member.** Deliberately not widened away — a monitored receive swap with nothing wired to refund it is the exact lie that type exists to prevent.
2. **`claimLockup`'s parameter widens to `ReceiveLockupSwap`**, so both receive legs share one claim path and one `expectedAmount` gate rather than duplicating it. Under `strictFunctionTypes` this rejects a callback whose parameter is explicitly annotated `LightningReceiveSwap`.

Inline lambdas are contextually typed and unaffected. `AvailableRfqSwapManagerCallbacks` users are unaffected.

**Known downstream:** `wallet/src/test/providers/lnReceive.test.tsx` casts a mock to the strict `RfqSwapManagerCallbacks`; that cast needs `refundOnchain` added when the wallet bumps `@arkade-os/swap`. The provider itself uses `setCallbacks` and is safe.

## Test plan

Gate run against a recorded baseline on `d4228ede`, whole repo, not narrowed:

| | baseline | this branch |
|---|---|---|
| ts-sdk | 183 files / 3047 + 1 skipped | unchanged |
| boltz-swap | 23 files / 617 | unchanged |
| swap | 33 files / **811** | 33 files / **844** |
| **total** | **239 / 4475 / 0 failing** | **239 / 4508 / 0 failing** |

Plus an e2e pair against the live stack (`test/e2e/rfqOnchainReceive.test.ts`), which the `swap-rfq / all` job picks up by glob — the swap package globs its e2e selection, unlike ts-sdk which enumerates in `ci.yml`.

`pnpm run lint`, `pnpm -r build`, all three `typecheck` targets and `pnpm run test:unit` each exit 0. Per-file reconciliation shows no file lost tests.

Asserted rather than left to be inferred: the two phases most likely to be misread (`refundable` = act now, `swept` = our refund landed), the terminal-shortcut ordering, the door refusal, and the record round-trip including `refundPkScript`'s absence.

One fix here is not in `src/`: `test:integration` excluded `test/e2e/rfq*.test.ts`, but the **shell** expands that before vitest sees it. With one matching file it produced a single argument and worked; a second made `--exclude` consume only the first while the other became a positional, which vitest reads as an *include* — so `rfqRegister.test.ts` ran against the offer stack's block-typed timelocks. Quoting the exclude alone fixes it; quoting both selects nothing, because vitest positionals are substring filters rather than globs.

Committed with `--no-verify` as the pre-commit hook's own message instructs — it selects no projects in a worktree (ts-sdk#880). Each gate above was run manually instead.

## Follow-ups, deliberately not in this PR

- **`client.quote()`'s second refusal.** `SUPPORTED_PAIRS` in `packages/swap/src/client/resolve.ts` refuses `onchain->arkade` with *"not served until the client owns the trader's L1 refund path end to end"*. That file exists only on `feat/v0.5` (#886), and the refusal is **load-bearing until this lands** — removing it first would hand out quotes for a corridor with no driver. Once both are in, the `give:` entry belongs beside `ONCHAIN_DRIVE` in `client/corridors/onchain.ts`, with `owner` flipped per contract, `actions: ["claimLockup", "refundOnchain"]` and the same two `seams`.
- **`ChainSource.getSpendingTx` and witness-stripped serializations.** Probed at runtime: a legacy-serialized claim parses cleanly, yields the *same txid*, and classifies as `swept` — i.e. a claim read as a refund. The parse-failure path is separately conflated inside `extractPreimage` but cannot reach that outcome, because `classifyOnchainHtlc` re-parses on the next line and throws. Only the contract is tightened here; changing `classifyOnchainHtlc` would alter a shipped send-leg path and deserves its own decision. Under this PR's both-halves rule the misread costs a label, never a recovery.
- **Amount flexibility — named dependency.** The `settled ⇒ never refund the L1 half` branch in `driveOnchainReceive` (`packages/swap/src/swapManager.ts`, branch `feat/onchain-receive-swap`) is correct **only while the exact-amount rule holds**. The `partiallyClaimed` path can publish `P` for a lockup funded below `expectedAmount`; there the trader has paid L1 and received less, and that branch also declines the refund. **Whoever lands step 6 of the flexible-amount design must re-derive it.** Related and already settled here: `claimArkTxid` is written in exactly one place, from the `claimLockup` callback's return, and the new drive path touches only `refundTxid` — so a restore preserves `partiallyClaimed` rather than manufacturing it, and it stays unreachable on a first claim. Pinned by two tests from both sides.
- **Timelock ordering is deliberately not gated.** `assertFundable` applies its order check to `direction === "send"` only. On receive an inverted order lets the trader take both sides, so the harm runs at the *solver*, and this is a client-side guard; the trader-side concern is availability only, already floored by `MIN_HEADROOM_SECONDS`, which is unconditional on direction. The driver is ordering-agnostic regardless — it takes no clock.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for onchain BTC receiving swaps between Bitcoin and Arkade.
  * Added swap lifecycle handling for funding, claiming, settlement, and L1 refunds.
  * Added validation and recovery for onchain receive swaps, including required chain data.
  * Added the “Onchain receive” activity label and related public swap information.

* **Documentation**
  * Clarified onchain HTLC phases, transaction witness requirements, and refund behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->