### PR TITLE
fix(swap): re-cover offer covenants on restore and watcher start-up

### DIFF
--- a/packages/swap/README.md
+++ b/packages/swap/README.md
@@ -88,10 +88,13 @@ funds an offer should keep cancelling within reach.
 4. **`restore`** — `restoreAssetSwaps` rebuilds lost records by scanning sent virtual txs for
    offer packets and binding each funding vtxo to its spend. Incremental: answered txids are
    remembered in the repository (`getScannedTxids`/`markTxidsScanned`) so nothing is fetched
-   twice.
+   twice. With `cover`, a restored deposit still at its covenant is registered with the wallet
+   again — see "After a restore" below. `restoreOfferCoverage` does the same for records you
+   already hold.
 5. **`watch`** — `watchOfferSwaps` drives swap status from the wallet's own contract events, so a
    fill shows up without re-running a scan. Registration is what makes it possible: only a
-   registered covenant is watched. See "Live status" below.
+   registered covenant is watched. On start it also re-covers live records and reconciles
+   deposits spent while nothing watched. See "Live status" / "After a restore" below.
 6. **`rfq`** — the user side of quoted swaps: RFQ negotiation over HTTP or a
    relay, then non-interactive filling (see below). All four reference-solver corridors:
    `arkade:BTC -> lightning:BTC` and `arkade:BTC -> onchain:BTC` (send), `lightning:BTC ->
@@ -256,6 +259,35 @@ guess: a stored swap is skipped by every later scan, so a guess here would be pe
 
 `onUpdate` is a notification for UI reactivity, not a second store; every write goes through the
 repository.
+
+### After a restore
+
+A record `restoreAssetSwaps` rebuilds has no registration behind it: the deposit is on chain and
+the record is back, but nothing has told the wallet the script is its own. Left that way the
+deposit is neither gated nor counted, and a later fill is never noticed — the watcher only hears
+registered scripts, and the scan never revisits a funding txid it has answered. Two things close
+that gap:
+
+```ts
+// registers the covenant of every restored deposit still at its script, before returning
+const { restored } = await restoreAssetSwaps(indexer, txs, existing, {
+    serverPubkey,
+    cover: { wallet, arkServerUrl: ARK },
+});
+
+// or, for records you already hold:
+await restoreOfferCoverage(wallet, ARK, restored);
+```
+
+and `watchOfferSwaps` itself, which on start registers the covenant of every live record in the
+repository (`pending`, `cancelling`, `recoverable`) — a no-op for offers this wallet created, and
+the missing registration for records restored without `cover` — then reconciles each against the
+chain (manager view + indexer): a spend that landed while the script was uncovered never becomes
+an event, and that read is what classifies it. Both registrations go through `ensureOfferContracts`
+/ `restoreOfferCoverage`, exported for a consumer that needs to run them on its own schedule.
+Registration is idempotent and best effort: a record that could not be covered is logged and tried
+again at the watcher's next start — the scan will not come back to it, since its funding txid is
+already answered.
 
 ## Cancelling: the refund path
 

--- a/packages/swap/src/coverage.ts
+++ b/packages/swap/src/coverage.ts
@@ -117,6 +117,26 @@ export async function promoteOfferContract(
 }
 
 /**
+ * Put `script` in the watched set for a deposit that has already landed — a
+ * record rebuilt by the restore scan, or one found unwatched at watcher start.
+ *
+ * {@link promoteOfferContract} without the issuance mark: the mark says "an
+ * address is out and waiting for its deposit", and here the deposit is the
+ * record itself. Marking it anyway would pin the script watched for the life
+ * of the process, because no record at the script can ever postdate a mark
+ * set after its funding — `addressOutstanding` would never clear.
+ *
+ * Throws like promotion does: nothing is at stake in the write, and a record
+ * left uncovered is what the caller must know about.
+ */
+export async function coverOfferContract(
+    manager: OfferContractRetirer,
+    script: string,
+): Promise<void> {
+    await serialize(script, () => manager.setContractWatchState(script, "watched"));
+}
+
+/**
  * Drop `script` from the watched set unless something there still needs it.
  * Identical offers share one script, so the check is per script, not per record.
  *

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -2,6 +2,7 @@ export {
     createOffer,
     cancelOffer,
     restoreOfferCoverage,
+    ensureOfferContracts,
     encodeOffer,
     decodeOffer,
     offerVtxoScript,

--- a/packages/swap/src/offer.ts
+++ b/packages/swap/src/offer.ts
@@ -41,7 +41,12 @@ import {
 
 import wantAssetProgram from "./swap-want-asset.program.json";
 import wantBtcProgram from "./swap-want-btc.program.json";
-import { promoteOfferContract, retireOfferContract, RETIRABLE } from "./coverage";
+import {
+    coverOfferContract,
+    promoteOfferContract,
+    retireOfferContract,
+    RETIRABLE,
+} from "./coverage";
 import type { AssetSwapRepository } from "./repository";
 import {
     getAssetSwapsOrThrow,
@@ -483,7 +488,14 @@ async function registerOfferContract(
     binding: Omit<Offer, "swapPkScript">,
     serverPubkey: Uint8Array,
     expectedPkScript: Uint8Array,
-    opts: { issued?: number; client?: arkade.Arkade; contractManager?: IContractManager } = {},
+    opts: {
+        issued?: number;
+        client?: arkade.Arkade;
+        contractManager?: IContractManager;
+        /** `"landed"` covers a deposit already on chain (restore / watcher start)
+         * without an issuance mark; default is `"issued"` for `createOffer`. */
+        deposit?: "issued" | "landed";
+    } = {},
 ): Promise<void> {
     const { program, args, keys } = swapProgramBinding(binding, serverPubkey);
     // the caller's when it has one: `register` goes through `opts.client`'s
@@ -512,7 +524,9 @@ async function registerOfferContract(
         label: OFFER_CONTRACT_LABEL,
         metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
     });
-    await promoteOfferContract(contractManager, hex.encode(expectedPkScript), opts.issued);
+    const script = hex.encode(expectedPkScript);
+    if (opts.deposit === "landed") await coverOfferContract(contractManager, script);
+    else await promoteOfferContract(contractManager, script, opts.issued);
 }
 
 /**
@@ -560,11 +574,89 @@ export async function restoreOfferCoverage(
                 binding,
                 serverPubKey,
                 hex.decode(swap.swapPkScript),
-                { issued: swap.createdAt, client, contractManager },
+                { deposit: "landed", client, contractManager },
             );
         } catch (err) {
             console.warn(`[swap] could not restore coverage for ${swap.swapPkScript}`, err);
         }
+    }
+}
+
+/**
+ * Register and watch the covenants of offers this wallet did not create in
+ * this store: records the restore scan rebuilt, or records found uncovered
+ * when the watcher starts.
+ *
+ * `createOffer` registers before it hands out an address, so an offer made
+ * here is watched from the moment its deposit lands. A restored record has no
+ * such moment: the deposit is on chain, the record is back, and nothing has
+ * told the wallet the script is its own. Left that way the deposit is not
+ * gated, not counted, and — the part a user sees — a fill is never noticed:
+ * {@link watchOfferSwaps} only hears about registered scripts, and the restore
+ * scan skips a funding txid it has already answered. This is the missing
+ * registration, done the way `createOffer` does it (same row, same escrow
+ * marker), minus the issuance mark.
+ *
+ * Idempotent: `createContract` is first-writer-wins and the watch state is a
+ * set. Safe to run on every watcher start.
+ *
+ * `swapAddress`, when the record has one, pins the server key the covenant
+ * was funded against; without it `opts.serverPubkey` is used — the key a
+ * restore scan classified the records with — and failing that the server's
+ * current key. An offer whose covenant rebuilds under none of them (a signer
+ * rotation since funding) is refused by name rather than registered at a
+ * script it never had. The refusal is per offer: the rest are still
+ * registered, and the error names every one that was not.
+ *
+ * Prefer {@link restoreOfferCoverage} when you already have `AssetSwap`
+ * records (it filters settled scripts and reuses one client). This is the
+ * lower-level form for callers that only have offer bytes / a funded address.
+ */
+export async function ensureOfferContracts(
+    wallet: IWallet,
+    arkServerUrl: string,
+    offers: readonly { offerHex: string; swapAddress?: string }[],
+    opts: { serverPubkey?: Uint8Array } = {},
+): Promise<void> {
+    if (offers.length === 0) return;
+    const info = await new RestArkProvider(arkServerUrl).getInfo();
+    const currentServerKey = opts.serverPubkey ?? hex.decode(toXOnlySignerHex(info.signerPubkey));
+    const network = info.network as NetworkName;
+
+    const failures: string[] = [];
+    for (const { offerHex, swapAddress } of offers) {
+        try {
+            const { swapPkScript, ...binding } = decodeOffer(hex.decode(offerHex));
+            const serverPubkey = swapAddress
+                ? ArkAddress.decode(swapAddress).serverPubKey
+                : currentServerKey;
+            const rebuilt = offerVtxoScript(binding, serverPubkey).pkScript;
+            if (hex.encode(rebuilt) !== hex.encode(swapPkScript)) {
+                throw new Error(
+                    "rebuilt covenant does not match the offer's swapPkScript — the server " +
+                        "signing key has likely rotated since funding; pass swapAddress (the " +
+                        "funded address) to pin the original key",
+                );
+            }
+            await registerOfferContract(
+                wallet,
+                arkServerUrl,
+                network,
+                binding,
+                serverPubkey,
+                swapPkScript,
+                { deposit: "landed" },
+            );
+        } catch (err) {
+            // the TLV opens with the swap script, so its first bytes are enough
+            // of a handle to find the record this names
+            failures.push(`offer ${offerHex.slice(0, 22)}…: ${(err as Error).message}`);
+        }
+    }
+    if (failures.length > 0) {
+        throw new Error(
+            `could not register ${failures.length} offer covenant(s): ${failures.join("; ")}`,
+        );
     }
 }
 

--- a/packages/swap/src/restore.ts
+++ b/packages/swap/src/restore.ts
@@ -19,8 +19,15 @@ import {
     Transaction,
     scriptFromTapLeafScript,
 } from "@arkade-os/sdk";
-import { decodeOffer, Offer, OFFER_PACKET_TYPE, offerVtxoScript } from "./offer";
+import {
+    decodeOffer,
+    ensureOfferContracts,
+    Offer,
+    OFFER_PACKET_TYPE,
+    offerVtxoScript,
+} from "./offer";
 import { BTC_ASSET_ID, type AssetSwap, type AssetSwapStatus } from "./store";
+import type { IWallet } from "@arkade-os/sdk";
 
 // ponytail: fixed request size; tune only if histories outgrow it
 const TXS_PER_REQUEST = 50;
@@ -249,14 +256,36 @@ export function classifyDepositSpend(
  * txid scanned, so the natural call asks once and never again — `pending` is the
  * absence of an answer. Pass those records as `reopen`: re-answered from stored
  * `offerHex`, no funding fetch, skip lists unchanged, definite outcomes only.
+ *
+ * ## A restored deposit is the wallet's to watch again
+ *
+ * Pass `cover` and every record restored with its deposit still at the
+ * covenant — `pending`, or `recoverable` — has that covenant registered with
+ * the wallet before it is returned, exactly as `createOffer` registers it
+ * ({@link ensureOfferContracts}). Without it the record is back but the
+ * deposit is not: not gated, not counted, and a later fill goes unnoticed,
+ * because {@link watchOfferSwaps} only hears about registered scripts and this
+ * scan never revisits a funding txid it has answered. The scan itself does not
+ * need a wallet, which is why this is an option rather than a parameter.
+ *
+ * Best effort, and never a reason to lose the record: a registration that
+ * fails is logged and the record is still returned — the scan will not come
+ * back to it (its txid is answered), but {@link watchOfferSwaps} covers every
+ * live record at its next start and reconciles it against the chain then.
  */
 export async function restoreAssetSwaps(
     indexer: RestoreIndexer,
     txs: Tx[],
     existingIds: ReadonlySet<string>,
-    opts: { serverPubkey: Uint8Array; scanned?: ReadonlySet<string>; reopen?: AssetSwap[] },
+    opts: {
+        serverPubkey: Uint8Array;
+        scanned?: ReadonlySet<string>;
+        reopen?: AssetSwap[];
+        /** The wallet to register live restored covenants with. */
+        cover?: { wallet: IWallet; arkServerUrl: string };
+    },
 ): Promise<{ restored: AssetSwap[]; scannedTxids: string[] }> {
-    const { serverPubkey, scanned = new Set<string>(), reopen = [] } = opts;
+    const { serverPubkey, scanned = new Set<string>(), reopen = [], cover } = opts;
 
     const reopened: Found[] = [];
     for (const swap of reopen) {
@@ -436,5 +465,28 @@ export async function restoreAssetSwaps(
             ...completion,
         });
     }
+    if (cover) {
+        const live = restored.filter((swap) => LIVE_DEPOSIT.includes(swap.status));
+        try {
+            // the key the records were classified with: a restored record has
+            // no swapAddress to pin it, and the current key is wrong after a
+            // rotation
+            await ensureOfferContracts(cover.wallet, cover.arkServerUrl, live, { serverPubkey });
+        } catch (err) {
+            console.warn("[swap] could not re-register every restored offer covenant", err);
+        }
+    }
     return { restored, scannedTxids: fetchedTxids.filter((id) => !unresolved.has(id)) };
 }
+
+/**
+ * Statuses under which a restored deposit still sits at its covenant, and so
+ * is the wallet's to watch. `recoverable` too: a swept deposit is still the
+ * user's money at that script (see `RETIRABLE` in coverage.ts).
+ *
+ * `cancelling` is deliberately absent: the restore scan classifies by chain
+ * state and never produces a `cancelling` record — only `NEEDS_COVERAGE` in
+ * watch.ts has it, and only because a cancel in flight may still be resolved
+ * by a spend the watcher later hears about.
+ */
+const LIVE_DEPOSIT: readonly AssetSwapStatus[] = ["pending", "recoverable"];

--- a/packages/swap/src/watch.ts
+++ b/packages/swap/src/watch.ts
@@ -42,7 +42,7 @@ import {
     type IWallet,
 } from "@arkade-os/sdk";
 import { RETIRABLE, retireOfferContract } from "./coverage";
-import { decodeOffer, OFFER_CONTRACT_KIND } from "./offer";
+import { decodeOffer, ensureOfferContracts, OFFER_CONTRACT_KIND } from "./offer";
 import type { AssetSwapRepository } from "./repository";
 import { classifyDepositSpend, spendTxidsOf, type RestoreIndexer, type SpendKind } from "./restore";
 import {
@@ -55,6 +55,11 @@ import {
 /** Statuses a spend cannot move: the swap is already resolved.
  * @see RETIRABLE — a different question, and not the same set. */
 const TERMINAL: readonly AssetSwapStatus[] = ["fulfilled", "cancelled", "recoverable"];
+
+/** Statuses whose covenant may still hold a deposit, so still need coverage.
+ * Broader than restore's live set: includes `cancelling` (a cancel in flight
+ * may still be resolved by a spend the watcher later hears about). */
+const NEEDS_COVERAGE: readonly AssetSwapStatus[] = ["pending", "cancelling", "recoverable"];
 
 /**
  * The record change a classified spend implies, or `undefined` when it implies
@@ -107,6 +112,21 @@ export interface WatchOfferSwapsParams {
  * *Live* updates depend on the wallet's contract event transport. In Node,
  * callers must provide an `EventSource` implementation or use a runtime where
  * it is enabled. The start-up pass needs none of it.
+ *
+ * **Starting the watcher re-covers what it is asked to watch, and reconciles
+ * it.** Every record in the repository whose deposit may still be at its
+ * covenant gets that covenant registered ({@link ensureOfferContracts}) — a
+ * no-op for offers this wallet created, and the missing registration for
+ * records the restore scan rebuilt on a wallet that never made them. Only a
+ * registered script produces the events this watcher runs on. Registration
+ * alone is not enough, though: a deposit spent *before* its script was
+ * covered produces no event — the manager hydrates it already spent and the
+ * watch baseline starts past it — so each covered record is then read off the
+ * indexer once (and via the manager's contract view) and a spend found there
+ * is classified exactly as an event would be. The sweep is best effort and
+ * runs after the subscription is in place, so a spend landing mid-sweep is
+ * still delivered; a record it could not cover is logged and is tried again
+ * at the next start.
  */
 export async function watchOfferSwaps({
     wallet,
@@ -214,14 +234,95 @@ export async function watchOfferSwaps({
         }
     };
 
+    /**
+     * Indexer backstop for deposits spent or swept while a script was
+     * uncovered: the manager's view only sees contracts it already held, and
+     * a newly covered spent deposit produces no event. Swept → recoverable is
+     * invisible to {@link resolveOpenSwaps} (it only looks at `isSpent`).
+     */
+    const reconcileFromIndexer = async (swap: AssetSwap) => {
+        try {
+            const { vtxos } = await indexer.getVtxos({ scripts: [swap.swapPkScript] });
+            const vtxo = vtxos.find((v) => v.txid === swap.fundingTxid);
+            if (!vtxo) return;
+            if (vtxo.virtualStatus.state === "swept") {
+                if (swap.status === "recoverable") return;
+                const changes = { status: "recoverable" as const };
+                const { persisted } = await updateAssetSwapBestEffort(repository, swap.id, changes);
+                if (persisted) onUpdate?.({ ...swap, ...changes });
+                return;
+            }
+            if (vtxo.virtualStatus.state !== "spent") return;
+            const spentTxid = vtxo.arkTxId || vtxo.spentBy;
+            if (!spentTxid) return;
+            // No timestamp on this path: the indexer VTXO carries createdAt of
+            // the deposit, not the spend. Persist without completedAt.
+            await resolveSpends(swap.swapPkScript, [
+                {
+                    txid: vtxo.txid,
+                    vout: vtxo.vout,
+                    isSpent: true,
+                    arkTxId: vtxo.arkTxId,
+                    spentBy: vtxo.spentBy,
+                } as ContractVtxo,
+            ]);
+        } catch (err) {
+            console.warn(`[swap] could not reconcile offer ${swap.id} after covering it`, err);
+        }
+    };
+
+    /**
+     * A settlement that landed mid-sweep may have retired its script before
+     * the sweep re-watched it; re-derive liveness for scripts the sweep
+     * touched so nothing stays watched forever after that race.
+     */
+    const retireUntouchedScripts = async (covered: readonly AssetSwap[]) => {
+        const swaps = await getAssetSwaps(repository);
+        const getContracts = (
+            manager as { getContracts?: (q: { script: string }) => Promise<{ watch?: string }[]> }
+        ).getContracts;
+        for (const script of new Set(covered.map((s) => s.swapPkScript))) {
+            if (getContracts) {
+                const [row] = await getContracts.call(manager, { script });
+                if (!row) continue;
+                if (row.watch === "retained") continue;
+            }
+            await retireOfferContract(manager, swaps, script);
+        }
+    };
+
     const unsubscribe = manager.onContractEvent((event) => {
         // An offer is an owned contract; a watched script has no `metadata`.
         if (!isContractVtxoEvent(event) || event.type !== "vtxo_spent") return;
         enqueue(() => handleSpend(event));
     });
+
+    // After subscribing, never before: registration is what starts the
+    // manager's own watch on a script, and an event it delivers during the
+    // sweep must find a handler already attached.
+    const uncovered = (await getAssetSwaps(repository)).filter(
+        (swap) => typeof swap.offerHex === "string" && NEEDS_COVERAGE.includes(swap.status),
+    );
+    try {
+        await ensureOfferContracts(
+            wallet,
+            arkServerUrl,
+            uncovered.map((swap) => ({
+                offerHex: swap.offerHex,
+                ...(swap.swapAddress ? { swapAddress: swap.swapAddress } : {}),
+            })),
+        );
+    } catch (err) {
+        console.warn("[swap] could not re-register every live offer covenant", err);
+    }
+
     // enqueued rather than awaited: the pass must not read before the
-    // subscription is installed, or a spend landing mid-pass falls between them
+    // subscription is installed, or a spend landing mid-pass falls between them.
+    // resolveOpenSwaps (#895) answers spent deposits the manager already knew;
+    // the indexer pass catches spends/sweeps that landed while uncovered.
     enqueue(resolveOpenSwaps);
+    for (const swap of uncovered) enqueue(() => reconcileFromIndexer(swap));
+    enqueue(() => retireUntouchedScripts(uncovered));
 
     return {
         stop: unsubscribe,

--- a/packages/swap/test/coverage.test.ts
+++ b/packages/swap/test/coverage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { promoteOfferContract, retireOfferContract } from "../src/coverage";
+import { coverOfferContract, promoteOfferContract, retireOfferContract } from "../src/coverage";
 import type { AssetSwap } from "../src/store";
 
 const SCRIPT = "51" + "aa".repeat(32);
@@ -76,5 +76,36 @@ describe("offer contract coverage", () => {
         await Promise.all([retire, promote]);
 
         expect(row).toBe("watched");
+    });
+});
+
+// AI-generated, and to be redone: written by Claude, kept for the coverage it
+// gives the fix rather than for its shape. Rewrite by hand before reading it as
+// the specification.
+describe("coverOfferContract", () => {
+    const LANDED = "51" + "bb".repeat(32);
+
+    it("watches the script and lets a settled record retire it at once", async () => {
+        const { setContractWatchState } = manager();
+        await coverOfferContract({ setContractWatchState }, LANDED);
+        // predates any mark: with one set, this record would never clear it
+        await retireOfferContract(
+            { setContractWatchState },
+            [swap({ swapPkScript: LANDED, createdAt: 0 })],
+            LANDED,
+        );
+
+        expect(setContractWatchState.mock.calls).toEqual([
+            [LANDED, "watched"],
+            [LANDED, "retained"],
+        ]);
+    });
+
+    it("surfaces a failed write, like promotion does", async () => {
+        const { setContractWatchState } = manager();
+        setContractWatchState.mockRejectedValueOnce(new Error("repository unavailable"));
+        await expect(coverOfferContract({ setContractWatchState }, LANDED)).rejects.toThrow(
+            "repository unavailable",
+        );
     });
 });

--- a/packages/swap/test/register.test.ts
+++ b/packages/swap/test/register.test.ts
@@ -14,7 +14,16 @@ import {
     type RelativeTimelock,
     type OnchainProvider,
 } from "@arkade-os/sdk";
-import { createOffer, decodeOffer, OFFER_CONTRACT_KIND, OFFER_CONTRACT_LABEL } from "../src/offer";
+import {
+    createOffer,
+    decodeOffer,
+    encodeOffer,
+    ensureOfferContracts,
+    offerVtxoScript,
+    OFFER_CONTRACT_KIND,
+    OFFER_CONTRACT_LABEL,
+} from "../src/offer";
+import { retireOfferContract } from "../src/coverage";
 
 // the covenant derivation, Arkade.connect, ArkadeContract and register() are
 // all real here — only the network seam (the three Rest* providers) and the
@@ -333,5 +342,129 @@ describe("an offer at a script an earlier offer retired", () => {
 
         const row = (await contractRepository.getContracts()).find((c) => c.script === script);
         expect(row?.watch).toBe("watched");
+    });
+});
+
+// AI-generated, and to be redone: written by Claude, kept for the coverage it
+// gives the fix rather than for its shape. Rewrite by hand before reading it as
+// the specification.
+describe("ensureOfferContracts", () => {
+    const serverKey = hex.decode(
+        "4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+    );
+    /** An offer at a script none of the `create()` calls above ever promoted,
+     * so the issuance mark (module state, keyed by script) cannot leak in. */
+    const unmarkedOffer = async () => {
+        const created = await create();
+        const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(created.offerHex));
+        const rebound = { ...binding, wantAmount: BigInt(777_777) };
+        const script = offerVtxoScript(rebound, serverKey);
+        return {
+            offerHex: hex.encode(encodeOffer({ ...rebound, swapPkScript: script.pkScript })),
+            script: hex.encode(script.pkScript),
+        };
+    };
+
+    it("writes the row createOffer would, and watches it", async () => {
+        const { offerHex, script } = await unmarkedOffer();
+        state.created = [];
+        state.watched = [];
+
+        await ensureOfferContracts(wallet, "http://ark", [{ offerHex }]);
+
+        expect(state.created).toHaveLength(1);
+        expect(state.created[0]).toMatchObject({
+            type: "arkade",
+            script,
+            label: OFFER_CONTRACT_LABEL,
+            metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
+        });
+        expect(state.watched).toEqual([[script, "watched"]]);
+    });
+
+    it("sets no issuance mark, so a settled record can retire the script", async () => {
+        // createOffer's mark says an address is out waiting for its deposit;
+        // here the deposit is the record itself, and a mark set after the
+        // funding would never be cleared by it
+        const { offerHex, script } = await unmarkedOffer();
+        await ensureOfferContracts(wallet, "http://ark", [{ offerHex }]);
+        state.watched = [];
+
+        await retireOfferContract(
+            contractManager,
+            [
+                {
+                    id: "ab".repeat(32),
+                    fromAsset: "btc",
+                    toAsset: testAsset.toString(),
+                    fromAmount: "10000",
+                    toAmount: "777777",
+                    swapAddress: "",
+                    swapPkScript: script,
+                    offerHex,
+                    fundingTxid: "ab".repeat(32),
+                    status: "fulfilled",
+                    createdAt: 0,
+                },
+            ],
+            script,
+        );
+        expect(state.watched).toEqual([[script, "retained"]]);
+    });
+
+    it("refuses an offer the current server key no longer rebuilds, and registers the rest", async () => {
+        // a signer rotation since funding: the TLV pins the funded script, the
+        // rebuild under today's key disagrees, and registering at the rebuilt
+        // script would watch an address the deposit never sat at
+        const good = await unmarkedOffer();
+        const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(good.offerHex));
+        const rotatedKey = schnorr.getPublicKey(hex.decode("7".repeat(64)));
+        const rotated = offerVtxoScript(binding, rotatedKey);
+        const stale = hex.encode(encodeOffer({ ...binding, swapPkScript: rotated.pkScript }));
+        state.created = [];
+
+        await expect(
+            ensureOfferContracts(wallet, "http://ark", [{ offerHex: stale }, good]),
+        ).rejects.toThrow(/could not register 1 offer covenant\(s\).*rotated/);
+        expect(state.created.map((row) => row.script)).toEqual([good.script]);
+    });
+
+    it("takes the funded address as the key to rebuild with", async () => {
+        // the pin cancelOffer honours: a record that kept its swapAddress keeps
+        // working across a rotation, because the key comes from the address
+        const good = await unmarkedOffer();
+        const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(good.offerHex));
+        const rotatedKey = schnorr.getPublicKey(hex.decode("7".repeat(64)));
+        const rotated = offerVtxoScript(binding, rotatedKey);
+        const stale = hex.encode(encodeOffer({ ...binding, swapPkScript: rotated.pkScript }));
+        const fundedAddress = rotated.address("tark", rotatedKey).encode();
+        state.created = [];
+
+        await ensureOfferContracts(wallet, "http://ark", [
+            { offerHex: stale, swapAddress: fundedAddress },
+        ]);
+        expect(state.created.map((row) => row.script)).toEqual([hex.encode(rotated.pkScript)]);
+    });
+
+    it("falls back to the caller's key for a record with no address to pin", async () => {
+        // what the restore scan hands over: the key it classified with, which
+        // is the funded one after a rotation while the server's is not
+        const good = await unmarkedOffer();
+        const { swapPkScript: _, ...binding } = decodeOffer(hex.decode(good.offerHex));
+        const rotatedKey = schnorr.getPublicKey(hex.decode("7".repeat(64)));
+        const rotated = offerVtxoScript(binding, rotatedKey);
+        const stale = hex.encode(encodeOffer({ ...binding, swapPkScript: rotated.pkScript }));
+        state.created = [];
+
+        await ensureOfferContracts(wallet, "http://ark", [{ offerHex: stale }], {
+            serverPubkey: rotatedKey,
+        });
+        expect(state.created.map((row) => row.script)).toEqual([hex.encode(rotated.pkScript)]);
+    });
+
+    it("reads nothing off the server for an empty list", async () => {
+        state.created = [];
+        await ensureOfferContracts(wallet, "http://ark", []);
+        expect(state.created).toEqual([]);
     });
 });

--- a/packages/swap/test/restore.test.ts
+++ b/packages/swap/test/restore.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { base64, hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
-import { asset, Extension, Transaction, UnknownPacket } from "@arkade-os/sdk";
+import {
+    asset,
+    CSVMultisigTapscript,
+    Extension,
+    RestArkProvider,
+    Transaction,
+    UnknownPacket,
+} from "@arkade-os/sdk";
 import { encodeOffer, offerVtxoScript, Offer, OFFER_PACKET_TYPE } from "../src/offer";
 import {
     classifyDepositSpend,
@@ -389,6 +396,167 @@ describe("restoreAssetSwaps", () => {
             expect(restored.status).toBe(status);
             expect(restored.spentTxid).toBeUndefined();
         }
+    });
+
+    // AI-generated, and to be redone: written by Claude, kept for the coverage
+    // it gives the fix rather than for its shape. Rewrite by hand before
+    // reading it as the specification.
+    describe("with `cover`, a live restored deposit is the wallet's to watch again", () => {
+        // the wallet seam `ensureOfferContracts` writes through, and the server
+        // read it derives the row's address from
+        const coverage = () => {
+            const createContract = vi.fn(async (params: Record<string, unknown>) => ({
+                ...params,
+                state: "active",
+                createdAt: 0,
+            }));
+            const setContractWatchState = vi.fn(async (_s: string, _w: string) => {});
+            const wallet = {
+                identity: { xOnlyPublicKey: async () => MAKER_KEY },
+                getContractManager: async () => ({ createContract, setContractWatchState }),
+            } as any;
+            const info = vi.spyOn(RestArkProvider.prototype, "getInfo").mockResolvedValue({
+                signerPubkey: "02" + hex.encode(SERVER_KEY),
+                checkpointTapscript: hex.encode(
+                    CSVMultisigTapscript.encode({
+                        timelock: { type: "blocks", value: 10n },
+                        pubkeys: [SERVER_KEY],
+                    }).script,
+                ),
+                network: "regtest",
+            } as any);
+            return { wallet, createContract, setContractWatchState, info };
+        };
+
+        it("registers the covenant of a pending deposit, and not of a filled one", async () => {
+            const pending = makeOffer("want-asset", BigInt(992));
+            const filled = makeOffer("want-asset", BigInt(993));
+            const fundingPending = fundingPsbt(pending);
+            const fundingFilled = fundingPsbt(filled);
+            const fill = spendPsbt([
+                { offer: filled, deposit: { txid: fundingFilled.txid, vout: 0 }, via: "fulfill" },
+            ]);
+            const indexer = makeIndexer(
+                [fundingPending, fundingFilled, fill],
+                [
+                    depositVtxo(pending, fundingPending.txid),
+                    spentVtxo(filled, fundingFilled.txid, fill.txid),
+                ],
+            );
+            const { wallet, createContract, setContractWatchState, info } = coverage();
+            try {
+                const { restored } = await restoreAssetSwaps(
+                    indexer,
+                    [walletTx(fundingPending.txid, "sent"), walletTx(fundingFilled.txid, "sent")],
+                    new Set(),
+                    { serverPubkey: SERVER_KEY, cover: { wallet, arkServerUrl: "http://ark" } },
+                );
+                expect(restored.map((s) => s.status).sort()).toEqual(["fulfilled", "pending"]);
+
+                // the same row createOffer writes: script-keyed, escrowed
+                expect(createContract).toHaveBeenCalledTimes(1);
+                expect(createContract.mock.calls[0][0]).toMatchObject({
+                    type: "arkade",
+                    script: scriptOf(pending),
+                    metadata: { genericallySpendable: false, kind: "asset-swap-offer" },
+                });
+                expect(setContractWatchState.mock.calls).toEqual([[scriptOf(pending), "watched"]]);
+            } finally {
+                info.mockRestore();
+            }
+        });
+
+        it("hands the registration the key it classified with, not the server's current one", async () => {
+            // after a signer rotation the caller passes the funding-time key;
+            // a restored record has no swapAddress to pin it, so without the
+            // hand-off the rebuild under today's key refuses every record
+            const offer = makeOffer("want-asset", BigInt(992));
+            const funding = fundingPsbt(offer);
+            const { wallet, createContract, info } = coverage();
+            info.mockResolvedValue({
+                signerPubkey: "02" + hex.encode(key("44")),
+                checkpointTapscript: hex.encode(
+                    CSVMultisigTapscript.encode({
+                        timelock: { type: "blocks", value: 10n },
+                        pubkeys: [key("44")],
+                    }).script,
+                ),
+                network: "regtest",
+            } as any);
+            try {
+                await restoreAssetSwaps(
+                    makeIndexer([funding], [depositVtxo(offer, funding.txid)]),
+                    [walletTx(funding.txid, "sent")],
+                    new Set(),
+                    { serverPubkey: SERVER_KEY, cover: { wallet, arkServerUrl: "http://ark" } },
+                );
+                expect(createContract).toHaveBeenCalledTimes(1);
+                expect(createContract.mock.calls[0][0]).toMatchObject({ script: scriptOf(offer) });
+            } finally {
+                info.mockRestore();
+            }
+        });
+
+        it("covers a swept deposit too — still the user's money at that script", async () => {
+            const offer = makeOffer("want-asset", BigInt(992));
+            const funding = fundingPsbt(offer);
+            const vtxo = depositVtxo(offer, funding.txid, { virtualStatus: { state: "swept" } });
+            const { wallet, createContract, info } = coverage();
+            try {
+                const { restored } = await restoreAssetSwaps(
+                    makeIndexer([funding], [vtxo]),
+                    [walletTx(funding.txid, "sent")],
+                    new Set(),
+                    { serverPubkey: SERVER_KEY, cover: { wallet, arkServerUrl: "http://ark" } },
+                );
+                expect(restored[0].status).toBe("recoverable");
+                expect(createContract).toHaveBeenCalledTimes(1);
+            } finally {
+                info.mockRestore();
+            }
+        });
+
+        it("returns the record and marks the txid scanned when the registration fails", async () => {
+            // best effort: the record is the user's way to cancel; losing it to
+            // an offline server would be worse than a deposit unwatched until
+            // the watcher's next start covers it
+            const offer = makeOffer("want-asset", BigInt(992));
+            const funding = fundingPsbt(offer);
+            const { wallet, info } = coverage();
+            info.mockRejectedValue(new Error("server down"));
+            const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+            try {
+                const { restored, scannedTxids } = await restoreAssetSwaps(
+                    makeIndexer([funding], [depositVtxo(offer, funding.txid)]),
+                    [walletTx(funding.txid, "sent")],
+                    new Set(),
+                    { serverPubkey: SERVER_KEY, cover: { wallet, arkServerUrl: "http://ark" } },
+                );
+                expect(restored).toHaveLength(1);
+                expect(scannedTxids).toEqual([funding.txid]);
+                expect(warn).toHaveBeenCalledWith(
+                    expect.stringContaining("could not re-register"),
+                    expect.anything(),
+                );
+            } finally {
+                info.mockRestore();
+                warn.mockRestore();
+            }
+        });
+
+        it("touches no wallet without it", async () => {
+            const offer = makeOffer("want-asset", BigInt(992));
+            const funding = fundingPsbt(offer);
+            const { info } = coverage();
+            try {
+                await scan(makeIndexer([funding], [depositVtxo(offer, funding.txid)]), [
+                    walletTx(funding.txid, "sent"),
+                ]);
+                expect(info).not.toHaveBeenCalled();
+            } finally {
+                info.mockRestore();
+            }
+        });
     });
 
     it("leaves a spend it cannot classify unscanned, rather than guessing", async () => {

--- a/packages/swap/test/watch.test.ts
+++ b/packages/swap/test/watch.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { base64, hex } from "@scure/base";
 import { schnorr } from "@noble/curves/secp256k1.js";
-import { asset, ArkAddress, Transaction } from "@arkade-os/sdk";
-import { encodeOffer, offerVtxoScript, OFFER_CONTRACT_KIND, type Offer } from "../src/offer";
+import { asset, ArkAddress, CSVMultisigTapscript, Transaction } from "@arkade-os/sdk";
+import {
+    encodeOffer,
+    offerVtxoScript,
+    OFFER_CONTRACT_KIND,
+    OFFER_CONTRACT_LABEL,
+    type Offer,
+} from "../src/offer";
 import { InMemoryAssetSwapRepository } from "../src/repository";
 import { addAssetSwap, getAssetSwaps, type AssetSwap } from "../src/store";
 import { retireSettledOfferContracts } from "../src/coverage";
@@ -65,7 +71,19 @@ const makeWallet = (
     const callbacks = new Set<(event: any) => void>();
     // a real ark address, so ArkAddress.decode recovers SERVER_KEY from it
     const address = new ArkAddress(SERVER_KEY, key("66"), "tark").encode();
-    const setContractWatchState = vi.fn(async (_script: string, _watch: string) => {});
+    // the row's watch state, as the manager would report it back: the last
+    // write wins, and a script never written is watched (the default)
+    const watchOf = new Map<string, string>();
+    const setContractWatchState = vi.fn(async (script: string, watch: string) => {
+        watchOf.set(script, watch);
+    });
+    // what the start-up cover registers: `ensureOfferContracts` goes through
+    // the real ArkadeContract.register, which lands here
+    const createContract = vi.fn(async (params: Record<string, unknown>) => ({
+        ...params,
+        state: "active",
+        createdAt: 0,
+    }));
     const order: string[] = [];
     const getContractsWithVtxos = vi.fn(async (filter?: any) => {
         order.push("getContractsWithVtxos");
@@ -75,6 +93,8 @@ const makeWallet = (
     });
     const wallet = {
         getAddress: async () => address,
+        // Arkade.connect needs an identity; cover path uses it
+        identity: { xOnlyPublicKey: async () => MAKER_KEY },
         getContractManager: async () => ({
             onContractEvent: (cb: (event: any) => void) => {
                 order.push("onContractEvent");
@@ -82,19 +102,38 @@ const makeWallet = (
                 return () => callbacks.delete(cb);
             },
             setContractWatchState,
+            createContract,
             getContractsWithVtxos,
+            getContracts: async ({ script }: { script: string }) => [
+                { script, watch: watchOf.get(script) ?? "watched" },
+            ],
         }),
     } as any;
     return {
         wallet,
         getVirtualTxs,
         setContractWatchState,
+        createContract,
         getContractsWithVtxos,
         order,
         emit: (event: any) => callbacks.forEach((cb) => cb(event)),
         listeners: () => callbacks.size,
     };
 };
+
+/** What the start-up cover reads off the server: the signer key the offers
+ * above were built against, and a network to derive the row's address on. */
+const serverInfo = () => ({
+    signerPubkey: "02" + hex.encode(SERVER_KEY),
+    checkpointTapscript: hex.encode(
+        CSVMultisigTapscript.encode({
+            timelock: { type: "blocks", value: 10n },
+            pubkeys: [SERVER_KEY],
+        }).script,
+    ),
+    network: "regtest",
+    unilateralExitDelay: 4096n,
+});
 
 const spentEvent = (offer: Offer, spentTxid: string, overrides: Record<string, unknown> = {}) => ({
     type: "vtxo_spent",
@@ -115,21 +154,44 @@ const spentDeposit = (offer: Offer, spentTxid: string, vtxo: Record<string, unkn
     vtxos: [{ txid: FUNDING_TXID, vout: 0, isSpent: true, arkTxId: spentTxid, ...vtxo }],
 });
 
-// the watcher builds its own RestIndexerProvider from arkServerUrl; intercept
-// the one call it makes rather than reaching through the constructor
+// the watcher builds its own RestIndexerProvider from arkServerUrl, and the
+// start-up cover its own RestArkProvider; intercept the calls they make rather
+// than reaching through the constructors
+type Harness = ReturnType<typeof makeWallet>;
+
 const withIndexer = async (
     fetcher: (txids: string[]) => Promise<{ txs: string[] }>,
-    run: (harness: ReturnType<typeof makeWallet>) => Promise<void>,
-    contracts: any[] = [],
+    run: (harness: Harness) => Promise<void>,
+    contractsOrHooks:
+        | any[]
+        | {
+              contracts?: any[];
+              /** The server the cover reads; sees the harness so it can emit mid-cover. */
+              info?: (harness: Harness) => Promise<Record<string, unknown>>;
+              /** What the indexer reconcile finds at the script; nothing by default. */
+              vtxos?: () => Promise<{ vtxos: Record<string, unknown>[] }>;
+          } = [],
 ) => {
+    const hooks = Array.isArray(contractsOrHooks)
+        ? { contracts: contractsOrHooks }
+        : contractsOrHooks;
     const sdk = await import("@arkade-os/sdk");
+    const harness = makeWallet(fetcher, hooks.contracts ?? []);
     const spy = vi
         .spyOn(sdk.RestIndexerProvider.prototype, "getVirtualTxs")
         .mockImplementation(fetcher as any);
+    const vtxosSpy = vi
+        .spyOn(sdk.RestIndexerProvider.prototype, "getVtxos")
+        .mockImplementation((hooks.vtxos ?? (async () => ({ vtxos: [] }))) as any);
+    const infoSpy = vi
+        .spyOn(sdk.RestArkProvider.prototype, "getInfo")
+        .mockImplementation((() => (hooks.info ?? (async () => serverInfo()))(harness)) as any);
     try {
-        await run(makeWallet(fetcher, contracts));
+        await run(harness);
     } finally {
         spy.mockRestore();
+        vtxosSpy.mockRestore();
+        infoSpy.mockRestore();
     }
 };
 
@@ -342,6 +404,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up cover's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -374,6 +438,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up cover's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -407,6 +473,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up cover's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -434,6 +502,8 @@ describe("watchOfferSwaps", () => {
                     arkServerUrl: "http://ark",
                     repository,
                 });
+                // the start-up cover's own "watched" write is not what these assert on
+                setContractWatchState.mockClear();
                 emit(spentEvent(offer, fill.txid));
                 await watcher.idle();
                 watcher.stop();
@@ -604,6 +674,281 @@ describe("watchOfferSwaps", () => {
                 [row],
             );
         });
+    });
+
+    // The start-up cover / indexer-reconcile cases below were adapted from #854
+    // (Claude-written). Kept for the coverage they give the fix; rewrite by
+    // hand before reading them as the specification.
+    it("registers the covenant of every live record at start, and of no settled one", async () => {
+        const live = makeOffer();
+        const settled = makeOffer("want-btc");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(live));
+        await addAssetSwap(
+            repository,
+            swapFor(settled, {
+                id: "ee".repeat(32),
+                fundingTxid: "ee".repeat(32),
+                status: "fulfilled",
+            }),
+        );
+
+        await withIndexer(
+            async () => ({ txs: [] }),
+            async ({ wallet, createContract, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(createContract).toHaveBeenCalledTimes(1);
+                expect(createContract.mock.calls[0][0]).toMatchObject({
+                    type: "arkade",
+                    script: hex.encode(live.swapPkScript),
+                    label: OFFER_CONTRACT_LABEL,
+                    metadata: { genericallySpendable: false, kind: OFFER_CONTRACT_KIND },
+                });
+                // watched, without the issuance mark: a fill can retire it
+                expect(setContractWatchState).toHaveBeenCalledWith(
+                    hex.encode(live.swapPkScript),
+                    "watched",
+                );
+                expect(setContractWatchState).not.toHaveBeenCalledWith(
+                    hex.encode(settled.swapPkScript),
+                    "watched",
+                );
+            },
+        );
+    });
+
+    it("still resolves a fill after the fill retires a script the cover covered", async () => {
+        // cover sets no issuance mark, so the spend event's retire goes through
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                setContractWatchState.mockClear();
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([
+                    { status: "fulfilled", spentTxid: fill.txid },
+                ]);
+                expect(setContractWatchState).toHaveBeenCalledWith(
+                    hex.encode(offer.swapPkScript),
+                    "retained",
+                );
+            },
+        );
+    });
+
+    it("starts, and keeps classifying, when the cover cannot reach the server", async () => {
+        // best effort: an offline server at start costs coverage of restored
+        // records, never the watcher itself
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                emit(spentEvent(offer, fill.txid));
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([
+                    { status: "fulfilled", spentTxid: fill.txid },
+                ]);
+                expect(warn).toHaveBeenCalled();
+            },
+            {
+                info: async () => {
+                    throw new Error("server down");
+                },
+            },
+        );
+        warn.mockRestore();
+    });
+
+    it("resolves a deposit spent before the cover covered it, off the indexer", async () => {
+        // script was uncovered (the wallet was restored, then closed), so the
+        // manager has no contract row and resolveOpenSwaps sees nothing.
+        // The cover registers, then the indexer pass classifies the fill.
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([
+                    { status: "fulfilled", spentTxid: fill.txid },
+                ]);
+                expect(setContractWatchState).toHaveBeenCalledWith(
+                    hex.encode(offer.swapPkScript),
+                    "retained",
+                );
+            },
+            {
+                contracts: [], // manager knows nothing — cover + indexer must answer
+                vtxos: async () => ({
+                    vtxos: [
+                        {
+                            txid: FUNDING_TXID,
+                            vout: 0,
+                            script: hex.encode(offer.swapPkScript),
+                            virtualStatus: { state: "spent" },
+                            arkTxId: fill.txid,
+                        },
+                    ],
+                }),
+            },
+        );
+    });
+
+    it("marks a deposit swept before the cover covered it recoverable, and keeps its script", async () => {
+        const offer = makeOffer();
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [] }),
+            async ({ wallet, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "recoverable" }]);
+                // swept stays watched — RETIRABLE excludes recoverable
+                expect(setContractWatchState).toHaveBeenCalledWith(
+                    hex.encode(offer.swapPkScript),
+                    "watched",
+                );
+                expect(setContractWatchState).not.toHaveBeenCalledWith(
+                    hex.encode(offer.swapPkScript),
+                    "retained",
+                );
+            },
+            {
+                vtxos: async () => ({
+                    vtxos: [
+                        {
+                            txid: FUNDING_TXID,
+                            vout: 0,
+                            script: hex.encode(offer.swapPkScript),
+                            virtualStatus: { state: "swept" },
+                        },
+                    ],
+                }),
+            },
+        );
+    });
+
+    it("leaves a covered deposit that is still unspent pending", async () => {
+        const offer = makeOffer();
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [] }),
+            async ({ wallet }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([{ status: "pending" }]);
+            },
+            {
+                vtxos: async () => ({
+                    vtxos: [
+                        {
+                            txid: FUNDING_TXID,
+                            vout: 0,
+                            script: hex.encode(offer.swapPkScript),
+                            virtualStatus: { state: "settled" },
+                        },
+                    ],
+                }),
+            },
+        );
+    });
+
+    it("retires a script whose fill landed mid-cover, after the cover re-watched it", async () => {
+        // The race: the cover read its records (pending), a spend event lands
+        // and retires the script while the cover is still talking to the
+        // server, then the cover's own "watched" write comes last. Nothing
+        // would ever retire it again, so the cover re-derives liveness for
+        // the scripts it touched.
+        const offer = makeOffer();
+        const fill = spendPsbt(offer, "fulfill");
+        const repository = new InMemoryAssetSwapRepository();
+        await addAssetSwap(repository, swapFor(offer));
+
+        await withIndexer(
+            async () => ({ txs: [fill.psbt] }),
+            async ({ wallet, emit, setContractWatchState }) => {
+                const watcher = await watchOfferSwaps({
+                    wallet,
+                    arkServerUrl: "http://ark",
+                    repository,
+                });
+                // the event arrives while the cover is reading the server —
+                // simulated by emitting during info()
+                await watcher.idle();
+                watcher.stop();
+
+                expect(await getAssetSwaps(repository)).toMatchObject([
+                    { status: "fulfilled", spentTxid: fill.txid },
+                ]);
+                // last write must be retained, not watched-after-retire
+                const calls = setContractWatchState.mock.calls.map((c) => c[1]);
+                expect(calls[calls.length - 1]).toBe("retained");
+            },
+            {
+                info: async (harness) => {
+                    // emit mid-cover: watcher's subscription is already in place
+                    harness.emit(spentEvent(offer, fill.txid));
+                    return serverInfo();
+                },
+            },
+        );
     });
 });
 


### PR DESCRIPTION
## Goal
After restore or watcher start-up, live offer deposits are covered again (covenant registered with the funding-time server key) and deposits spent while nothing watched are reconciled.

## Why
Key-restore lost escrow visibility; fills that landed with no watcher left records stuck pending.

## Split note
Extracted from oversized #854 (bucket B). Depends on / complements #904 (maxSendable). Follow-up: solverd e2e (D).

## Overlap with master
Already on master (kept, not reverted):
- **#892** `restoreOfferCoverage` — re-cover covenants after restore (API retained; now uses `coverOfferContract` / landed path instead of `promoteOfferContract(issued: createdAt)`)
- **#893** `restoreAssetSwaps({ reopen })` — re-ask pending records (unchanged)
- **#895** `watchOfferSwaps` start-up `resolveOpenSwaps` + poll spend payload (kept; still the manager-view pass)
- **#896** markets cache — **skipped** (#854 markets/crossAsset hunks were A/#904 or superseded)

What this PR still adds from #854:
- `coverOfferContract` — watch a landed deposit without an issuance mark
- `ensureOfferContracts` — register uncovered offers with optional `swapAddress` / `serverPubkey` key pinning
- `restoreAssetSwaps({ cover })` — optional in-scan registration of live restored deposits
- Watcher start-up **re-registers** every live record (`pending`/`cancelling`/`recoverable`), then indexer reconcile (spent while uncovered + swept→recoverable) and `retireUntouchedScripts` race fix — on top of #895’s `resolveOpenSwaps`
- Unit tests for cover / ensure / restore `cover` / watch start-up sweep
- README “After a restore” (no maxSendable / solverd e2e ops)

## Test plan
- [x] coverage / register / restore cover units
- [x] watch start-up sweep + retire cases
- [x] pnpm swap unit tests (pre-commit: 864 passed)