### PR TITLE
fix(swap): support CAIP-19 registry markets

### DIFF
--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -18,6 +18,15 @@ export {
     type PlanError,
 } from "./markets";
 export {
+    MARKET_CORRIDORS,
+    isRfqMarket,
+    marketAssetId,
+    marketCorridor,
+    marketPairLabel,
+    type MarketCorridor,
+    type MarketLike,
+} from "./marketShape";
+export {
     BTC_ASSET_ID,
     getAssetSwaps,
     getAssetSwapsOrThrow,

--- a/packages/swap/src/marketShape.ts
+++ b/packages/swap/src/marketShape.ts
@@ -1,0 +1,59 @@
+import type { Side } from "@arkade-os/solver-discovery";
+
+export const MARKET_CORRIDORS = ["arkade", "bolt11", "bitcoin", "eip155"] as const;
+export type MarketCorridor = (typeof MARKET_CORRIDORS)[number];
+
+type AssetLike = { id?: unknown; caip19_id?: unknown; ticker?: unknown };
+export type MarketLike = {
+    base_asset?: unknown;
+    quote_asset?: unknown;
+    base_corridor?: unknown;
+    quote_corridor?: unknown;
+};
+
+const LEGACY_CORRIDORS: Record<string, MarketCorridor> = {
+    arkade: "arkade",
+    lightning: "bolt11",
+    onchain: "bitcoin",
+    eip155: "eip155",
+};
+
+const assetOf = (market: MarketLike, side: Side): AssetLike | undefined =>
+    (side === "base" ? market.base_asset : market.quote_asset) as AssetLike | undefined;
+
+export const marketAssetId = (market: MarketLike, side: Side): string | undefined => {
+    const asset = assetOf(market, side);
+    if (typeof asset?.caip19_id === "string") return asset.caip19_id;
+    return typeof asset?.id === "string" ? asset.id : undefined;
+};
+
+const chainNamespaceOf = (id: string | undefined): string | undefined => {
+    if (id === undefined) return undefined;
+    const slash = id.indexOf("/");
+    const colon = id.indexOf(":");
+    return slash === -1 || colon === -1 || colon > slash ? undefined : id.slice(0, colon);
+};
+
+export const marketCorridor = (market: MarketLike, side: Side): MarketCorridor => {
+    const namespace = chainNamespaceOf(marketAssetId(market, side));
+    if (namespace !== undefined) {
+        return (MARKET_CORRIDORS as readonly string[]).includes(namespace)
+            ? (namespace as MarketCorridor)
+            : "arkade";
+    }
+    const legacy = side === "base" ? market.base_corridor : market.quote_corridor;
+    return typeof legacy === "string" ? (LEGACY_CORRIDORS[legacy] ?? "arkade") : "arkade";
+};
+
+export const isRfqMarket = (market: MarketLike): boolean =>
+    marketCorridor(market, "base") !== "arkade" || marketCorridor(market, "quote") !== "arkade";
+
+const sideLabel = (market: MarketLike, side: Side): string => {
+    const ticker = assetOf(market, side)?.ticker;
+    const label = typeof ticker === "string" && ticker.length > 0 ? ticker : "?";
+    const corridor = marketCorridor(market, side);
+    return corridor === "arkade" ? label : `${corridor}:${label}`;
+};
+
+export const marketPairLabel = (market: MarketLike): string =>
+    `${sideLabel(market, "base")}/${sideLabel(market, "quote")}`;

--- a/packages/swap/src/markets.ts
+++ b/packages/swap/src/markets.ts
@@ -27,6 +27,7 @@ import {
 } from "@arkade-os/solver-discovery";
 import { isSubdust } from "@arkade-os/sdk";
 import type { AssetSwapRepository, MarketsCacheEntry } from "./repository";
+import { marketAssetId } from "./marketShape";
 import { BTC_ASSET_ID } from "./store";
 
 /** Shared quote options so every quote path agrees.
@@ -106,8 +107,8 @@ const MARKETS_CACHE_TTL_MS = 60 * 60 * 1000;
 
 const isMarketShaped = (m: unknown): m is DiscoveredMarket => {
     const market = m as Partial<DiscoveredMarket> | null;
+    if (!market) return false;
     return (
-        typeof market?.pair === "string" &&
         typeof market.base_asset?.id === "string" &&
         typeof market.quote_asset?.id === "string" &&
         typeof market.quote_asset.decimals === "number"
@@ -208,10 +209,35 @@ export const findMarket = (
     toId: string,
 ): { market: DiscoveredMarket | null; give: Side } | undefined => {
     if (fromId === toId) return undefined;
-    const givingBase = bestMarket(markets, { baseId: fromId, quoteId: toId, wantSide: "quote" });
+    const resolveMarketId = (id: string): string => {
+        for (const market of markets) {
+            for (const side of ["base", "quote"] as const) {
+                const asset = side === "base" ? market.base_asset : market.quote_asset;
+                if (asset.id === id) return id;
+                const canonical = marketAssetId(market, side) ?? "";
+                const matchesBtc =
+                    id === BTC_ASSET_ID && /^arkade:[^/]+\/slip44:(?:0|1)$/.test(canonical);
+                const matchesAsset =
+                    /^[0-9a-f]{68}$/.test(id) && canonical.endsWith(`/asset:${id}`);
+                if ((matchesBtc || matchesAsset) && typeof asset.id === "string") return asset.id;
+            }
+        }
+        return id;
+    };
+    const resolvedFrom = resolveMarketId(fromId);
+    const resolvedTo = resolveMarketId(toId);
+    const givingBase = bestMarket(markets, {
+        baseId: resolvedFrom,
+        quoteId: resolvedTo,
+        wantSide: "quote",
+    });
     if (givingBase) return { market: givingBase, give: "base" };
     return {
-        market: bestMarket(markets, { baseId: toId, quoteId: fromId, wantSide: "base" }),
+        market: bestMarket(markets, {
+            baseId: resolvedTo,
+            quoteId: resolvedFrom,
+            wantSide: "base",
+        }),
         give: "quote",
     };
 };

--- a/packages/swap/test/marketShape.test.ts
+++ b/packages/swap/test/marketShape.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { isRfqMarket, marketCorridor, marketPairLabel } from "../src/marketShape";
+
+const legacy = {
+    pair: "BTC/lightning:BTC",
+    base_asset: { id: "btc", ticker: "BTC" },
+    quote_asset: { id: "btc", ticker: "BTC" },
+    quote_corridor: "lightning",
+};
+
+const card = {
+    base_asset: { id: "arkade:mutinynet/slip44:1", ticker: "BTC" },
+    quote_asset: { id: "bolt11:mutinynet/slip44:1", ticker: "BTC" },
+};
+
+describe("market shape compatibility", () => {
+    it("classifies legacy and CAIP-19 Lightning markets identically", () => {
+        for (const market of [legacy, card]) {
+            expect(marketCorridor(market, "base")).toBe("arkade");
+            expect(marketCorridor(market, "quote")).toBe("bolt11");
+            expect(isRfqMarket(market)).toBe(true);
+            expect(marketPairLabel(market)).toBe("BTC/bolt11:BTC");
+        }
+    });
+
+    it("reads the canonical id retained beside a down-projected index id", () => {
+        const index = {
+            ...legacy,
+            base_asset: { ...legacy.base_asset, caip19_id: "arkade:mutinynet/slip44:1" },
+            quote_asset: { ...legacy.quote_asset, caip19_id: "bolt11:mutinynet/slip44:1" },
+        };
+        expect(marketCorridor(index, "quote")).toBe("bolt11");
+    });
+
+    it("prefers a CAIP-19 identity over a disagreeing legacy corridor", () => {
+        expect(
+            marketCorridor(
+                { quote_asset: { id: "bolt11:bitcoin/slip44:0" }, quote_corridor: "onchain" },
+                "quote",
+            ),
+        ).toBe("bolt11");
+    });
+
+    it("recognizes Bitcoin and EIP-155 without treating either as spot", () => {
+        for (const [id, corridor] of [
+            ["bitcoin:bitcoin/slip44:0", "bitcoin"],
+            [`eip155:1/erc20:0x${"a".repeat(40)}`, "eip155"],
+        ] as const) {
+            const market = { quote_asset: { id, ticker: "X" } };
+            expect(marketCorridor(market, "quote")).toBe(corridor);
+            expect(isRfqMarket(market)).toBe(true);
+        }
+    });
+
+    it("defaults malformed and unknown namespaces to Arkade", () => {
+        expect(marketCorridor({}, "quote")).toBe("arkade");
+        expect(marketCorridor({ quote_asset: { id: "ripple:mainnet/slip44:144" } }, "quote")).toBe(
+            "arkade",
+        );
+    });
+
+    it("uses a question mark when display metadata is absent", () => {
+        expect(marketPairLabel({ base_asset: {}, quote_asset: {} })).toBe("?/?");
+    });
+});

--- a/packages/swap/test/markets.test.ts
+++ b/packages/swap/test/markets.test.ts
@@ -51,6 +51,30 @@ describe("findMarket", () => {
     it("returns a null market for unknown assets", () => {
         expect(findMarket(markets, "btc", "ff".repeat(34))?.market).toBeNull();
     });
+
+    it("maps logical btc to the Arkade CAIP-19 BTC leg", () => {
+        const caip19 = {
+            ...btcUsd,
+            pair: undefined,
+            base_asset: { ...btcUsd.base_asset, id: "arkade:mutinynet/slip44:1" },
+        } as unknown as DiscoveredMarket;
+        expect(findMarket([caip19], "btc", USD_ID)).toEqual({ market: caip19, give: "base" });
+        expect(findMarket([caip19], USD_ID, "btc")).toEqual({ market: caip19, give: "quote" });
+    });
+
+    it("maps an Arkade asset id to its CAIP-19 market leg", () => {
+        const caip19 = {
+            ...btcUsd,
+            pair: undefined,
+            base_asset: { ...btcUsd.base_asset, id: "arkade:mutinynet/slip44:1" },
+            quote_asset: {
+                ...btcUsd.quote_asset,
+                id: `arkade:mutinynet/asset:${USD_ID}`,
+            },
+        } as unknown as DiscoveredMarket;
+        expect(findMarket([caip19], "btc", USD_ID)).toEqual({ market: caip19, give: "base" });
+        expect(findMarket([caip19], USD_ID, "btc")).toEqual({ market: caip19, give: "quote" });
+    });
 });
 
 describe("quoteOffer with the package quote options", () => {
@@ -228,6 +252,19 @@ describe("discoverMarkets caching", () => {
         const fetchImpl = jsonFetch([registryIndex()]);
         const markets = await discoverWith(fetchImpl);
         expect(markets).toHaveLength(1);
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("serves a fresh pairless CAIP-19 cache without fetching", async () => {
+        const pairless = {
+            ...btcUsd,
+            pair: undefined,
+            base_asset: { ...btcUsd.base_asset, id: "arkade:mutinynet/slip44:1" },
+        } as unknown as DiscoveredMarket;
+        await seedCache(Date.now(), [pairless]);
+        const fetchImpl = jsonFetch([registryIndex()]);
+
+        expect(await discoverWith(fetchImpl)).toEqual([pairless]);
         expect(fetchImpl).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

- centralize legacy and CAIP-19 market classification/labels in @arkade-os/swap`n- make market discovery resolve logical BTC and issued-asset IDs against canonical CAIP-19 registry cards
- accept pairless CAIP-19 cache entries while preserving legacy behavior

This provides one compatibility layer for arkade-os/wallet#976 and the intent-solver card-schema migration. Downstream PRs vendor the exact package tarball from this PR commit to avoid workspace/git dependency resolution issues.

## Verification

- pnpm run build`n- swap focused tests: 36 passed
- Biome check on all touched files
- full unit suite running locally; CI is authoritative across supported platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added market classification and labeling support for legacy and CAIP-19 asset identifiers.
  - Improved market discovery for Bitcoin, Arkade, and EIP-155 assets across both trade directions.
  - Added canonical asset ID matching and support for cached markets without registry lookups.
  - Added consistent fallback labels and handling for unknown or malformed asset namespaces.

- **Tests**
  - Expanded coverage for market classification, asset matching, corridor detection, and cached market discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->