### PR TITLE
fix(swap): support solver discovery 0.2.4

### DIFF
--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -77,7 +77,7 @@
     "license": "MIT",
     "dependencies": {
         "@arkade-os/sdk": "workspace:*",
-        "@arkade-os/solver-discovery": "0.2.3",
+        "@arkade-os/solver-discovery": "0.2.4",
         "@noble/ciphers": "2.1.1",
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",

--- a/packages/swap/src/markets.ts
+++ b/packages/swap/src/markets.ts
@@ -18,6 +18,7 @@ import {
     bestMarket,
     discover,
     isNetwork,
+    marketLegKey,
     sideLimits,
     type DiscoveredMarket,
     type LocalCardInput,
@@ -217,13 +218,13 @@ export const findMarket = (
         for (const market of markets) {
             for (const side of ["base", "quote"] as const) {
                 const asset = side === "base" ? market.base_asset : market.quote_asset;
-                if (asset.id === id) return id;
+                if (asset.id === id) return marketLegKey(market, side);
                 const canonical = marketAssetId(market, side) ?? "";
                 const matchesBtc =
                     id === BTC_ASSET_ID && /^arkade:[^/]+\/slip44:(?:0|1)$/.test(canonical);
                 const matchesAsset =
                     /^[0-9a-f]{68}$/.test(id) && canonical.endsWith(`/asset:${id}`);
-                if ((matchesBtc || matchesAsset) && typeof asset.id === "string") return asset.id;
+                if (matchesBtc || matchesAsset) return marketLegKey(market, side);
             }
         }
         return id;

--- a/packages/swap/src/payment/rendezvous.ts
+++ b/packages/swap/src/payment/rendezvous.ts
@@ -2,9 +2,9 @@
  * Choosing which solver to negotiate with. Both send corridors pick a card the
  * same way and differ only in the payout-side corridor they look for.
  */
-import { selectMarkets, sideLimits, type DiscoveredMarket } from "@arkade-os/solver-discovery";
+import { sideLimits, type DiscoveredMarket } from "@arkade-os/solver-discovery";
 import { hex } from "@scure/base";
-import { BTC_ASSET_ID } from "../store";
+import { marketAssetId, marketCorridor } from "../marketShape";
 
 const XONLY_HEX = /^[0-9a-f]{64}$/;
 
@@ -69,12 +69,16 @@ export const solverRendezvous = (
     // Corridor AND asset: both rails negotiate the hard-coded `arkade:BTC`
     // pair, so a corridor-only match bounds sats against another asset's
     // limits and burns — and leaks — a negotiation the solver refuses.
-    const candidates = selectMarkets(markets, {
-        baseId: BTC_ASSET_ID,
-        quoteId: BTC_ASSET_ID,
-        baseCorridor: "arkade",
-        quoteCorridor: payoutCorridor,
-    });
+    const quoteCorridor = payoutCorridor === "lightning" ? "bolt11" : "bitcoin";
+    const isBtc = (id: string | undefined): boolean =>
+        id === "btc" || /^\w+:[^/]+\/slip44:(?:0|1)$/.test(id ?? "");
+    const candidates = markets.filter(
+        (market) =>
+            marketCorridor(market, "base") === "arkade" &&
+            marketCorridor(market, "quote") === quoteCorridor &&
+            isBtc(marketAssetId(market, "base")) &&
+            isBtc(marketAssetId(market, "quote")),
+    );
 
     for (const market of candidates) {
         const rendezvous = rendezvousOf(market, pinned);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: workspace:*
         version: link:../ts-sdk
       '@arkade-os/solver-discovery':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: 0.2.4
+        version: 0.2.4
       '@noble/ciphers':
         specifier: 2.1.1
         version: 2.1.1
@@ -190,8 +190,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@arkade-os/solver-discovery@0.2.3':
-    resolution: {integrity: sha512-i77/BCAmHY4fec41HfYb5osu+QkCEOf2jLha1HX5pkp6bHGrm10WG8eOGREKqPCC4bOI3E8cKwEVGxP0qlNt5g==}
+  '@arkade-os/solver-discovery@0.2.4':
+    resolution: {integrity: sha512-iLjcZhnNmzndD6KLbgmMbyYL/JqmMYA2gSOn6MrESAMHWuF68CRtqn9ijvnDJDz8BzYXuFMZ/ghZfLjIvrdAdA==}
     engines: {node: '>=18'}
 
   '@babel/code-frame@7.10.4':
@@ -3852,7 +3852,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@arkade-os/solver-discovery@0.2.3': {}
+  '@arkade-os/solver-discovery@0.2.4': {}
 
   '@babel/code-frame@7.10.4':
     dependencies:


### PR DESCRIPTION
Updates @arkade-os/solver-discovery to 0.2.4 and adapts the stable swap routes to the canonical CAIP-19 selector API while preserving legacy card/index compatibility.\n\nVerification:\n- pnpm --filter @arkade-os/swap test:unit (886 passed)\n- pnpm --filter @arkade-os/swap typecheck\n- pnpm --filter @arkade-os/swap lint\n- pnpm --filter @arkade-os/swap build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap market matching for Bitcoin and asset-based markets.
  * Corrected payout corridor handling when selecting candidate swap markets.
  * Improved compatibility with Bitcoin assets represented through supported identifiers.

* **Maintenance**
  * Updated the solver discovery component to improve market resolution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->