### PR TITLE
fix(swap): a pass behind watchOfferSwaps, and a poll payload that can carry a spend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ This file covers the **0.4.x** line. Pre-0.4 release history (0.3.x and
 earlier) lives in `git log` — those entries were not written in this
 style and have not been backfilled.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **A `vtxo_spent` from the failsafe poll now carries the row that records
+  the spend.** `ContractWatcher.pollContracts` reported the difference
+  using its *cached* rows, and those were unspent when cached — so a
+  poll-derived `vtxo_spent` stated `isSpent: false`, `spentBy: ""` and no
+  `arkTxId` on an event whose whole meaning is that the output was spent.
+  Anything reading a spend txid off these events saw nothing to bind the
+  spend to, including `Wallet`'s own subscription, which forwards them as
+  `spentVtxos`. The poll now takes spent rows from the repository query it
+  was already making — no extra read — and emits the stored row, falling
+  back to the cached one when storage has nothing fresher. **Grep your
+  `vtxo_spent` handlers for `spentBy`, `arkTxId` and `isSpent`**: fields
+  that were always empty on the poll path are now populated, and a handler
+  branching on `!vtxo.isSpent` inside a spend handler now takes the other
+  branch. (#864)
+
 ## [0.4.23] - 2026-05-04
 
 ### Breaking Changes

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -104,9 +104,9 @@ export interface WatchOfferSwapsParams {
  * registered covenant is watched, so only registered offers produce events.
  * Offers funded before registration existed stay on the restore scan.
  *
- * This depends on the wallet's contract event transport. In Node, callers must
- * provide an `EventSource` implementation or use a runtime where it is enabled;
- * otherwise live updates do not arrive and restore remains the fallback.
+ * *Live* updates depend on the wallet's contract event transport. In Node,
+ * callers must provide an `EventSource` implementation or use a runtime where
+ * it is enabled. The start-up pass needs none of it.
  */
 export async function watchOfferSwaps({
     wallet,
@@ -152,10 +152,8 @@ export async function watchOfferSwaps({
         }
     };
 
-    const handleSpend = async (event: Extract<ContractVtxoEvent, { type: "vtxo_spent" }>) => {
-        if (event.contract.metadata?.kind !== OFFER_CONTRACT_KIND) return;
-
-        for (const vtxo of event.vtxos) {
+    const resolveSpends = async (contractScript: string, vtxos: ContractVtxo[], at?: number) => {
+        for (const vtxo of vtxos) {
             const spentTxid = vtxo.arkTxId || vtxo.spentBy;
             if (!spentTxid) continue;
             // Identical offers share one script and are told apart by the
@@ -163,12 +161,12 @@ export async function watchOfferSwaps({
             // this is O(history) per spend event; add a query API if offer
             // event volume makes this hot.
             const swap = (await getAssetSwaps(repository)).find(
-                (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === event.contractScript,
+                (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === contractScript,
             );
             if (!swap) continue;
 
             const kind: SpendKind = await classify(swap, vtxo, spentTxid);
-            const changes = spendUpdate(swap, { txid: spentTxid, kind, at: event.timestamp });
+            const changes = spendUpdate(swap, { txid: spentTxid, kind, at });
             if (!changes) continue;
 
             // notify only on a write that landed: `onUpdate` is documented as
@@ -186,8 +184,33 @@ export async function watchOfferSwaps({
             // `swaps` is the post-update view, so the liveness check sees this
             // record's new status without a third read
             if (changes.status && RETIRABLE.includes(changes.status)) {
-                await retireOfferContract(manager, swaps, event.contractScript);
+                await retireOfferContract(manager, swaps, contractScript);
             }
+        }
+    };
+
+    const handleSpend = async (event: Extract<ContractVtxoEvent, { type: "vtxo_spent" }>) => {
+        if (event.contract.metadata?.kind !== OFFER_CONTRACT_KIND) return;
+        await resolveSpends(event.contractScript, event.vtxos, event.timestamp);
+    };
+
+    /**
+     * Answer, once, what became of every deposit no event ever reported:
+     * `ContractManager.initialize` reconciles before it installs its watcher
+     * callback and `create` awaits it, so no subscriber can observe the boot
+     * sync. Passes no `at` — the manager's view carries no spend time, and
+     * `Date.now()` would record the scan as the completion.
+     */
+    const resolveOpenSwaps = async () => {
+        const open = (await getAssetSwaps(repository)).filter((s) => !TERMINAL.includes(s.status));
+        if (open.length === 0) return;
+        const script = [...new Set(open.map((s) => s.swapPkScript))];
+        for (const { contract, vtxos } of await manager.getContractsWithVtxos({ script })) {
+            if (contract.metadata?.kind !== OFFER_CONTRACT_KIND) continue;
+            await resolveSpends(
+                contract.script,
+                vtxos.filter((v) => v.isSpent),
+            );
         }
     };
 
@@ -196,6 +219,9 @@ export async function watchOfferSwaps({
         if (!isContractVtxoEvent(event) || event.type !== "vtxo_spent") return;
         enqueue(() => handleSpend(event));
     });
+    // enqueued rather than awaited: the pass must not read before the
+    // subscription is installed, or a spend landing mid-pass falls between them
+    enqueue(resolveOpenSwaps);
 
     return {
         stop: unsubscribe,

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -58,25 +58,39 @@ const spendPsbt = (offer: Offer, via: "cancel" | "fulfill", vout = 0) => {
  * event seam, and an address to recover the server key from. `emit` plays the
  * manager's part.
  */
-const makeWallet = (getVirtualTxs: (txids: string[]) => Promise<{ txs: string[] }>) => {
+const makeWallet = (
+    getVirtualTxs: (txids: string[]) => Promise<{ txs: string[] }>,
+    contracts: any[] = [],
+) => {
     const callbacks = new Set<(event: any) => void>();
     // a real ark address, so ArkAddress.decode recovers SERVER_KEY from it
     const address = new ArkAddress(SERVER_KEY, key("66"), "tark").encode();
     const setContractWatchState = vi.fn(async (_script: string, _watch: string) => {});
+    const order: string[] = [];
+    const getContractsWithVtxos = vi.fn(async (filter?: any) => {
+        order.push("getContractsWithVtxos");
+        const scripts = filter?.script;
+        if (!scripts) return contracts;
+        return contracts.filter((c) => scripts.includes(c.contract.script));
+    });
     const wallet = {
         getAddress: async () => address,
         getContractManager: async () => ({
             onContractEvent: (cb: (event: any) => void) => {
+                order.push("onContractEvent");
                 callbacks.add(cb);
                 return () => callbacks.delete(cb);
             },
             setContractWatchState,
+            getContractsWithVtxos,
         }),
     } as any;
     return {
         wallet,
         getVirtualTxs,
         setContractWatchState,
+        getContractsWithVtxos,
+        order,
         emit: (event: any) => callbacks.forEach((cb) => cb(event)),
         listeners: () => callbacks.size,
     };
@@ -91,18 +105,29 @@ const spentEvent = (offer: Offer, spentTxid: string, overrides: Record<string, u
     ...overrides,
 });
 
+/** A contract row as the manager's own view returns it, deposit already spent —
+ * what the start-up pass reads when no live event ever arrived. */
+const spentDeposit = (offer: Offer, spentTxid: string, vtxo: Record<string, unknown> = {}) => ({
+    contract: {
+        script: hex.encode(offer.swapPkScript),
+        metadata: { kind: OFFER_CONTRACT_KIND },
+    },
+    vtxos: [{ txid: FUNDING_TXID, vout: 0, isSpent: true, arkTxId: spentTxid, ...vtxo }],
+});
+
 // the watcher builds its own RestIndexerProvider from arkServerUrl; intercept
 // the one call it makes rather than reaching through the constructor
 const withIndexer = async (
     fetcher: (txids: string[]) => Promise<{ txs: string[] }>,
     run: (harness: ReturnType<typeof makeWallet>) => Promise<void>,
+    contracts: any[] = [],
 ) => {
     const sdk = await import("@arkade-os/sdk");
     const spy = vi
         .spyOn(sdk.RestIndexerProvider.prototype, "getVirtualTxs")
         .mockImplementation(fetcher as any);
     try {
-        await run(makeWallet(fetcher));
+        await run(makeWallet(fetcher, contracts));
     } finally {
         spy.mockRestore();
     }
@@ -469,6 +494,116 @@ describe("watchOfferSwaps", () => {
                 expect(await getAssetSwaps(repository)).toMatchObject([{ status: "pending" }]);
             },
         );
+    });
+
+    describe("start-up pass", () => {
+        it("resolves a spend that landed while nothing was subscribed", async () => {
+            // the wallet was closed when the solver filled the offer: the boot
+            // sync wrote the spend before any subscriber existed, and nothing
+            // replays it. Without a pass the record is pending forever.
+            const offer = makeOffer();
+            const fill = spendPsbt(offer, "fulfill");
+            const repository = new InMemoryAssetSwapRepository();
+            await addAssetSwap(repository, swapFor(offer));
+
+            await withIndexer(
+                async () => ({ txs: [fill.psbt] }),
+                async ({ wallet }) => {
+                    const watcher = await watchOfferSwaps({
+                        wallet,
+                        arkServerUrl: "http://ark",
+                        repository,
+                    });
+                    await watcher.idle();
+                    watcher.stop();
+
+                    expect(await getAssetSwaps(repository)).toMatchObject([
+                        { status: "fulfilled", spentTxid: fill.txid },
+                    ]);
+                },
+                [spentDeposit(offer, fill.txid)],
+            );
+        });
+
+        it("subscribes before it reads, so a spend landing mid-pass is not lost", async () => {
+            const offer = makeOffer();
+            const repository = new InMemoryAssetSwapRepository();
+            await addAssetSwap(repository, swapFor(offer));
+
+            await withIndexer(
+                async () => ({ txs: [] }),
+                async ({ wallet, order }) => {
+                    const watcher = await watchOfferSwaps({
+                        wallet,
+                        arkServerUrl: "http://ark",
+                        repository,
+                    });
+                    await watcher.idle();
+                    watcher.stop();
+
+                    expect(order).toEqual(["onContractEvent", "getContractsWithVtxos"]);
+                },
+                [],
+            );
+        });
+
+        it("asks only about scripts a live record still holds", async () => {
+            const open = makeOffer();
+            const settled = makeOffer("want-btc");
+            const repository = new InMemoryAssetSwapRepository();
+            await addAssetSwap(repository, swapFor(open));
+            await addAssetSwap(
+                repository,
+                swapFor(settled, {
+                    id: "ee".repeat(32),
+                    fundingTxid: "ee".repeat(32),
+                    status: "fulfilled",
+                }),
+            );
+
+            await withIndexer(
+                async () => ({ txs: [] }),
+                async ({ wallet, getContractsWithVtxos }) => {
+                    const watcher = await watchOfferSwaps({
+                        wallet,
+                        arkServerUrl: "http://ark",
+                        repository,
+                    });
+                    await watcher.idle();
+                    watcher.stop();
+
+                    expect(getContractsWithVtxos).toHaveBeenCalledWith({
+                        script: [hex.encode(open.swapPkScript)],
+                    });
+                },
+                [],
+            );
+        });
+
+        it("leaves a contract that is not an offer covenant alone", async () => {
+            const offer = makeOffer();
+            const fill = spendPsbt(offer, "fulfill");
+            const repository = new InMemoryAssetSwapRepository();
+            await addAssetSwap(repository, swapFor(offer));
+            const row = spentDeposit(offer, fill.txid);
+            row.contract.metadata = { kind: "other" };
+
+            await withIndexer(
+                async () => ({ txs: [fill.psbt] }),
+                async ({ wallet }) => {
+                    const watcher = await watchOfferSwaps({
+                        wallet,
+                        arkServerUrl: "http://ark",
+                        repository,
+                    });
+                    await watcher.idle();
+                    watcher.stop();
+
+                    expect(await getAssetSwaps(repository)).toMatchObject([{ status: "pending" }]);
+                },
+                [row],
+            );
+        });
     });
 });
 

--- a/packages/ts-sdk/src/contracts/contractWatcher.ts
+++ b/packages/ts-sdk/src/contracts/contractWatcher.ts
@@ -697,17 +697,22 @@ export class ContractWatcher {
         const now = Date.now();
 
         try {
-            // Load all the virtual outputs for these contracts, from DB
+            // spent rows too: `includeSpent` post-filters one repository read,
+            // so a spend can be reported with the row that records it. The row
+            // this diffs against was unspent when cached (#864).
             const vtxosMap = await this.getContractVtxos({
                 contractScripts,
-                includeSpent: false, // only spendable ones!
+                includeSpent: true,
             });
 
             for (const contractScript of contractScripts) {
                 const state = this.contracts.get(contractScript);
                 if (!state) continue;
 
-                const currentVtxos = vtxosMap.get(contractScript) || [];
+                const known = vtxosMap.get(contractScript) || [];
+                const knownByKey = new Map(known.map((v) => [`${v.txid}:${v.vout}`, v]));
+                // the diff below is still against the unspent set
+                const currentVtxos = known.filter((v) => !v.isSpent);
                 const currentKeys = new Set(currentVtxos.map((v) => `${v.txid}:${v.vout}`));
 
                 // Find new virtual outputs and add them to the contract's state
@@ -724,7 +729,8 @@ export class ContractWatcher {
                 const spentVtxos: VirtualCoin[] = [];
                 for (const [key, vtxo] of state.lastKnownVtxos) {
                     if (!currentKeys.has(key)) {
-                        spentVtxos.push(vtxo);
+                        // the cached row only when storage has nothing fresher
+                        spentVtxos.push(knownByKey.get(key) ?? vtxo);
                         state.lastKnownVtxos.delete(key);
                     }
                 }

--- a/packages/ts-sdk/test/contracts/pollSpendPayload.test.ts
+++ b/packages/ts-sdk/test/contracts/pollSpendPayload.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    type Contract,
+    type ContractEvent,
+    ContractWatcher,
+    type ExtendedVirtualCoin,
+    type IndexerProvider,
+    InMemoryWalletRepository,
+    isContractVtxoEvent,
+} from "../../src";
+import { saveVtxosForContract } from "../../src/contracts/vtxoOwnership";
+import {
+    createDefaultContractParams,
+    createMockIndexerProvider,
+    createMockVtxo,
+    TEST_DEFAULT_SCRIPT,
+} from "./helpers";
+
+const CHECKPOINT = "cc".repeat(32);
+const ARK_TX = "dd".repeat(32);
+
+const contract = (): Contract => ({
+    type: "default",
+    params: createDefaultContractParams(),
+    script: TEST_DEFAULT_SCRIPT,
+    address: "address",
+    state: "active",
+    createdAt: Date.now(),
+});
+
+/**
+ * That payload used to be the cached, pre-spend row, stating `spentBy: ""` on
+ * an event that says the output was spent. Nothing pinned that shape, which is
+ * how it survived; this pins the one that replaced it.
+ */
+describe("failsafe poll: what a vtxo_spent event carries", () => {
+    let watcher: ContractWatcher;
+    let indexer: IndexerProvider;
+    let repository: InMemoryWalletRepository;
+
+    beforeEach(() => {
+        indexer = createMockIndexerProvider();
+        repository = new InMemoryWalletRepository();
+        watcher = new ContractWatcher({
+            indexerProvider: indexer,
+            walletRepository: repository,
+            failsafePollIntervalMs: 1000,
+        });
+    });
+
+    afterEach(() => vi.useRealTimers());
+
+    it("reports the spend with the row that records it", async () => {
+        const unspent = createMockVtxo({
+            script: TEST_DEFAULT_SCRIPT,
+            value: 4200,
+        }) as ExtendedVirtualCoin;
+        const target = contract();
+        await saveVtxosForContract(repository, target, [unspent]);
+
+        vi.useFakeTimers();
+        const events: ContractEvent[] = [];
+        await watcher.addContract(target);
+        await watcher.startWatching((e) => events.push(e));
+        events.length = 0;
+
+        // the sync has since written the spend against the same outpoint
+        await saveVtxosForContract(repository, target, [
+            {
+                ...unspent,
+                isSpent: true,
+                virtualStatus: { state: "spent" },
+                spentBy: CHECKPOINT,
+                arkTxId: ARK_TX,
+            },
+        ]);
+        await vi.advanceTimersByTimeAsync(1200);
+
+        const spent = events.filter(
+            (e) => e.type === "vtxo_spent" && isContractVtxoEvent(e) && e.vtxos.length > 0,
+        );
+        expect(spent).toHaveLength(1);
+        expect((spent[0] as { vtxos: unknown[] }).vtxos[0]).toMatchObject({
+            txid: unspent.txid,
+            vout: unspent.vout,
+            isSpent: true,
+            spentBy: CHECKPOINT,
+            arkTxId: ARK_TX,
+        });
+
+        await watcher.stopWatching();
+    });
+
+    it("still reports a spend whose row storage never gained", async () => {
+        // an outpoint that simply left the unspent set, with nothing fresher to
+        // report it by: the cached row, exactly as before
+        const unspent = createMockVtxo({
+            script: TEST_DEFAULT_SCRIPT,
+            value: 4200,
+        }) as ExtendedVirtualCoin;
+        const target = contract();
+        await saveVtxosForContract(repository, target, [unspent]);
+
+        vi.useFakeTimers();
+        const events: ContractEvent[] = [];
+        await watcher.addContract(target);
+        await watcher.startWatching((e) => events.push(e));
+        events.length = 0;
+
+        await repository.deleteVtxosForScript!(TEST_DEFAULT_SCRIPT);
+        await vi.advanceTimersByTimeAsync(1200);
+
+        const spent = events.filter(
+            (e) => e.type === "vtxo_spent" && isContractVtxoEvent(e) && e.vtxos.length > 0,
+        );
+        expect(spent).toHaveLength(1);
+        expect((spent[0] as { vtxos: { txid: string }[] }).vtxos[0].txid).toBe(unspent.txid);
+
+        await watcher.stopWatching();
+    });
+
+    it("does not read a spent row as a new receipt", async () => {
+        // `includeSpent: true` widens the read, so the unspent set the diff runs
+        // against has to be narrowed back or every spend reads as a receipt too
+        const target = contract();
+
+        vi.useFakeTimers();
+        const events: ContractEvent[] = [];
+        await watcher.addContract(target);
+        await watcher.startWatching((e) => events.push(e));
+        events.length = 0;
+
+        // arrives already spent, and only after the boot poll — seeding it up
+        // front would let that poll claim it before this assertion looks
+        await saveVtxosForContract(repository, target, [
+            {
+                ...(createMockVtxo({ script: TEST_DEFAULT_SCRIPT }) as ExtendedVirtualCoin),
+                txid: "ee".repeat(32),
+                isSpent: true,
+                virtualStatus: { state: "spent" },
+                spentBy: CHECKPOINT,
+            },
+        ]);
+        await vi.advanceTimersByTimeAsync(1200);
+
+        expect(events.filter((e) => e.type === "vtxo_received")).toEqual([]);
+
+        await watcher.stopWatching();
+    });
+});

--- a/packages/ts-sdk/test/contracts/spentRowsSurviveStorage.test.ts
+++ b/packages/ts-sdk/test/contracts/spentRowsSurviveStorage.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { TaprootControlBlock } from "@scure/btc-signer";
+import {
+    type Contract,
+    type ExtendedVirtualCoin,
+    IndexedDBWalletRepository,
+    InMemoryWalletRepository,
+    type TapLeafScript,
+} from "../../src";
+import { SQLiteWalletRepository } from "../../src/repositories/sqlite/walletRepository";
+import type { WalletRepository } from "../../src/repositories";
+import { getVtxosForContract, saveVtxosForContract } from "../../src/contracts/vtxoOwnership";
+import { createMockSQLExecutor } from "../helpers/mockSqlExecutor";
+import { TEST_DEFAULT_SCRIPT } from "./helpers";
+
+const CHECKPOINT = "cc".repeat(32);
+const ARK_TX = "dd".repeat(32);
+
+const contract: Pick<Contract, "script" | "address"> = {
+    script: TEST_DEFAULT_SCRIPT,
+    address: "contract-address",
+};
+
+function tapLeaf(): TapLeafScript {
+    const controlBlock = TaprootControlBlock.decode(new Uint8Array([0xc0, ...new Uint8Array(32)]));
+    return [controlBlock, new Uint8Array(20).fill(2)];
+}
+
+/** A deposit the sync has already seen spent. */
+const spentDeposit = (): ExtendedVirtualCoin => ({
+    txid: "ab".repeat(32),
+    vout: 0,
+    value: 10_000,
+    status: { confirmed: true },
+    virtualStatus: { state: "spent" },
+    createdAt: new Date("2024-01-15T12:00:00Z"),
+    isUnrolled: false,
+    isSpent: true,
+    spentBy: CHECKPOINT,
+    arkTxId: ARK_TX,
+    script: TEST_DEFAULT_SCRIPT,
+    forfeitTapLeafScript: tapLeaf(),
+    intentTapLeafScript: tapLeaf(),
+    tapTree: new Uint8Array(32).fill(3),
+});
+
+const backends: { name: string; make: () => WalletRepository }[] = [
+    { name: "InMemoryWalletRepository", make: () => new InMemoryWalletRepository() },
+    { name: "IndexedDBWalletRepository", make: () => new IndexedDBWalletRepository() },
+    {
+        name: "SQLiteWalletRepository",
+        make: () => new SQLiteWalletRepository(createMockSQLExecutor()),
+    },
+];
+
+/**
+ * `getContractsWithVtxos` delegates straight to `getVtxosForContract`, so this
+ * is the read behind every consumer asking a contract what became of its
+ * deposits — and it fails silently: a backend that pruned spent rows, or dropped
+ * their txids in its serializer, leaves them finding nothing, suite still green.
+ */
+describe.each(backends)("spent rows survive $name", ({ make }) => {
+    let repository: WalletRepository;
+
+    beforeEach(() => {
+        repository = make();
+    });
+
+    afterEach(async () => {
+        await repository?.clear();
+        await repository?.[Symbol.asyncDispose]();
+    });
+
+    it("returns the spent deposit, carrying both halves of its spend", async () => {
+        await saveVtxosForContract(repository, contract, [spentDeposit()]);
+
+        const vtxos = await getVtxosForContract(repository, contract);
+
+        expect(vtxos).toHaveLength(1);
+        expect(vtxos[0]).toMatchObject({
+            txid: "ab".repeat(32),
+            vout: 0,
+            isSpent: true,
+            spentBy: CHECKPOINT,
+            arkTxId: ARK_TX,
+        });
+    });
+
+    it("keeps the spent row alongside an unspent one at the same script", async () => {
+        const unspent: ExtendedVirtualCoin = {
+            ...spentDeposit(),
+            txid: "ef".repeat(32),
+            virtualStatus: { state: "settled" },
+            isSpent: false,
+            spentBy: "",
+            arkTxId: undefined,
+        };
+        await saveVtxosForContract(repository, contract, [spentDeposit(), unspent]);
+
+        const vtxos = await getVtxosForContract(repository, contract);
+
+        expect(vtxos.map((v) => v.txid).sort()).toEqual(["ab".repeat(32), "ef".repeat(32)].sort());
+        expect(vtxos.find((v) => v.txid === "ab".repeat(32))?.spentBy).toBe(CHECKPOINT);
+    });
+});


### PR DESCRIPTION
Closes #864.

Two distinct halves, two commits, so either can be reverted without the other. The first is `@arkade-os/swap`; the second is `@arkade-os/sdk` core and has the wider blast radius.

---

## Half 1 — `watchOfferSwaps` had no pass behind its subscription

`f3231e64` · `packages/swap/src/watch.ts`

`watchOfferSwaps` was a pure event sink: one `onContractEvent` subscription and an immediate return. A spend it did not receive as a live, well-formed `vtxo_spent` was never learned, and the record kept `status: "pending"` with no `spentTxid` indefinitely.

The ordinary case is a wallet closed with an offer funded, the solver filling it, and the user reopening. `ContractManager.initialize` calls `reconcileWatched()` and installs the watcher callback *afterwards*, and `create` awaits `initialize()` — so no caller can have called `onContractEvent` before the boot reconcile ran. `emitEvent` is private with one call site. Everything the boot sync writes to the repository is therefore unobservable to subscribers.

`resolveOpenSwaps` asks the contract manager what became of those deposits, once per watcher, scoped to the scripts of records still open, and drives the same classify / persist / retire path the event handler uses — `resolveSpends`, lifted out of `handleSpend` unchanged. It is **enqueued rather than awaited**, so the subscription is installed before it reads and a spend landing mid-pass arrives as an event instead of falling between the two.

It passes no `at`: the manager's view carries no spend time, and `Date.now()` would record the *scan* as the completion. `restoreAssetSwaps` omits it on the same grounds.

---

## Half 2 — the failsafe poll emitted a payload that could not carry a spend txid

`482b1297` · `packages/ts-sdk/src/contracts/contractWatcher.ts`

`pollContracts` reads the post-sync repository with `includeSpent: false` and reports the difference using the **cached** rows — and those were unspent when cached. By the type's own documentation they carry neither `arkTxId` nor a truthy `spentBy`: *"The empty string means 'not spent by anything' — test truthiness, never presence"* (`wallet/index.ts:826-833`).

**Observed, not inferred.** A `vtxo_spent` for a genuinely spent deposit arrived at a subscriber as:

```
isSpent: false, spentBy: "", arkTxId: undefined, state: "settled"
```

on an event whose entire meaning is that the output was spent. The offer watcher drops every such event at its first guard (`const spentTxid = vtxo.arkTxId || vtxo.spentBy`), so the failsafe poll — the thing that exists to catch what the live subscription missed — could never resolve an offer.

### Why this is fixed in the watcher and not in its consumer

The payload is wrong for everyone who reads it, not just for offers. `Wallet`'s own subscription forwards these same rows to every consumer as `spentVtxos` (`wallet.ts`), so nothing downstream can bind the spend either.

And it costs nothing. `includeSpent` is a post-filter over the same `walletRepository` read (`getContractVtxos`), so asking for spent rows adds no query. The unspent set the diff runs against is narrowed back explicitly — otherwise every spend would also read as a receipt, which has its own test. When storage holds nothing fresher for an outpoint, the cached row is still emitted, so no case loses an event it used to get.

The alternative considered was having `handleSpend` in `@arkade-os/swap` resolve the missing txid itself. Rejected on two grounds: it leaves the payload wrong for every other consumer, and it puts an **unbounded** indexer round trip on a recovery path — this SDK has no `AbortSignal.timeout` anywhere, so that call has nothing to stop it hanging.

### What integrators should check

Every change here is *toward* truth, but the values do change. **Grep your `vtxo_spent` handlers for `spentBy`, `arkTxId` and `isSpent`.** Fields that were always empty on the poll path are now populated. A handler branching on `!vtxo.isSpent` inside a spend handler was asking "is this spent vtxo unspent?", getting `true`, and silently skipping real spends — it now takes the other branch. `CHANGELOG.md` says the same so it is greppable.

### Not fixed here, and why

`pollWatchedScripts` has the same symptom for a **different** cause: it reads the indexer with `spendableOnly: true`, so it never sees the spent row at all. Fixing that costs a network call rather than nothing, which is the tradeoff rejected above, and watch-only events carry no `contract` so they never reach the offer path. Out of scope for this issue — worth its own, if someone wants it.

---

## Test plan

- `packages/swap/test/watch.test.ts` — 4 new tests for the start-up pass.
- `packages/ts-sdk/test/contracts/pollSpendPayload.test.ts` — 3 tests pinning the event payload. Nothing pinned the old shape, which is how it survived for so long.
- `packages/ts-sdk/test/contracts/spentRowsSurviveStorage.test.ts` — 6 tests pinning the precondition the whole fix rests on: that a contract's **spent** rows come back out of storage with their spend txids intact, across `InMemory`, `IndexedDB` and `SQLite`. This one fails in the silent direction — a backend that pruned spent rows, or dropped their txids in its serializer, would leave every consumer finding nothing with the suite still green. **`Realm` is confirmed by reading rather than by test.** Its mock is private to its own test file and sharing it is a bigger change than this PR should carry, so instead: `realm/walletRepository.ts:109-113` filters on `script` alone with no spent predicate (same at `:54-58` for the address path); the write persists `isSpent` / `spentBy` / `arkTxId` at `:87-90`; and `vtxoObjectToDomain` restores all three at `:286-289`. Everything downstream of that — `deserializeVtxo` in the shared `serialization.ts`, then `normalizeVtxo` — is common to all four backends and is exercised by the IndexedDB and SQLite cases above. So the Realm-specific surface is those two hops, both read.
- Every new guard was mutation-checked; each mutation is caught.
- Gate on this branch: `pnpm -r lint`, `pnpm -r build`, `pnpm -r test:unit` all exit 0. ts-sdk `183 files / 3047 +1 skipped` -> `185 / 3056 +1`; swap `33 / 811` -> `33 / 815`; boltz-swap `23 / 617` unchanged.

## Notes for review

- The pre-commit hook refuses to run in a git worktree (#880) — its filter selects no projects, so lint and `test:unit` would test nothing. The gate above was run manually and both commits use `--no-verify`, as that hook's own message instructs.
- `CHANGELOG.md` was last updated at `0.4.23` while the package is at `0.4.71`. I added an `[Unreleased]` entry anyway because this change is field-level and integrator-visible; say the word if the file is considered retired and I will drop it.
- Independent of #877 and #893's branch, not stacked. #864 makes the watcher trustworthy for any swap that *has* a contract row; #877 is what gives a restored swap one.



## Corrections and coverage, after review

**What the start-up pass actually costs.** The description above says it "reads the manager's own view". That understates it: `getContractsWithVtxos` calls `syncedWithin(contracts, this.config.vtxoSyncMaxAgeMs ?? 0)`, and `syncedWithin` returns `false` outright when the budget is `<= 0` (`contractManager.ts:2371`). No caller sets a budget today, so the pass **always triggers a live `syncContracts` and then reads**, rather than serving the boot-sync result. For a start-up path that is acceptable and it is the same shape the wallet's own reconcile takes — but it is one live indexer round trip, not a repository read, and the call is unbounded (this SDK has no `AbortSignal.timeout` anywhere). Caught in review; recording it rather than quietly leaving the body optimistic.

**Review coverage on these three PRs is not uniform — don't read three green boards as three equal reviews.** CodeRabbit has genuinely reviewed only #892; on this PR and #893 it reported `SUCCESS` while its comment body said "Review limit reached", and an explicit `@coderabbitai review` re-trigger was itself rate-limited. Both have `0` formal CodeRabbit reviews. arkana has reviewed all three. So this PR — the largest blast radius of the three, and the only one touching `ContractWatcher`, which every `vtxo_spent` consumer depends on — has had exactly one automated reviewer, not two.
