### PR TITLE
fix(test): put the ts-sdk stack back on arkd v0.9.14

### DIFF
--- a/packages/ts-sdk/.env.regtest
+++ b/packages/ts-sdk/.env.regtest
@@ -1,7 +1,15 @@
 # ts-sdk arkade-regtest overrides
 
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.16
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.16
+# v0.9.14, NOT the v0.9.16 the other stacks run and the regtest submodule
+# defaults to. v0.9.16 is a security-hardening release, and this suite does not
+# yet satisfy it: settlement-delegation dies on `missing forfeit transactions`
+# and unilateralExit's graph mode reads 2 steps where it expects 0. The release
+# notes name the mechanism — "bind PSBT prevout metadata to the operator's own
+# records in forfeit path" and "ban participants that withhold forfeit
+# signatures". That is SDK work, not a fixture tweak, and it is tracked
+# separately; the swap stacks are green on v0.9.16 and stay there.
+ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.14
+ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.14
 
 # Resolves to base,ark,delegate,emulator. The default is every tier, which also
 # starts the solver, intent-solver, strfry and bucket-sync — none of which this


### PR DESCRIPTION
**master is red and this is the cause.** I bumped all three regtest overrides to
arkd v0.9.16 in #908. The swap stacks took it fine; the ts-sdk suite did not.

## Baseline vs now

Same workflow, same groups, one variable:

| run | commit | arkd | result |
|---|---|---|---|
| `34483778987` | `fe2c9eed` | v0.9.14 | **all 7 groups green** |
| `34490272673` | `06548eb4` | v0.9.16 | `ark-core`, `settlement-delegation`, `exit-providers-rotation` **failing**; both swap groups green |

## It is a migration, not a stale pin

The failures land exactly where v0.9.16's release notes say it hardened:

- *"Bind PSBT `prevout` metadata to the operator's own records in **forfeit path**"* (#10)
- *"**Ban participants that withhold forfeit signatures**"* (#93)

and the symptoms match: `settlement-delegation` dies on `INTERNAL_ERROR (0):
missing forfeit transactions`, `unilateralExit`'s graph mode reads 2 steps where
it expects 0.

master carries **no** v0.9.16 work anywhere (`git grep 0.9.16` on master is empty
outside lockfiles), and v0.9.16 additionally ships documented breaking changes —
the `client-lib` / `client-wallet` split. Making the SDK satisfy a
security-hardening release is its own piece of work, and #93 in particular
suggests a real SDK bug rather than a fixture needing adjustment.

## Scope

Only `packages/ts-sdk/.env.regtest` moves back to v0.9.14.

- `packages/swap/.env.regtest` and `.env.regtest.rfq` **stay on v0.9.16** — both
  proved green on it, and the rfq stack needs it for the intent solver.
- arkade-regtest's own `.env.defaults` stays on v0.9.16; its CI is green there.

So the arkd update holds everywhere it actually works, and the one place it does
not is now visible rather than buried in a red master.

## Follow-up this leaves open

Getting the ts-sdk suite onto v0.9.16. Worth treating as a security item, not
housekeeping: if #93 is rejecting our forfeit signatures, the SDK may be
withholding them in a case the old server tolerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the regtest environment to use compatible v0.9.14 service images.
  - Documented the current compatibility status of the v0.9.16 security-hardening release and tracked follow-up work separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->