### PR TITLE
fix(swap): preserve readable cached markets

### DIFF
--- a/packages/swap/src/markets.ts
+++ b/packages/swap/src/markets.ts
@@ -127,7 +127,11 @@ const readMarketsCache = async (
         const entry = await repository.getCachedMarkets(network, registry);
         if (!Array.isArray(entry?.markets) || typeof entry?.fetchedAt !== "number")
             return undefined;
-        return entry.markets.every(isMarketShaped) ? entry : undefined;
+        const markets = entry.markets.filter(isMarketShaped);
+        // An empty cache is authoritative. A non-empty cache with no readable
+        // markets is malformed and should be replaced by a fresh fetch.
+        if (entry.markets.length > 0 && markets.length === 0) return undefined;
+        return { ...entry, markets };
     } catch {
         return undefined;
     }

--- a/packages/swap/src/payment/crossAsset.ts
+++ b/packages/swap/src/payment/crossAsset.ts
@@ -74,6 +74,9 @@ const parseAssetId = (assetId: string): assetExt.AssetId | undefined => {
     }
 };
 
+const marketLabel = (market: OfferPlan["market"]): string =>
+    `${market.base_asset.ticker || market.base_asset.id}/${market.quote_asset.ticker || market.quote_asset.id}`;
+
 /** Rank after `ark-asset`, which pays from a balance already held. Both match,
  *  so `options()` can offer "pay from your USDX" beside "buy USDX and pay". */
 export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
@@ -147,7 +150,7 @@ export function crossAssetRail(deps: CrossAssetRailDeps): PaymentRail {
                     spent: { assetId: BTC_ASSET_ID, amount: plan.deposit.atomic },
                 },
                 meta: {
-                    market: plan.market.pair,
+                    market: marketLabel(plan.market),
                     priceDisplay: plan.priceDisplay,
                     give: plan.give,
                 },

--- a/packages/swap/test/markets.test.ts
+++ b/packages/swap/test/markets.test.ts
@@ -292,6 +292,24 @@ describe("discoverMarkets caching", () => {
         expect(fetchImpl).toHaveBeenCalledTimes(1);
     });
 
+    it("drops an unreadable market without discarding the readable cache", async () => {
+        await seedCache(Date.now(), [btcUsd, null as unknown as DiscoveredMarket]);
+        const fetchImpl = jsonFetch([registryIndex()]);
+
+        const served = await discoverWith(fetchImpl);
+        expect(served).toHaveLength(1);
+        expect(served[0].source).toBe(btcUsd.source);
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("serves a fresh empty cache without refetching", async () => {
+        await seedCache(Date.now(), []);
+        const fetchImpl = jsonFetch([registryIndex()]);
+
+        expect(await discoverWith(fetchImpl)).toEqual([]);
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
     it("fetches when the cache backend itself is unreadable", async () => {
         // a broken backend must degrade to a network fetch, never throw out
         const broken = Object.assign(new InMemoryAssetSwapRepository(), {

--- a/packages/swap/test/payment/crossAsset.test.ts
+++ b/packages/swap/test/payment/crossAsset.test.ts
@@ -207,6 +207,20 @@ describe("crossAssetRail.quote", () => {
         expect(quote.assets?.spent.assetId).not.toBe(quote.assets?.delivered.assetId);
     });
 
+    it("derives the market label when the wire pair is absent", async () => {
+        const pairless = {
+            ...plan(100_000n, 500n),
+            market: market({
+                pair: undefined,
+                base_asset: { id: "arkade:mutinynet/slip44:1", decimals: 8, ticker: "BTC" },
+                quote_asset: { id: USDX_ID, decimals: 2, ticker: "USDX" },
+            }),
+        } as OfferPlan;
+        const rail = crossAssetRail(depsWith({ quote: vi.fn(async () => pairless) }));
+
+        expect((await rail.quote(req, ctxWith())).meta?.market).toBe("BTC/USDX");
+    });
+
     it("prices BOTH legs into the sats that leave the wallet", async () => {
         const quote = await crossAssetRail(depsWith({ carrierSats: 330 })).quote(req, ctxWith());
         expect(quote).toMatchObject({ amount: 330, fee: 100_000, total: 100_330 });


### PR DESCRIPTION
## Why

PR #899 already taught the cache to accept pairless CAIP-19 markets, making the original headline change here redundant. Two independent resilience fixes remain:

- a single unreadable persisted market must not discard every readable market and the stale-cache fallback
- `crossAsset` must derive its display label from asset metadata instead of the removed registry `pair` field

## What changed

This branch is rebuilt on current `master` and contains only those two fixes. The compatibility-window fixtures and duplicate pairless-cache coverage were removed.

`readMarketsCache` now filters malformed market rows individually. A non-empty cache with no readable rows remains a miss, while an intentionally empty cache remains authoritative.

`crossAsset` derives `BTC/USDX`-style display labels from tickers, falling back to canonical asset IDs when display metadata is absent.

## Verification

- focused red/green tests: 66 passed
- `pnpm --filter @arkade-os/swap build`: passed
- changed-file Biome formatting: passed
- `pnpm --filter @arkade-os/swap test:unit`: 34 files, 826 tests passed
- `git diff --check`: passed

The repository-wide lint command remains affected by the existing Windows CRLF formatting issue in untouched files; all four changed files pass Biome directly.