### PR TITLE
docs(dx): align terminology with Arkade canonical terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Arkade Monorepo
 
-TypeScript packages for the Arkade Bitcoin wallet ecosystem — on-chain/off-chain wallets via the Ark protocol and Arkade Intents asset swaps.
+TypeScript packages for the Arkade Bitcoin wallet ecosystem — onchain/offchain wallets within Arkade, plus Arkade Intents asset swaps.
 
 ## Packages
 
 | Package | Description |
 |---------|-------------|
-| [`@arkade-os/sdk`](packages/ts-sdk/) | Bitcoin wallet SDK with Taproot and Ark protocol support |
+| [`@arkade-os/sdk`](packages/ts-sdk/) | Bitcoin wallet SDK with Taproot support for building within Arkade |
 | [`@arkade-os/boltz-swap`](packages/boltz-swap/) | **Deprecated, unmaintained.** Lightning and chain swaps using Boltz |
 | [`@arkade-os/swap`](packages/swap/) | Client-side Arkade Intents asset swaps: market discovery, offers, RFQ, restore |
 

--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -63,7 +63,7 @@ Every swap has the same two beats, on this route and on the cross-ledger corrido
    deposit back.
 
 Cancel is this route's refund path. Where an HTLC corridor refunds through a timelocked leaf, this
-covenant refunds through `cancelOffer` — a 2-of-2 with the Arkade server, **no solver signature
+covenant refunds through `cancelOffer` — a 2-of-2 with the operator, **no solver signature
 involved**. Same job, same guarantee that the money comes home, reached by a script that fits a
 single-ledger swap.
 
@@ -214,7 +214,7 @@ await wallet.send({
 ```
 
 The covenant co-signer ("emulator") key defaults to the SDK's per-network pin, resolved from the
-network the Ark server reports — never fetched from the emulator itself. Pass
+network the operator reports — never fetched from the emulator itself. Pass
 `params.emulatorPubkey` (33-byte compressed hex, the same contract as `Arkade.connect`'s option)
 to override it for a self-hosted emulator, an unpinned network (signet, testnet), or a key
 rotation the SDK hasn't shipped yet.
@@ -307,7 +307,7 @@ message anywhere: **acceptance is funding**.
 - **Arkade → Lightning** (`arkade:BTC->lightning:BTC`, implemented): the trader derives the
   lightning-send covenant LOCALLY from the quote's binding fields plus its own data, refuses to
   fund on any address mismatch, funds its own derivation before `valid_until`, and may go
-  offline. The solver observes the funding on-chain, pays the invoice, and claims with the
+  offline. The solver observes the funding onchain, pays the invoice, and claims with the
   preimage — which lands publicly in the claim witness as the receipt. A failed swap refunds by
   covenant to the trader's address, pushable by anyone, no trader keys or state.
 - **Arkade ↔ arkade** (BTC↔asset, asset↔asset): an arkade asset leg names the asset id itself —
@@ -470,7 +470,7 @@ The invoice on the lightning-receive leg is the _solver's_, so the SDK owns the 
 than taking the caller's facts about it: `requestLightningReceive` requires a `decodeInvoice`
 callback (no BOLT11 dependency is added) and `verifyReceiveInvoice` binds the decoded invoice to
 this swap's `H` and to `quote.from_amount` — an invoice on another payment hash is the one attack
-here with no on-chain trace, since the payer pays it in full and no lockup on `H` is ever funded.
+here with no onchain trace, since the payer pays it in full and no lockup on `H` is ever funded.
 `assertReceivable` replaces `assertFundable` on this leg: the refund CLTV is the solver's, so the
 window that can run out is the hold invoice's, and the claim window is measured from
 `payDeadline = min(invoice expiry, valid_until)` — returned as the absolute `invoiceExpiresAt`,
@@ -482,7 +482,7 @@ flows return `expectedAmount` (the quote's `to_amount`) — persist it: `pushCla
 refuses, with `LockupAmountMismatchError`, to publish `P` for a lockup funded below it. Matching the
 `pkScript` is not enough on this leg, since a solver that funds the correctly derived script with
 dust still settles the payer's HTLC in full once `P` is out. The gate sums every live output and
-runs before signing — `P` reaches the Ark server at submit — and is skipped only for a lockup we
+runs before signing — `P` reaches the operator at submit — and is skipped only for a lockup we
 have already partially claimed (`partiallyClaimed`), where `P` is public anyway. The push itself is
 core's `signAndSubmitOffchainTx` plus `claimWithPreimageIdentity`, with `verifyServerSignatures`
 on: the server's countersignature is checked per input, against the leaf the local build spends,

--- a/packages/ts-sdk/README.md
+++ b/packages/ts-sdk/README.md
@@ -1,6 +1,6 @@
 # Arkade TypeScript SDK
 
-The Arkade SDK is a TypeScript library for building Bitcoin wallets using the Arkade protocol.
+The Arkade SDK is a TypeScript library for building Bitcoin wallets within Arkade.
 
 [![TypeDoc](https://img.shields.io/badge/TypeScript-Documentation-blue?style=flat-square)](https://arkade-os.github.io/ts-sdk/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/arkade-os/ts-sdk)
@@ -217,7 +217,7 @@ Identities without `signMultiple` continue to work unchanged — each checkpoint
 
 ### Ark Provider Caching
 
-`RestArkProvider.getInfo()` fetches current Arkade server parameters on every call. Wrap it
+`RestArkProvider.getInfo()` fetches current operator parameters on every call. Wrap it
 with `CachingArkProvider` when you reuse that response for fee, signer, or limit lookups:
 
 ```typescript
@@ -249,7 +249,7 @@ Wallets read onchain state (UTXOs, transactions, fee rates, chain tip) through a
 
 If you don't pass a provider explicitly, `OnchainWallet` and `Wallet.create({ ... })` both default to `EsploraProvider` pointing at the URL in `ESPLORA_URL[networkName]`.
 
-> **New:** the interface also requires `getRawTransaction(txid): Promise<Uint8Array>`, the raw wire bytes of a transaction. Emulator v0.0.7+ demands the previous transaction of every input a covenant spend or intent proof carries, and a boarding or commitment parent has no off-chain source. Both shipped providers implement it; a custom `OnchainProvider` has to add it.
+> **New:** the interface also requires `getRawTransaction(txid): Promise<Uint8Array>`, the raw wire bytes of a transaction. Emulator v0.0.7+ demands the previous transaction of every input a covenant spend or intent proof carries, and a boarding or commitment parent has no offchain source. Both shipped providers implement it; a custom `OnchainProvider` has to add it.
 
 #### Default URLs
 
@@ -470,7 +470,7 @@ const activities = await wallet.getActivityHistory()
 
 ### Assets (Issue, Reissue, Burn, Send)
 
-The wallet's `assetManager` lets you create and manage assets on Arkade. The `send` method supports sending assets.
+The wallet's `assetManager` lets you create and manage assets within Arkade. The `send` method supports sending assets.
 
 ```typescript
 // Issue a new asset (non-reissuable by default)
@@ -596,7 +596,7 @@ const manager = await wallet.getVtxoManager()
 #### Renewal: Prevent Expiration
 
 Renew virtual outputs before they expire to retain unilateral control of funds.
-This settles expiring and recoverable virtual outputs back to your wallet, refreshing their expiration time.
+This settles expiring and recoverable virtual outputs back to your wallet, renewing their expiration time.
 
 ```typescript
 // Renew all virtual outputs to prevent expiration
@@ -633,9 +633,9 @@ try {
 }
 ```
 
-#### Recovery: Reclaim Swept VTXOs
+#### Recovery: Reclaim swept virtual outputs
 
-Recover virtual outputs that have been swept by the server or consolidate small amounts (subdust).
+Recover virtual outputs that have been swept by the operator or consolidate small amounts (subdust).
 
 ```typescript
 // Recover swept virtual outputs and preconfirmed subdust
@@ -656,7 +656,7 @@ Instead of the delegating user renewing virtual outputs by themselves, their del
 
 This is useful for wallets that cannot be online 24/7.
 
-When a `delegateProvider` is configured, the wallet address includes an extra tapscript path that authorizes the delegate to co-sign renewals alongside the Arkade server.
+When a `delegateProvider` is configured, the wallet address includes an extra tapscript path that authorizes the delegate to co-sign renewals alongside the operator.
 
 To run a delegation service, you'll need to set up a [Fulmine server](https://github.com/ArkLabsHQ/fulmine) with the [Delegation API](https://github.com/ArkLabsHQ/fulmine?tab=readme-ov-file#-delegate-api) enabled.
 
@@ -786,7 +786,7 @@ const wallet = await Wallet.create({
   identity: MnemonicIdentity.fromMnemonic('abandon abandon...'),
 })
 
-// Get fee information from the server
+// Get fee information from the operator
 const { fees: feeInfo } = await wallet.arkProvider.getInfo();
 
 const exitTxid = await new Ramps(wallet).offboard(
@@ -797,7 +797,7 @@ const exitTxid = await new Ramps(wallet).offboard(
 
 ### Unilateral Exit
 
-Unilateral exit allows you to withdraw your funds from the Arkade protocol back to the Bitcoin blockchain without requiring cooperation from the Arkade server. This process involves two main steps:
+Unilateral exit allows you to withdraw your funds within Arkade back to the Bitcoin blockchain if the operator is unavailable. This process involves two main steps:
 
 1. **Unrolling**: Broadcasting the transaction chain from offchain back to onchain
 2. **Completing the exit**: Spending the unrolled virtual outputs after the timelock expires

--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@arkade-os/sdk",
     "version": "0.4.71",
-    "description": "TypeScript SDK for building Bitcoin wallets using the Arkade protocol",
+    "description": "TypeScript SDK for building Bitcoin wallets within Arkade, an open execution engine for Bitcoin",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/arkade-os/ts-sdk.git",

--- a/packages/ts-sdk/src/arkadeCash/index.ts
+++ b/packages/ts-sdk/src/arkadeCash/index.ts
@@ -7,7 +7,7 @@ import { RelativeTimelock } from "../script/tapscript";
 import { sequenceToTimelock, timelockToSequence } from "../utils/timelock";
 
 /**
- * ArkadeCash is a bearer instrument for the Ark protocol.
+ * ArkadeCash is a bearer instrument within Arkade.
  * It encodes a private key and contract parameters as a bech32m string,
  * enabling wallet-to-wallet transfers without address exchange.
  *

--- a/packages/ts-sdk/src/arknote/index.ts
+++ b/packages/ts-sdk/src/arknote/index.ts
@@ -5,7 +5,7 @@ import { TapLeafScript, VtxoScript } from "../script/base";
 import { ExtendedCoin, Status } from "../wallet";
 
 /**
- * ArkNotes are special virtual outputs in the Arkade protocol that
+ * ArkNotes are special virtual outputs within Arkade that
  * can be created and spent without requiring any transactions.
  * The server mints them, and they are encoded as base58 strings
  * with a human-readable prefix, a preimage and a value.

--- a/packages/ts-sdk/src/contracts/handlers/boarding.ts
+++ b/packages/ts-sdk/src/contracts/handlers/boarding.ts
@@ -22,10 +22,10 @@ export type BoardingContractParams = DefaultContractParams;
 /**
  * Handler for the boarding contract (registered type `boarding`).
  *
- * The boarding contract derives the on-chain Bitcoin address used to
+ * The boarding contract derives the onchain Bitcoin address used to
  * board funds onto Arkade. It shares the exact `DefaultVtxo.Script`
  * shape with the `default` contract — a Taproot output co-owned by the
- * wallet and the Ark server, with a CSV exit path back to the wallet —
+ * wallet and the operator, with a CSV exit path back to the wallet —
  * and therefore reuses the `default` handler's path logic (forfeit via
  * server cooperation, exit after the boarding CSV).
  *
@@ -40,10 +40,10 @@ export type BoardingContractParams = DefaultContractParams;
  *
  * Like `default` / `delegate`, the boarding handler implements
  * {@link Discoverable.discoverAt} so `wallet.restore()` can rediscover
- * used boarding indices from authoritative on-chain data. It differs from
- * the L2 handlers in its source of truth: boarding probes the **on-chain**
+ * used boarding indices from authoritative onchain data. It differs from
+ * the virtual-output handlers in its source of truth: boarding probes the **onchain**
  * UTXO set at its P2TR address (`OnchainProvider.getCoins`) rather than the
- * Ark indexer, and builds its candidate from the boarding-exit CSV
+ * indexer, and builds its candidate from the boarding-exit CSV
  * (`deps.boardingTimelock`). When boarding discovery is not plumbed (no
  * `deps.boardingTimelock` / `deps.onchainNetwork`) `discoverAt` no-ops.
  *
@@ -110,13 +110,13 @@ export const BoardingContractHandler: ContractHandler<BoardingContractParams, De
     isGenericallySpendable: () => true,
 
     /**
-     * Probe the on-chain UTXO set for a boarding output at this HD index.
+     * Probe the onchain UTXO set for a boarding output at this HD index.
      *
-     * Boarding's source of truth is the **current** on-chain coin set
-     * (`OnchainProvider.getCoins`), not the Ark indexer: a boarded (spent)
-     * boarding output becomes an L2 VTXO at the receive index, so the
+     * Boarding's source of truth is the **current** onchain coin set
+     * (`OnchainProvider.getCoins`), not the indexer: a boarded (spent)
+     * boarding output becomes a virtual output at the receive index, so the
      * indexer probe already keeps the gap window open for it; only an
-     * *unspent* boarding output needs the on-chain probe (see plan §2).
+     * *unspent* boarding output needs the onchain probe (see plan §2).
      *
      * No-ops (returns `[]`) when boarding discovery is not plumbed — i.e.
      * `deps.boardingTimelock` or `deps.onchainNetwork` is absent — so the
@@ -153,8 +153,8 @@ export const BoardingContractHandler: ContractHandler<BoardingContractParams, De
         // Always `type: "boarding"` (see method doc). The equal-delay
         // same-script collision is resolved first-wins at persistence, and the
         // scan probes boarding before default so a both-purpose rotated index
-        // resolves to a `boarding` row — keeping both the on-chain UTXO and any
-        // L2 VTXO recoverable (docs/hd-wallets_onchain_rotation_collision_fix.md
+        // resolves to a `boarding` row — keeping both the onchain UTXO and any
+        // virtual output recoverable (docs/hd-wallets_onchain_rotation_collision_fix.md
         // §5.2, §5.4).
         return [
             {
@@ -166,8 +166,8 @@ export const BoardingContractHandler: ContractHandler<BoardingContractParams, De
                 },
                 script: scriptHex,
                 // The persisted row's `address` is the *Ark* address (not the
-                // on-chain P2TR), matching the row registered at init so the
-                // ContractWatcher keeps monitoring the same L2 script and the
+                // onchain P2TR), matching the row registered at init so the
+                // ContractWatcher keeps monitoring the same virtual-output script and the
                 // VTXO repository bucket lines up (plan §6-I.4). The P2TR is
                 // recomputed from params only for the `getCoins` probe.
                 address: script.address(deps.network.hrp, deps.serverPubKey).encode(),

--- a/packages/ts-sdk/src/providers/ark.ts
+++ b/packages/ts-sdk/src/providers/ark.ts
@@ -225,7 +225,7 @@ export interface ArkInfo {
     vtxoMinAmount: bigint;
 }
 
-/** Signed intent payload sent to the Arkade server. */
+/** Signed intent payload sent to the operator. */
 export interface SignedIntent<T extends Intent.Message> {
     /** Base64-encoded signed proof transaction. */
     proof: string;
@@ -234,7 +234,7 @@ export interface SignedIntent<T extends Intent.Message> {
     message: T;
 }
 
-/** Transaction notification emitted by the Arkade server stream. */
+/** Transaction notification emitted by the operator stream. */
 export interface TxNotification {
     /** Transaction id. */
     txid: string;
@@ -277,7 +277,7 @@ export interface TxNotificationEvent {
 }
 
 export interface ArkProvider {
-    /** Fetch Arkade server configuration and fee settings. */
+    /** Fetch operator configuration and fee settings. */
     getInfo(): Promise<ArkInfo>;
 
     /** Submit a signed Arkade transaction and its checkpoint transactions. */
@@ -293,7 +293,7 @@ export interface ArkProvider {
     /** Finalize a previously submitted Arkade transaction. */
     finalizeTx(arkTxid: string, finalCheckpointTxs: string[]): Promise<void>;
 
-    /** Register a signed intent with the Arkade server. */
+    /** Register a signed intent with the operator. */
     registerIntent(intent: SignedIntent<Intent.RegisterMessage>): Promise<string>;
 
     /** Delete a previously registered intent. */
@@ -318,7 +318,7 @@ export interface ArkProvider {
     /** Open the settlement event stream for the given topics. */
     getEventStream(signal: AbortSignal, topics: string[]): AsyncIterableIterator<SettlementEvent>;
 
-    /** Stream transaction notifications emitted by the Arkade server. */
+    /** Stream transaction notifications emitted by the operator. */
     getTransactionsStream(signal: AbortSignal): AsyncIterableIterator<TxNotificationEvent>;
 
     /** Fetch pending transactions for a signed get-pending-tx intent. */
@@ -474,8 +474,8 @@ export class RestArkProvider implements ArkProvider {
         }
         this.emitServerInfoChanged(info);
         throw new DigestMismatchError(
-            "Arkade server reported a configuration digest mismatch; server info was " +
-                "refreshed. Rebuild and retry the request under the new server info.",
+            "The operator reported a configuration digest mismatch; operator info was " +
+                "refreshed. Rebuild and retry the request under the new operator info.",
         );
     }
 

--- a/packages/ts-sdk/src/script/address.ts
+++ b/packages/ts-sdk/src/script/address.ts
@@ -36,7 +36,7 @@ export class ArkAddress {
     /**
      * Create an Arkade address from its server public key, Taproot output key, and prefix.
      *
-     * @param serverPubKey - 32-byte Arkade server public key
+     * @param serverPubKey - 32-byte operator public key
      * @param vtxoTaprootKey - 32-byte Taproot output key (a.k.a. tweaked public key)
      * @param hrp - Bech32 human-readable prefix
      * @param version - Address version byte

--- a/packages/ts-sdk/src/script/vhtlc.ts
+++ b/packages/ts-sdk/src/script/vhtlc.ts
@@ -430,7 +430,7 @@ export namespace VHTLC {
     /**
      * Virtual Hash Time Lock Contract (VHTLC) script implementation.
      *
-     * VHTLC enables atomic swaps and conditional payments in the Arkade protocol.
+     * VHTLC enables atomic swaps and conditional payments within Arkade.
      * It provides multiple spending paths:
      *
      * - **claim**: Receiver can claim funds by revealing the preimage

--- a/packages/ts-sdk/src/tree/validation.ts
+++ b/packages/ts-sdk/src/tree/validation.ts
@@ -14,7 +14,9 @@ export const ErrWrongSettlementTxid = new Error("wrong settlement txid");
 export const ErrInvalidAmount = new Error("invalid amount");
 export const ErrNoLeaves = new Error("no leaves");
 export const ErrInvalidTaprootScript = new Error("invalid taproot script");
-export const ErrInvalidRoundTxOutputs = new Error("invalid round transaction outputs");
+export const ErrInvalidCommitmentTxOutputs = new Error("invalid commitment transaction outputs");
+/** @deprecated Use {@link ErrInvalidCommitmentTxOutputs}. */
+export const ErrInvalidRoundTxOutputs = ErrInvalidCommitmentTxOutputs;
 export const ErrWrongCommitmentTxid = new Error("wrong commitment txid");
 export const ErrMissingCosignersPublicKeys = new Error("missing cosigners public keys");
 
@@ -50,16 +52,16 @@ export function validateConnectorsTxGraph(settlementTxB64: string, connectorsGra
 // - input and output amounts.
 export function validateVtxoTxGraph(
     graph: TxTree,
-    roundTransaction: Transaction,
+    commitmentTransaction: Transaction,
     sweepTapTreeRoot: Uint8Array,
 ): void {
-    if (roundTransaction.outputsLength < BATCH_OUTPUT_VTXO_INDEX + 1) {
-        throw ErrInvalidRoundTxOutputs;
+    if (commitmentTransaction.outputsLength < BATCH_OUTPUT_VTXO_INDEX + 1) {
+        throw ErrInvalidCommitmentTxOutputs;
     }
 
-    const batchOutputAmount = roundTransaction.getOutput(BATCH_OUTPUT_VTXO_INDEX)?.amount;
+    const batchOutputAmount = commitmentTransaction.getOutput(BATCH_OUTPUT_VTXO_INDEX)?.amount;
     if (!batchOutputAmount) {
-        throw ErrInvalidRoundTxOutputs;
+        throw ErrInvalidCommitmentTxOutputs;
     }
 
     if (!graph.root) {
@@ -67,7 +69,7 @@ export function validateVtxoTxGraph(
     }
 
     const rootInput = graph.root.getInput(0);
-    const commitmentTxid = roundTransaction.id;
+    const commitmentTxid = commitmentTransaction.id;
 
     if (
         !rootInput.txid ||

--- a/packages/ts-sdk/src/utils/arkTransaction.ts
+++ b/packages/ts-sdk/src/utils/arkTransaction.ts
@@ -531,7 +531,7 @@ export function assertSubmittedArkTxid(
  * confirm, and learning the truth when the counterparty's refund lands.
  */
 export interface VerifyServerSignatures {
-    /** The Ark server's key; x-only or compressed, both accepted. */
+    /** The operator's key; x-only or compressed, both accepted. */
     serverPubkey: Uint8Array;
 }
 
@@ -631,7 +631,7 @@ export function assertCheckpointsMatchInputs(
 }
 
 /**
- * Submit a pre-built offchain transaction to the Ark server and finalize it.
+ * Submit a pre-built offchain transaction to the operator and finalize it.
  *
  * Owns the submit → checkpoint-sign → finalize sequence shared by every Ark
  * spend path (the wallet send/migration path and the single-key ArkadeCash

--- a/packages/ts-sdk/src/utils/fetch.ts
+++ b/packages/ts-sdk/src/utils/fetch.ts
@@ -84,7 +84,7 @@ function readDeadline(input: RequestInfo | URL, init?: RequestInit): AbortSignal
 
 /**
  * Guarded passthrough to the platform `fetch` with no Arkade-specific headers.
- * Use for any service that is NOT the Ark server (delegate, Esplora, …): those
+ * Use for any service that is NOT the operator (delegate, Esplora, …): those
  * origins reject unknown request headers such as `X-Build-Version` in the CORS
  * preflight.
  *
@@ -112,7 +112,7 @@ export function baseFetch(input: RequestInfo | URL, init?: RequestInit): Promise
 }
 
 /**
- * `fetch` for the Ark server only: adds the `X-Build-Version` compatibility
+ * `fetch` for the operator only: adds the `X-Build-Version` compatibility
  * header that arkd's version guard reads, plus the `X-SDK-VERSION` header
  * carrying this package's own version. Do NOT use it for other origins — they
  * reject these custom headers in CORS preflight.

--- a/packages/ts-sdk/src/utils/transaction.ts
+++ b/packages/ts-sdk/src/utils/transaction.ts
@@ -4,7 +4,7 @@ import { Bytes } from "@scure/btc-signer/utils.js";
 
 /**
  * Transaction is a wrapper around the @scure/btc-signer Transaction class.
- * It adds the Arkade protocol specific options to the transaction.
+ * It adds Arkade-specific options to the transaction.
  */
 export class Transaction extends BtcSignerTransaction {
     static ARK_TX_OPTS: TxOpts = {

--- a/packages/ts-sdk/src/wallet/index.ts
+++ b/packages/ts-sdk/src/wallet/index.ts
@@ -127,7 +127,7 @@ export interface NewAddress {
  *
  * The wallet will use provided URLs to create default providers if custom provider
  * instances are not supplied. If optional parameters are not provided, the wallet
- * will fetch configuration from the Arkade server.
+ * will fetch configuration from the operator.
  *
  * @remarks
  * URL-based and provider-based configuration can be mixed, but provider instances
@@ -139,7 +139,7 @@ export interface NewAddress {
  */
 export interface BaseWalletConfig {
     /**
-     * Base URL of the Arkade server.
+     * Base URL of the operator.
      *
      * @deprecated Pass an explicit `arkProvider` instance instead. URL-based
      * configuration will be removed in a future major version.
@@ -158,7 +158,7 @@ export interface BaseWalletConfig {
      */
     esploraUrl?: string;
 
-    /** Optional Arkade server public key used to construct and validate Arkade addresses. */
+    /** Optional operator public key used to construct and validate Arkade addresses. */
     arkServerPublicKey?: string;
     /** Relative timelock applied to boarding scripts. */
     boardingTimelock?: RelativeTimelock;
@@ -1074,7 +1074,7 @@ export interface IAssetManager extends IReadonlyAssetManager {
 }
 
 /**
- * Core wallet interface for Bitcoin transactions with Arkade protocol support.
+ * Core wallet interface for Bitcoin transactions with Arkade support.
  *
  * This interface defines the contract that all wallet implementations must follow.
  * It provides methods for address management, balance checking, virtual output
@@ -1152,7 +1152,7 @@ export interface IWallet extends IReadonlyWallet {
 }
 
 /**
- * Readonly wallet interface for Bitcoin transactions with Arkade protocol support.
+ * Readonly wallet interface for Bitcoin transactions with Arkade support.
  *
  * This interface defines the contract that all wallet implementations must follow.
  * It provides methods for address management, balance checking, virtual output

--- a/packages/ts-sdk/src/wallet/onchain.ts
+++ b/packages/ts-sdk/src/wallet/onchain.ts
@@ -14,7 +14,7 @@ import { DUST_AMOUNT } from "./utils";
  * Onchain Bitcoin wallet implementation for traditional Bitcoin transactions.
  *
  * This wallet handles regular Bitcoin transactions on the blockchain without
- * using the Arkade protocol. It supports P2TR (Pay-to-Taproot) addresses and
+ * within Arkade. It supports P2TR (Pay-to-Taproot) addresses and
  * provides basic Bitcoin wallet functionality.
  *
  * @example

--- a/packages/ts-sdk/src/wallet/validation.ts
+++ b/packages/ts-sdk/src/wallet/validation.ts
@@ -66,7 +66,7 @@ export function assertFinalCommitmentMatchesValidated(
 /**
  * Validates both offchain and onchain recipients.
  * Offchain recipients are checked against vtxo tree leaves for correct amounts and assets.
- * Onchain recipients are validated against the round transaction outputs (amounts and scripts)
+ * Onchain recipients are validated against the commitment transaction outputs (amounts and scripts)
  * via validateOnchainRecipient.
  *
  * Presence only: the commitment tx and the tree are shared with every other intent in the batch,

--- a/packages/ts-sdk/src/wallet/vtxo-manager.ts
+++ b/packages/ts-sdk/src/wallet/vtxo-manager.ts
@@ -96,7 +96,7 @@ interface SweepCapableWallet extends IReadonlyWallet {
     arkProvider: ArkProvider;
     network: Network;
     /**
-     * Descriptor-aware signer for on-chain boarding exit/sweep txs. Routes
+     * Descriptor-aware signer for onchain boarding exit/sweep txs. Routes
      * each input to the identity (baseline) or its per-index descriptor
      * (rotated boarding), so a sweep that batches UTXOs across boarding
      * addresses signs each with the correct key (plan §6-III.3).
@@ -815,7 +815,7 @@ export type MigrationGlobalSkipReason = "no-deprecated-vtxos" | "unknown-wallet-
 /**
  * Outcome of one migration leg. The VTXO leg migrates through the Ark send path
  * ({@link Wallet.sendSelectedVtxosToSelf}); the boarding leg keeps its
- * settle-backed migration (boarding coins are on-chain inputs with no send
+ * settle-backed migration (boarding coins are onchain inputs with no send
  * path). Each leg owns its full sizing pipeline (oversized filtering, count +
  * amount caps, its own dust floor) and reports independently — a failure or skip
  * in one leg never suppresses the other.
@@ -948,7 +948,7 @@ interface ClassifiedVtxo {
 
 /**
  * A deprecated-signer boarding UTXO paired with its signer classification
- * (Section 7). Mirrors {@link ClassifiedVtxo}, substituting the on-chain
+ * (Section 7). Mirrors {@link ClassifiedVtxo}, substituting the onchain
  * boarding coin for the offchain VTXO.
  */
 interface ClassifiedBoarding {
@@ -1022,7 +1022,7 @@ function mergeSignerReports(...reportLists: DeprecatedSignerReport[][]): Depreca
  * - **Expiry monitoring**: Check for virtual outputs that are expiring soon
  *
  * Virtual outputs become recoverable when:
- * - The Arkade server sweeps them (`isSwept`) and they remain spendable
+ * - The operator sweeps them (`isSwept`) and they remain spendable
  * - They are preconfirmed subdust (to consolidate small amounts without locking liquidity on settled virtual outputs)
  *
  * @example
@@ -1863,7 +1863,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * - Batches multiple expired boarding inputs into one transaction
      * - Skips the sweep if the output after fees would be below dust
      *
-     * No Arkade server involvement is needed — this is a pure onchain transaction.
+     * No operator involvement is needed — this is a pure onchain transaction.
      *
      * @returns The broadcast transaction ID
      * @throws Error if no expired boarding inputs are found
@@ -2143,7 +2143,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
 
         // Two independent legs, run sequentially (each acquires the wallet tx
         // lock itself): VTXOs migrate through the Ark send path; boarding UTXOs
-        // keep a SEPARATE settle-backed migration — they are on-chain inputs
+        // keep a SEPARATE settle-backed migration — they are onchain inputs
         // with no send path. They are never combined into one intent, each owns
         // its full sizing pipeline (oversized + caps + its own dust floor), and a
         // failure/skip in one never suppresses the other. A leg is present iff it
@@ -2418,7 +2418,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
                     // wallet-owned output when one exists), and a single unrolled/
                     // settled input here would otherwise throw and fail the whole
                     // VTXO leg. Such holdings stay counted in the per-signer report
-                    // above; they exit via on-chain/recovery paths, not cooperative
+                    // above; they exit via onchain/recovery paths, not cooperative
                     // send.
                     if (v.expiresAt === undefined && v.expiresAtHeight === undefined) continue;
                     migratable.push({ vtxo: v, classification: cls });
@@ -2439,7 +2439,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
     /**
      * Boarding sibling of {@link classifyDeprecatedSignerContracts} (Section 7):
      * fan out over the wallet's boarding addresses (current + historical), group
-     * the on-chain UTXOs per address, classify each address's signer against the
+     * the onchain UTXOs per address, classify each address's signer against the
      * fresh signer set, and split the confirmed boarding coins into cooperatively-
      * migratable and cutoff-expired sets while building the per-signer report.
      *
@@ -2447,7 +2447,7 @@ export class VtxoManager implements AsyncDisposable, IVtxoManager {
      * included), so expired-signer boarding is still reported; migration
      * eligibility is gated afterwards by {@link isCooperativelyMigratable} and a
      * per-row boarding-output CSV check — never by the fetch. Current-signer
-     * coins are classified `CURRENT` and ignored; foreign-ASP rows are excluded
+     * coins are classified `CURRENT` and ignored; foreign-operator rows are excluded
      * because their keys are not in the signer set.
      */
     private async classifyDeprecatedSignerBoarding(info: ArkInfo): Promise<{

--- a/packages/ts-sdk/src/wallet/wallet.ts
+++ b/packages/ts-sdk/src/wallet/wallet.ts
@@ -912,7 +912,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
-     * The wallet's current boarding tapscript (the on-chain onboarding
+     * The wallet's current boarding tapscript (the onchain onboarding
      * target). Read-only from the outside; mutated only via
      * {@link Wallet.setBoardingTapscriptForRotation} when a fresh boarding
      * address is explicitly allocated. Single-valued for static / `auto`
@@ -1029,14 +1029,14 @@ export class ReadonlyWallet implements IReadonlyWallet {
             if (identityIsMainnet && !serverIsMainnet) {
                 throw new Error(
                     `Network mismatch: identity uses mainnet derivation (coin type 0) ` +
-                        `but the Arkade server is on ${info.network}. ` +
+                        `but the operator is on ${info.network}. ` +
                         `Create identity with { isMainnet: false } to use testnet derivation.`,
                 );
             }
             if (!identityIsMainnet && serverIsMainnet) {
                 throw new Error(
                     `Network mismatch: identity uses testnet derivation (coin type 1) ` +
-                        `but the Arkade server is on mainnet. ` +
+                        `but the operator is on mainnet. ` +
                         `Create identity with { isMainnet: true } or omit isMainnet (defaults to mainnet).`,
                 );
             }
@@ -1542,7 +1542,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         }
     }
     /**
-     * The on-chain (P2TR) addresses of every boarding tapscript this wallet
+     * The onchain (P2TR) addresses of every boarding tapscript this wallet
      * uses — the current address plus any historical rotated boarding
      * addresses. The aggregating boarding readers (history, notifications) fan
      * out over this set so deposits at previous boarding addresses are still
@@ -1671,7 +1671,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
     }
 
     /**
-     * The set of boarding tapscripts whose on-chain UTXOs belong to this
+     * The set of boarding tapscripts whose onchain UTXOs belong to this
      * wallet — the current display tapscript plus every historical boarding
      * address it has used. Under per-derivation rotation (plan §6-II) a wallet
      * can hold unspent boarding UTXOs at several addresses at once, so fund
@@ -1685,7 +1685,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
      * @param allowedSigners - Optional set of x-only-hex server keys whose
      *   persisted boarding rows are included. Defaults to `{current x-only
      *   signer}`, preserving today's current-signer-only discovery (and the
-     *   foreign-ASP guard). The deprecated-signer migration path widens this to
+     *   foreign-operator guard). The deprecated-signer migration path widens this to
      *   reach old-signer boarding addresses. The index-0 baseline and the
      *   current display tapscript are always included regardless of the set.
      */
@@ -1719,7 +1719,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
         });
         for (const c of boardingContracts) {
             // Only allowed servers. By default this is the wallet's current
-            // signer, so a row left by a previous ASP (e.g. a repo recovered
+            // signer, so a row left by a previous operator (e.g. a repo recovered
             // against a different server) — or, here, an old-signer row outside
             // the requested set — would otherwise emit a spurious onchain script
             // and a wasted getCoins/getTransactions call on every boarding read.
@@ -2314,7 +2314,7 @@ export class ReadonlyWallet implements IReadonlyWallet {
 }
 
 /**
- * Main wallet implementation for Bitcoin transactions with Arkade protocol support.
+ * Main wallet implementation for Bitcoin transactions with Arkade support.
  * The wallet does not store any data locally and relies on Arkade and onchain
  * providers to fetch onchain and virtual outputs.
  *
@@ -2571,7 +2571,7 @@ export class Wallet
     private _serverRotationChain: Promise<void> = Promise.resolve();
 
     /**
-     * Allocate and return a *fresh* on-chain boarding address, rotating the
+     * Allocate and return a *fresh* onchain boarding address, rotating the
      * wallet's current boarding tapscript to a new HD index.
      *
      * This is the explicit boarding allocator — the analogue of dotnet's
@@ -2580,7 +2580,7 @@ export class Wallet
      * address that never burns an index), each call here:
      *
      * - allocates the next index from the shared HD stream (so boarding and
-     *   L2 receive interleave on one monotonic index);
+     *   virtual-output receive interleave on one monotonic index);
      * - builds the boarding tapscript at that index with the boarding-exit
      *   CSV;
      * - persists an `active` `boarding` contract tagged
@@ -3325,7 +3325,7 @@ export class Wallet
             indexerProvider: this.indexerProvider,
             onchainProvider: this.onchainProvider,
             network: { hrp: this.network.hrp },
-            // Full network for the boarding on-chain (P2TR) probe — the
+            // Full network for the boarding onchain (P2TR) probe — the
             // `{ hrp }` shape above lacks the `bech32` data
             // `VtxoScript.onchainAddress` needs (plan §6-I.1).
             onchainNetwork: this.network,
@@ -4177,7 +4177,7 @@ export class Wallet
 
         const abortController = new AbortController();
         let stream: AsyncIterableIterator<SettlementEvent> | undefined;
-        // Set once Batch.join returns: the batch is committed on-chain and no
+        // Set once Batch.join returns: the batch is committed onchain and no
         // local cleanup failure may cancel it. Authoritative in memory even if
         // the hook's terminal repo write failed, which repo state can't tell us.
         let committedTxid: string | undefined;
@@ -4257,11 +4257,11 @@ export class Wallet
             await this.updateDbAfterSettle(params.inputs, commitmentTxid);
 
             // Boarding rotation (rotate-on-board): if this settle swept any
-            // boarding (on-chain) UTXO into Arkade, advance the boarding
+            // boarding (onchain) UTXO into Arkade, advance the boarding
             // address to a fresh HD index so the next deposit lands on a new
-            // address. This is the boarding analogue of the L2 receive
-            // rotation that runs on `vtxo_received` — boarding has no on-chain
-            // receival event (ContractWatcher watches only the L2 indexer), so
+            // address. This is the boarding analogue of the virtual-output receive
+            // rotation that runs on `vtxo_received` — boarding has no onchain
+            // receival event (ContractWatcher watches only the indexer), so
             // the board itself is the trigger. Best-effort: it never fails an
             // already-committed settle.
             await this.maybeRotateBoardingAfterBoard(params.inputs);
@@ -4319,9 +4319,9 @@ export class Wallet
     /**
      * Rotate the boarding address after a board (rotate-on-board trigger).
      *
-     * Mirrors {@link WalletReceiveRotator}'s L2 rotation, but driven by a
+     * Mirrors {@link WalletReceiveRotator}'s virtual-output rotation, but driven by a
      * board instead of a `vtxo_received` event: when a settle consumes at
-     * least one boarding (on-chain) UTXO, the current boarding address has
+     * least one boarding (onchain) UTXO, the current boarding address has
      * served its purpose, so we allocate a fresh one via
      * {@link getNewBoardingAddress}. A settle that consumed only VTXOs (a
      * renewal / offboard) is not a board and leaves the boarding address
@@ -4746,7 +4746,7 @@ export class Wallet
     }
 
     /**
-     * @internal Sign an on-chain boarding exit / sweep transaction, routing
+     * @internal Sign an onchain boarding exit / sweep transaction, routing
      * each input to the correct key by its `witnessUtxo.script`: the identity
      * for index-0 / static boarding, the per-index descriptor for a rotated
      * boarding UTXO (plan §6-III.3). Used by
@@ -6242,7 +6242,7 @@ export class Wallet
                     // boarding input = remove it from the bucket of the
                     // address it actually sits on. The source boarding address
                     // is recoverable from the input's tapTree (its leaves
-                    // determine the tweaked key → on-chain P2TR), so a UTXO
+                    // determine the tweaked key → onchain P2TR), so a UTXO
                     // received at a rotated-away boarding address is cleaned up
                     // in its own bucket rather than the current one. Fall back
                     // to the current boarding address if the tapTree can't be


### PR DESCRIPTION
## Summary
Aligns SDK docs and JSDoc with Arkade canonical terminology (CLAUDE.md): drop Ark-protocol conflation, prefer **the operator**, **onchain/offchain**, **within Arkade**, and virtual-output prose. Includes a small `tree/validation.ts` commitment-transaction rename with a deprecated alias.

## Changes
- Root + package READMEs, `package.json` description
- JSDoc/comments: Ark/Arkade server → operator; ASP → operator; protocol framing; hyphen spelling; some L2 framing in boarding/wallet comments
- `packages/swap/README.md`: Ark server → the operator
- `tree/validation.ts`: `ErrInvalidCommitmentTxOutputs` + deprecated `ErrInvalidRoundTxOutputs`; param `commitmentTransaction`

## Explicitly not in this PR
- Public API renames (`ArkAddress`, `VtxoScript`, `ArkProvider`, …) — prefer follow-up deprecate-with-alias
- Renaming `refreshVtxos` (indexer sync ≠ renewal; renewal is already `renewVtxos`)
- CHANGELOG historical wording

## Test plan
- [ ] Skim README diffs for accidental API sample breakage
- [ ] Typecheck / unit tests (validation param rename is positional-compatible)
- [ ] Confirm `ErrInvalidRoundTxOutputs` still available for any external importers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated product and SDK documentation with consistent terminology for Arkade, operators, onchain/offchain functionality, virtual outputs, recovery, and transaction workflows.
  - Refined package descriptions, API comments, wallet guidance, and swap documentation for improved clarity.
  - Updated user-facing network mismatch and digest-mismatch messages to reference the operator.

- **API Updates**
  - Added `ErrInvalidCommitmentTxOutputs` for commitment transaction validation.
  - Retained `ErrInvalidRoundTxOutputs` as a deprecated compatibility alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->