### PR TITLE
perf(swap): read offer history once per start-up pass, not once per deposit

### DIFF
--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -152,15 +152,18 @@ export async function watchOfferSwaps({
         }
     };
 
-    const resolveSpends = async (contractScript: string, vtxos: ContractVtxo[], at?: number) => {
+    /** `known` must be the FULL list: {@link retireOfferContract} reads liveness off it. */
+    const resolveSpends = async (
+        contractScript: string,
+        vtxos: ContractVtxo[],
+        { at, known }: { at?: number; known?: AssetSwap[] } = {},
+    ) => {
+        // repository v1 has no indexed lookup, so each `find` costs O(history)
+        let swaps = known ?? (await getAssetSwaps(repository));
         for (const vtxo of vtxos) {
             const spentTxid = vtxo.arkTxId || vtxo.spentBy;
             if (!spentTxid) continue;
-            // Identical offers share one script and are told apart by the
-            // deposit that funded them. Repository v1 has no indexed lookup, so
-            // this is O(history) per spend event; add a query API if offer
-            // event volume makes this hot.
-            const swap = (await getAssetSwaps(repository)).find(
+            const swap = swaps.find(
                 (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === contractScript,
             );
             if (!swap) continue;
@@ -172,17 +175,16 @@ export async function watchOfferSwaps({
             // notify only on a write that landed: `onUpdate` is documented as
             // firing after the change is persisted, and a consumer that caches
             // from it would otherwise run ahead of the store
-            const { persisted, swaps } = await updateAssetSwapBestEffort(
+            const { persisted, swaps: written } = await updateAssetSwapBestEffort(
                 repository,
                 swap.id,
                 changes,
             );
-            // a lost write must not retire: the next restore scan still
-            // believes this deposit is live
+            // a lost write must not retire, nor carry its optimistic merge:
+            // the store still holds the old record and later deposits see that
             if (!persisted) continue;
+            swaps = written;
             onUpdate?.({ ...swap, ...changes });
-            // `swaps` is the post-update view, so the liveness check sees this
-            // record's new status without a third read
             if (changes.status && RETIRABLE.includes(changes.status)) {
                 await retireOfferContract(manager, swaps, contractScript);
             }
@@ -191,7 +193,7 @@ export async function watchOfferSwaps({
 
     const handleSpend = async (event: Extract<ContractVtxoEvent, { type: "vtxo_spent" }>) => {
         if (event.contract.metadata?.kind !== OFFER_CONTRACT_KIND) return;
-        await resolveSpends(event.contractScript, event.vtxos, event.timestamp);
+        await resolveSpends(event.contractScript, event.vtxos, { at: event.timestamp });
     };
 
     /**
@@ -202,14 +204,18 @@ export async function watchOfferSwaps({
      * `Date.now()` would record the scan as the completion.
      */
     const resolveOpenSwaps = async () => {
-        const open = (await getAssetSwaps(repository)).filter((s) => !TERMINAL.includes(s.status));
+        const swaps = await getAssetSwaps(repository);
+        const open = swaps.filter((s) => !TERMINAL.includes(s.status));
         if (open.length === 0) return;
         const script = [...new Set(open.map((s) => s.swapPkScript))];
         for (const { contract, vtxos } of await manager.getContractsWithVtxos({ script })) {
             if (contract.metadata?.kind !== OFFER_CONTRACT_KIND) continue;
+            // one read serves every contract: a swap carries one script, so a
+            // write under another contract is never the record this one seeks
             await resolveSpends(
                 contract.script,
                 vtxos.filter((v) => v.isSpent),
+                { known: swaps },
             );
         }
     };

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -45,10 +45,15 @@ const swapFor = (offer: Offer, overrides: Partial<AssetSwap> = {}): AssetSwap =>
     ...overrides,
 });
 
-const spendPsbt = (offer: Offer, via: "cancel" | "fulfill", vout = 0) => {
+const spendPsbt = (
+    offer: Offer,
+    via: "cancel" | "fulfill",
+    vout = 0,
+    fundingTxid = FUNDING_TXID,
+) => {
     const leaf = offerVtxoScript(offer, SERVER_KEY).functionByName(via)!.tapLeafScript;
     const tx = new Transaction({ allowUnknownOutputs: true, allowUnknownInputs: true });
-    tx.addInput({ txid: hex.decode(FUNDING_TXID), index: vout, tapLeafScript: [leaf] });
+    tx.addInput({ txid: hex.decode(fundingTxid), index: vout, tapLeafScript: [leaf] });
     tx.addOutput({ script: MAKER_PK_SCRIPT, amount: BigInt(9_000) });
     return { psbt: base64.encode(tx.toPSBT()), txid: tx.id };
 };
@@ -114,6 +119,31 @@ const spentDeposit = (offer: Offer, spentTxid: string, vtxo: Record<string, unkn
     },
     vtxos: [{ txid: FUNDING_TXID, vout: 0, isSpent: true, arkTxId: spentTxid, ...vtxo }],
 });
+
+const spentDeposits = (
+    offer: Offer,
+    deposits: { txid: string; vout: number; spentTxid: string }[],
+) => ({
+    contract: {
+        script: hex.encode(offer.swapPkScript),
+        metadata: { kind: OFFER_CONTRACT_KIND },
+    },
+    vtxos: deposits.map((d) => ({
+        txid: d.txid,
+        vout: d.vout,
+        isSpent: true,
+        arkTxId: d.spentTxid,
+    })),
+});
+
+/** Answers only for spends the test built: a wrong txid reads as indeterminate
+ * rather than reusing another deposit's transaction. */
+const psbtsByTxid = (spends: { psbt: string; txid: string }[]) => {
+    const byTxid = new Map(spends.map((s) => [s.txid, s.psbt]));
+    return async (txids: string[]) => ({
+        txs: txids.flatMap((t) => (byTxid.has(t) ? [byTxid.get(t)!] : [])),
+    });
+};
 
 // the watcher builds its own RestIndexerProvider from arkServerUrl; intercept
 // the one call it makes rather than reaching through the constructor
@@ -577,6 +607,81 @@ describe("watchOfferSwaps", () => {
                     });
                 },
                 [],
+            );
+        });
+
+        it("reads history once for the pass, not once per deposit", async () => {
+            const offer = makeOffer();
+            const funding = ["c1", "c2", "c3"].map((b) => b.repeat(32));
+            const spends = funding.map((txid, i) => spendPsbt(offer, "fulfill", i, txid));
+            const repository = new InMemoryAssetSwapRepository();
+            for (const txid of funding) {
+                await addAssetSwap(repository, swapFor(offer, { id: txid, fundingTxid: txid }));
+            }
+            const reads = vi.spyOn(repository, "getAllSwaps");
+
+            await withIndexer(
+                psbtsByTxid(spends),
+                async ({ wallet }) => {
+                    reads.mockClear();
+                    const watcher = await watchOfferSwaps({
+                        wallet,
+                        arkServerUrl: "http://ark",
+                        repository,
+                    });
+                    await watcher.idle();
+                    watcher.stop();
+                    const duringPass = reads.mock.calls.length;
+
+                    const after = await getAssetSwaps(repository);
+                    expect(after.filter((s) => s.status === "fulfilled")).toHaveLength(
+                        funding.length,
+                    );
+                    // one read to open the pass, then one inside each write it
+                    // makes; a per-deposit lookup adds a third for every deposit
+                    expect(duringPass).toBe(1 + funding.length);
+                },
+                [
+                    spentDeposits(
+                        offer,
+                        funding.map((txid, i) => ({ txid, vout: i, spentTxid: spends[i].txid })),
+                    ),
+                ],
+            );
+        });
+
+        it("sees its own write, so two deposits of one funding tx resolve once", async () => {
+            // the aliasing case a hoisted read breaks: both lookups hit one record
+            const offer = makeOffer();
+            const first = spendPsbt(offer, "fulfill", 0);
+            const second = spendPsbt(offer, "fulfill", 1);
+            const repository = new InMemoryAssetSwapRepository();
+            await addAssetSwap(repository, swapFor(offer));
+
+            await withIndexer(
+                psbtsByTxid([first, second]),
+                async ({ wallet }) => {
+                    const updates: AssetSwap[] = [];
+                    const watcher = await watchOfferSwaps({
+                        wallet,
+                        arkServerUrl: "http://ark",
+                        repository,
+                        onUpdate: (swap) => updates.push(swap),
+                    });
+                    await watcher.idle();
+                    watcher.stop();
+
+                    expect(updates).toHaveLength(1);
+                    expect(await getAssetSwaps(repository)).toMatchObject([
+                        { status: "fulfilled", spentTxid: first.txid },
+                    ]);
+                },
+                [
+                    spentDeposits(offer, [
+                        { txid: FUNDING_TXID, vout: 0, spentTxid: first.txid },
+                        { txid: FUNDING_TXID, vout: 1, spentTxid: second.txid },
+                    ]),
+                ],
             );
         });
 


### PR DESCRIPTION
`resolveSpends` re-read the entire record list *inside* its loop:

```ts
for (const vtxo of vtxos) {
    const swap = (await getAssetSwaps(repository)).find(
        (s) => s.fundingTxid === vtxo.txid && s.swapPkScript === contractScript,
    );
```

`getAssetSwaps` is `getAllSwaps()` + filter + sort. With each write costing a
read of its own, the start-up pass ran `1 + 2N` full history reads for N spent
deposits, at exactly the moment history is longest. `resolveOpenSwaps` also read
the list and discarded everything but the scripts, so nothing reused it.

The comment above the lookup conceded the cost as "O(history) per spend event",
which was a fair trade when one event carried a handful of deposits. The
start-up pass is a new caller that sentence does not cover.

## Why it could not just be hoisted

The loop writes, and the re-read was load-bearing. Two deposits of one funding
tx both satisfy `fundingTxid === vtxo.txid`, so they resolve to the **same
record**; the fresh read is what lets the second see the first one's write and
bail on `TERMINAL` in `spendUpdate`. A plain `const swaps = await
getAssetSwaps(...)` above the loop resolves that swap twice and fires
`onUpdate` twice.

`updateAssetSwapBestEffort` already returns `swaps`, the post-update view — the
retire check consumes it. Carrying that forward keeps the guarantee at one read
per write, `1 + N`.

## The seed, and why it is safe across contracts

`resolveOpenSwaps` passes its own read down, so the whole boot pass makes a
single lookup read. A swap carries exactly one script, so a write made under one
contract can never be the record another contract is looking for.

The seed is the **unfiltered** list, not `open`. `retireOfferContract` reads
liveness off whatever it is handed (`coverage.ts:160`), so a filtered view would
retire a script another record still holds.

## The one behavioural choice

A failed write does not carry its optimistic merge forward. That matches the old
re-read exactly: the store still holds the old record, so a later deposit for the
same swap sees the stored value and retries, rather than treating an unpersisted
merge as resolved.

## Tests

Two added, both mutation-checked in **both** arms — green with the fix, red
without:

| mutation | result |
|---|---|
| restore the per-deposit re-read | `reads history once for the pass` fails: `expected 7 to be 4` |
| drop the `swaps = written` carry-forward | `sees its own write` fails (2 updates, not 1), plus two pre-existing retire tests |

The second arm is the useful one: it shows the carry-forward is what makes the
hoist correct, and that `retireOfferContract` was depending on it too.

## Test plan

Rebased onto `master` after #895 squash-merged as `ac8167b2`; every file this
branch builds on is byte-identical between the old base and master, so the
replay was conflict-free and the code is unchanged from what was tested.

- Baseline on `ac8167b2`: **243 files / 4517 tests / 0 failing**
  (`pnpm -r lint`, `pnpm -r build`, `pnpm -r test:unit`).
- This branch: **243 / 4519 / 0** — +2, reconciled against the two tests added.
- `tsc --noEmit` and `biome format` clean on both changed files.
- The repo-wide gate is run by hand because the pre-commit hook cannot gate a
  worktree: `pnpm --filter="...[HEAD]"` selects nothing there, and the hook now
  says so rather than passing vacuously.

## Not in scope

`classify` calls `indexer.getVirtualTxs(candidates)` per deposit — one HTTP
round trip each, where the API already takes an array. That is the more
expensive loop, but batching it means pulling classification out of the write
loop, and the batched call has hazards worth handling separately: the endpoint
puts txids in a path segment, and it paginates. Left as a follow-up.
