### PR TITLE
fix: schedule delegation before VTXO expiry

### DIFF
--- a/packages/ts-sdk/src/wallet/delegate.ts
+++ b/packages/ts-sdk/src/wallet/delegate.ts
@@ -222,9 +222,8 @@ export type DelegatorManagerImpl = DelegateManagerImpl;
  * Delegates virtual outputs to a delegation service, allowing them to manage their renewal
  * on behalf of the wallet owner.
  * @param vtxos - Array of extended virtual outputs to delegate. Must not be empty.
- * @param delegateAt - Optional Date specifying when the delegation
- *                     should occur. If not provided, defaults to 12 hours before the earliest
- *                     expiry time of the provided vtxos.
+ * @param delegateAt - Optional delegation time. By default, scheduling leaves at least 10% of
+ *                     the remaining lifetime and one operator session before the earliest expiry.
  */
 async function delegate(
     identity: Identity,
@@ -252,13 +251,7 @@ async function delegate(
             // if no expiry (recoverable virtual outputs), delegate 1 minute from now
             delegateAt = new Date(Date.now() + 1 * 60 * 1000);
         } else {
-            const remainingTimeMs = expiryTimestamp - Date.now();
-            if (remainingTimeMs <= 0) {
-                delegateAt = new Date(Date.now() + 1 * 60 * 1000);
-            } else {
-                // delegate 10% before the expiry
-                delegateAt = new Date(expiryTimestamp - remainingTimeMs * 0.1);
-            }
+            delegateAt = defaultDelegateAt(expiryTimestamp, arkInfo.sessionDuration);
         }
     }
     const { fees, dust, forfeitAddress, network } = arkInfo;
@@ -465,6 +458,19 @@ async function makeSignedDelegateIntent(
         proof: base64.encode(signedProof.toPSBT()),
         message,
     };
+}
+
+export function defaultDelegateAt(
+    expiryTimestamp: number,
+    sessionDurationSeconds: bigint,
+    now = Date.now(),
+): Date {
+    const remainingTimeMs = expiryTimestamp - now;
+    if (remainingTimeMs <= 0) return new Date(now + 60_000);
+
+    const sessionLeadMs = Number(sessionDurationSeconds * 1000n);
+    const leadTimeMs = Math.max(remainingTimeMs * 0.1, sessionLeadMs);
+    return new Date(Math.max(now + 2_000, expiryTimestamp - leadTimeMs));
 }
 
 /**

--- a/packages/ts-sdk/src/wallet/delegate.ts
+++ b/packages/ts-sdk/src/wallet/delegate.ts
@@ -470,7 +470,8 @@ export function defaultDelegateAt(
 
     const sessionLeadMs = Number(sessionDurationSeconds * 1000n);
     const leadTimeMs = Math.max(remainingTimeMs * 0.1, sessionLeadMs);
-    return new Date(Math.max(now + 2_000, expiryTimestamp - leadTimeMs));
+    const delegateAt = expiryTimestamp - leadTimeMs;
+    return new Date(delegateAt > now ? delegateAt : now + 2_000);
 }
 
 /**

--- a/packages/ts-sdk/test/wallet/delegate.test.ts
+++ b/packages/ts-sdk/test/wallet/delegate.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from "vitest";
-import { findDestinationOutputIndex } from "../../src/wallet/delegate";
+import { defaultDelegateAt, findDestinationOutputIndex } from "../../src/wallet/delegate";
+
+describe("defaultDelegateAt", () => {
+    const now = Date.UTC(2026, 0, 1);
+
+    it("uses ten percent of a long remaining lifetime", () => {
+        expect(defaultDelegateAt(now + 1_000_000, 30n, now).getTime()).toBe(now + 900_000);
+    });
+
+    it("leaves a full server session when it is longer than ten percent", () => {
+        expect(defaultDelegateAt(now + 120_000, 30n, now).getTime()).toBe(now + 90_000);
+    });
+
+    it("uses a short scheduling margin when less than one server session remains", () => {
+        expect(defaultDelegateAt(now + 20_000, 30n, now).getTime()).toBe(now + 2_000);
+    });
+});
 
 describe("findDestinationOutputIndex", () => {
     const scriptA = new Uint8Array([0x00, 0x14, 0xaa, 0xbb]);

--- a/packages/ts-sdk/test/wallet/delegate.test.ts
+++ b/packages/ts-sdk/test/wallet/delegate.test.ts
@@ -12,6 +12,10 @@ describe("defaultDelegateAt", () => {
         expect(defaultDelegateAt(now + 120_000, 30n, now).getTime()).toBe(now + 90_000);
     });
 
+    it("preserves the full server session at the short-lifetime boundary", () => {
+        expect(defaultDelegateAt(now + 31_000, 30n, now).getTime()).toBe(now + 1_000);
+    });
+
     it("uses a short scheduling margin when less than one server session remains", () => {
         expect(defaultDelegateAt(now + 20_000, 30n, now).getTime()).toBe(now + 2_000);
     });


### PR DESCRIPTION
Fix the arkd v0.9.16 auto-delegation failure without downgrading arkd or upgrading discontinued Fulmine.\n\nThe default delegation time now leaves at least one advertised operator session before expiry while retaining the existing 10% lead for normal lifetimes. Short regtest lifetimes use the reference SDK's two-second scheduling margin. The regtest fixture now funds the Ark CLI through a real confirmed boarding deposit instead of server-issued notes, via ArkLabsHQ/arkade-regtest#66.\n\nLocal verification: full build passed; full monorepo unit suite passed; affected e2e group passed all 23 tests across 7 files against arkd v0.9.16; arkade-regtest #66 smoke passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved default scheduling for delegations when no delegation time is specified.
  - Delegations now account for the operator session duration, remaining expiry time, and a minimum two-second lead time.
  - Added a public utility for calculating the default delegation time.
- **Bug Fixes**
  - Updated delegation timing behavior for short-lived and expiring authorizations to improve scheduling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->