### PR TITLE
Enforce negotiated Lightning send refund delay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,35 +143,10 @@ jobs:
       - name: Build ts-sdk
         run: pnpm -C packages/ts-sdk build
 
-      # The RFQ client and solver share a fail-closed quote contract. Until the
-      # matching solver change is released, exercising this SDK head against
-      # the last published image would only prove that mixed versions reject
-      # each other. Build the exact reviewed solver revision so this matrix
-      # continues to test the corridor itself, with no mutable branch or image
-      # tag hidden in the result.
-      - name: Check out matching intent solver
-        if: matrix.package == 'swap-rfq'
-        uses: actions/checkout@v6
-        with:
-          repository: arkade-os/intent-solver
-          ref: 173c5672216d3ed65baf428825bc0362f944a5be
-          path: .integration/intent-solver
-          persist-credentials: false
-
-      - name: Build matching intent solver image
-        if: matrix.package == 'swap-rfq'
-        run: >-
-          docker build
-          -f .integration/intent-solver/packages/solver-app/Dockerfile
-          -t intent-solver:refund-timing
-          .integration/intent-solver
-
       - name: Make regtest controller executable
         run: chmod +x scripts/regtest.sh
 
       - name: Start regtest environment
-        env:
-          INTENT_SOLVER_IMAGE: ${{ matrix.package == 'swap-rfq' && 'intent-solver:refund-timing' || '' }}
         run: pnpm run regtest:up:${{ matrix.package }}
 
       - name: Setup test wallets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,35 @@ jobs:
       - name: Build ts-sdk
         run: pnpm -C packages/ts-sdk build
 
+      # The RFQ client and solver share a fail-closed quote contract. Until the
+      # matching solver change is released, exercising this SDK head against
+      # the last published image would only prove that mixed versions reject
+      # each other. Build the exact reviewed solver revision so this matrix
+      # continues to test the corridor itself, with no mutable branch or image
+      # tag hidden in the result.
+      - name: Check out matching intent solver
+        if: matrix.package == 'swap-rfq'
+        uses: actions/checkout@v6
+        with:
+          repository: arkade-os/intent-solver
+          ref: 173c5672216d3ed65baf428825bc0362f944a5be
+          path: .integration/intent-solver
+          persist-credentials: false
+
+      - name: Build matching intent solver image
+        if: matrix.package == 'swap-rfq'
+        run: >-
+          docker build
+          -f .integration/intent-solver/packages/solver-app/Dockerfile
+          -t intent-solver:refund-timing
+          .integration/intent-solver
+
       - name: Make regtest controller executable
         run: chmod +x scripts/regtest.sh
 
       - name: Start regtest environment
+        env:
+          INTENT_SOLVER_IMAGE: ${{ matrix.package == 'swap-rfq' && 'intent-solver:refund-timing' || '' }}
         run: pnpm run regtest:up:${{ matrix.package }}
 
       - name: Setup test wallets

--- a/packages/swap/src/rfq.ts
+++ b/packages/swap/src/rfq.ts
@@ -34,7 +34,8 @@
  *
  * Trust model, identical to the offer side: from a quote the user uses only
  * the binding fields — `solver_pubkey`, `refund_locktime`, `valid_until`, the
- * amounts. Every other contract parameter is the user's own data (its
+ * amounts, and `profile.refund_without_receiver_delay` on Lightning sends.
+ * Every other contract parameter is the user's own data (its
  * invoice, its Ark server connection, its refund address) or a trusted
  * constant — the emulator key defaults to the SDK's per-network pin (see
  * `resolveEmulatorPubkey`). Anything address-shaped the solver sends is
@@ -288,7 +289,12 @@ export interface RfqQuote {
     valid_until: number;
     /** HTLC-class quotes only; absent for arkade↔arkade. */
     refund_locktime?: number;
-    profile: { [key: string]: unknown; payment_hash?: string; lockup_address?: string };
+    profile: {
+        [key: string]: unknown;
+        payment_hash?: string;
+        lockup_address?: string;
+        refund_without_receiver_delay?: number;
+    };
     [key: string]: unknown;
 }
 
@@ -974,6 +980,8 @@ export function lightningSendVtxoScript(params: {
      * {@link unilateralRefundDelay} and {@link unilateralRefundWithoutReceiverDelay}
      * derive from this same value — one rounding, shared across all three tiers. */
     claimDelay: number;
+    /** Binding quote field. Optional only for rebuilding pre-upgrade scripts. */
+    refundWithoutReceiverDelay?: number;
     /** Emulator x-only key (32 bytes). */
     emulatorPubkey: Uint8Array;
     /** Where a refund must pay: the trader's P2TR pkScript (34 bytes). Also
@@ -1007,7 +1015,8 @@ export function lightningSendVtxoScript(params: {
         unilateralClaimDelay: seconds(params.claimDelay),
         unilateralRefundDelay: seconds(unilateralRefundDelay(params.claimDelay)),
         unilateralRefundWithoutReceiverDelay: seconds(
-            unilateralRefundWithoutReceiverDelay(params.claimDelay),
+            params.refundWithoutReceiverDelay ??
+                unilateralRefundWithoutReceiverDelay(params.claimDelay),
         ),
         nonInteractiveParameters: {
             receiverPkScript: params.receiverPkScript,
@@ -1133,6 +1142,23 @@ export async function requestLightningSend(
     if (quote.refund_locktime === undefined) {
         throw new Error("lightning-send quote is missing refund_locktime");
     }
+    const now = Math.floor(Date.now() / 1000);
+    const claimDelay = unilateralClaimDelay(Number(info.unilateralExitDelay));
+    const refundWithoutReceiverDelay = quote.profile?.refund_without_receiver_delay;
+    if (refundWithoutReceiverDelay === undefined) {
+        throw new Error("lightning-send quote is missing profile.refund_without_receiver_delay");
+    }
+    if (
+        !Number.isSafeInteger(refundWithoutReceiverDelay) ||
+        refundWithoutReceiverDelay < claimDelay ||
+        refundWithoutReceiverDelay % SEQUENCE_GRANULARITY_SECONDS !== 0 ||
+        refundWithoutReceiverDelay > 0xffff * SEQUENCE_GRANULARITY_SECONDS
+    ) {
+        throw new Error("lightning-send quote carries an invalid refund_without_receiver_delay");
+    }
+    if (refundWithoutReceiverDelay < quote.refund_locktime - now) {
+        throw new Error("lightning-send quote lets the solo refund open before refund_locktime");
+    }
     const receiverPkScriptHex = quote.profile?.receiver_pk_script as string | undefined;
     if (receiverPkScriptHex === undefined) {
         throw new Error("lightning-send quote is missing profile.receiver_pk_script");
@@ -1161,7 +1187,8 @@ export async function requestLightningSend(
         refundLocktime: quote.refund_locktime,
         serverPubkey,
         paymentHash: params.invoice.paymentHash,
-        claimDelay: unilateralClaimDelay(Number(info.unilateralExitDelay)),
+        claimDelay,
+        refundWithoutReceiverDelay,
         emulatorPubkey: toXOnly(
             hex.decode(resolveEmulatorPubkey(network, params.emulatorPubkey)),
             "emulator signer key",
@@ -1186,7 +1213,7 @@ export async function requestLightningSend(
     assertFundable({
         quote,
         invoiceExpiresAt: params.invoice.expiresAt,
-        now: Math.floor(Date.now() / 1000),
+        now,
     });
 
     // Last, so a refused quote leaves no row behind, but still before the

--- a/packages/swap/test/e2e/rfqRegister.test.ts
+++ b/packages/swap/test/e2e/rfqRegister.test.ts
@@ -106,12 +106,14 @@ const stubTransport = (): RfqTransport => ({
     async requestQuote(payload) {
         const profile = (payload as { profile: Record<string, unknown> }).profile;
         const refundLocktime = NOW() + 24 * 3600;
+        const refundWithoutReceiverDelay = Math.ceil((24 * 3600) / 512) * 512;
         const script = lightningSendVtxoScript({
             solverPubkey: SOLVER,
             refundLocktime,
             serverPubkey: operatorPubkey,
             paymentHash: PAYMENT_HASH,
             claimDelay,
+            refundWithoutReceiverDelay,
             emulatorPubkey,
             senderPubkey: hex.decode(profile.client_refund_pubkey as string),
             receiverPkScript: RECEIVER_PK_SCRIPT,
@@ -130,6 +132,7 @@ const stubTransport = (): RfqTransport => ({
             profile: {
                 receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
                 lockup_address: script.address(hrp, operatorPubkey).encode(),
+                refund_without_receiver_delay: refundWithoutReceiverDelay,
             },
         } satisfies RfqQuote;
     },

--- a/packages/swap/test/emulatorTrustBoundary.test.ts
+++ b/packages/swap/test/emulatorTrustBoundary.test.ts
@@ -97,6 +97,7 @@ const VALID_UNTIL = NOW + 3600;
 // gate (all bounded in hours) — the fixture never needs tuning against those
 // margins.
 const REFUND_LOCKTIME = NOW + 60 * 24 * 3600;
+const REFUND_WITHOUT_RECEIVER_DELAY = REFUND_LOCKTIME - NOW;
 const HTLC_LOCKTIME = NOW + 30 * 24 * 3600;
 
 const wallet = {
@@ -133,6 +134,7 @@ const lightningTransport = (forEmulatorPubkey: Uint8Array): RfqTransport => ({
             serverPubkey: SERVER,
             paymentHash: PAYMENT_HASH,
             claimDelay: 4096,
+            refundWithoutReceiverDelay: REFUND_WITHOUT_RECEIVER_DELAY,
             emulatorPubkey: forEmulatorPubkey,
             senderPubkey,
             receiverPkScript: RECEIVER_PK_SCRIPT,
@@ -151,6 +153,7 @@ const lightningTransport = (forEmulatorPubkey: Uint8Array): RfqTransport => ({
             profile: {
                 receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
                 lockup_address: script.address("tark", SERVER).encode(),
+                refund_without_receiver_delay: REFUND_WITHOUT_RECEIVER_DELAY,
             },
         } satisfies RfqQuote;
     },

--- a/packages/swap/test/rfq.test.ts
+++ b/packages/swap/test/rfq.test.ts
@@ -58,6 +58,7 @@ const quoteFixture = (over: Partial<RfqQuote> = {}): RfqQuote => ({
     profile: {
         payment_hash: "da".repeat(32),
         lockup_address: "ark1qexample",
+        refund_without_receiver_delay: 277_504,
         receiver_pk_script: hex.encode(p2tr(key(1))),
     },
     ...over,

--- a/packages/swap/test/rfqDerivedSecrets.test.ts
+++ b/packages/swap/test/rfqDerivedSecrets.test.ts
@@ -72,6 +72,7 @@ state.arkInfo.signerPubkey = hex.encode(SERVER);
 const NOW = Math.floor(Date.now() / 1000);
 const VALID_UNTIL = NOW + 3600;
 const REFUND_LOCKTIME = NOW + 60 * 24 * 3600;
+const REFUND_WITHOUT_RECEIVER_DELAY = REFUND_LOCKTIME - NOW;
 const HTLC_LOCKTIME = NOW + 30 * 24 * 3600;
 
 /** A wallet backed by the real allocator and the real deterministic signer. */
@@ -112,7 +113,7 @@ const staticWallet = (rows: { params: Record<string, string> }[] = []): IWallet 
     }) as unknown as IWallet;
 
 /** Quotes back whatever the maker derived, so the flow reaches its gates. */
-const lightningTransport = (): RfqTransport => ({
+const lightningTransport = (profileOverrides: Record<string, unknown> = {}): RfqTransport => ({
     async requestQuote(payload) {
         const profile = (payload as { profile: Record<string, unknown> }).profile;
         const script = lightningSendVtxoScript({
@@ -121,6 +122,7 @@ const lightningTransport = (): RfqTransport => ({
             serverPubkey: SERVER,
             paymentHash: PAYMENT_HASH,
             claimDelay: 4096,
+            refundWithoutReceiverDelay: REFUND_WITHOUT_RECEIVER_DELAY,
             emulatorPubkey: EMULATOR_PUBKEY,
             senderPubkey: hex.decode(profile.client_refund_pubkey as string),
             receiverPkScript: RECEIVER_PK_SCRIPT,
@@ -139,6 +141,8 @@ const lightningTransport = (): RfqTransport => ({
             profile: {
                 receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
                 lockup_address: script.address("tark", SERVER).encode(),
+                refund_without_receiver_delay: REFUND_WITHOUT_RECEIVER_DELAY,
+                ...profileOverrides,
             },
         } satisfies RfqQuote;
     },
@@ -219,6 +223,7 @@ describe("requestLightningSend and the corridor spread", () => {
                 serverPubkey: SERVER,
                 paymentHash: PAYMENT_HASH,
                 claimDelay: 4096,
+                refundWithoutReceiverDelay: REFUND_WITHOUT_RECEIVER_DELAY,
                 emulatorPubkey: EMULATOR_PUBKEY,
                 senderPubkey: hex.decode(profile.client_refund_pubkey as string),
                 receiverPkScript: RECEIVER_PK_SCRIPT,
@@ -237,6 +242,7 @@ describe("requestLightningSend and the corridor spread", () => {
                 profile: {
                     receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
                     lockup_address: script.address("tark", SERVER).encode(),
+                    refund_without_receiver_delay: REFUND_WITHOUT_RECEIVER_DELAY,
                 },
             } satisfies RfqQuote;
         },
@@ -244,6 +250,28 @@ describe("requestLightningSend and the corridor spread", () => {
             return null;
         },
         async close() {},
+    });
+
+    it("refuses an old solver quote with no negotiated solo-refund delay", async () => {
+        await expect(
+            requestLightningSend(
+                await hdWallet(),
+                "http://ark",
+                lightningTransport({ refund_without_receiver_delay: undefined }),
+                { emulatorPubkey: EMULATOR_PUBKEY_HEX, invoice: INVOICE },
+            ),
+        ).rejects.toThrow(/missing profile\.refund_without_receiver_delay/);
+    });
+
+    it("refuses a solo-refund delay that opens before the absolute refund", async () => {
+        await expect(
+            requestLightningSend(
+                await hdWallet(),
+                "http://ark",
+                lightningTransport({ refund_without_receiver_delay: 8192 }),
+                { emulatorPubkey: EMULATOR_PUBKEY_HEX, invoice: INVOICE },
+            ),
+        ).rejects.toThrow(/solo refund open before refund_locktime/);
     });
 
     it("funds from_amount — the invoice PLUS the fee, never the bare invoice", async () => {

--- a/packages/swap/test/rfqRegister.test.ts
+++ b/packages/swap/test/rfqRegister.test.ts
@@ -83,6 +83,7 @@ state.arkInfo.signerPubkey = hex.encode(SERVER);
 const NOW = Math.floor(Date.now() / 1000);
 const VALID_UNTIL = NOW + 3600;
 const REFUND_LOCKTIME = NOW + 60 * 24 * 3600;
+const REFUND_WITHOUT_RECEIVER_DELAY = REFUND_LOCKTIME - NOW;
 const HTLC_LOCKTIME = NOW + 30 * 24 * 3600;
 
 const PAYMENT_HASH = "ab".repeat(32);
@@ -103,6 +104,7 @@ const lightningTransport = (): RfqTransport => ({
             serverPubkey: SERVER,
             paymentHash: PAYMENT_HASH,
             claimDelay: 4096,
+            refundWithoutReceiverDelay: REFUND_WITHOUT_RECEIVER_DELAY,
             emulatorPubkey: EMULATOR_PUBKEY,
             senderPubkey: hex.decode(profile.client_refund_pubkey as string),
             receiverPkScript: RECEIVER_PK_SCRIPT,
@@ -121,6 +123,7 @@ const lightningTransport = (): RfqTransport => ({
             profile: {
                 receiver_pk_script: hex.encode(RECEIVER_PK_SCRIPT),
                 lockup_address: script.address("tark", SERVER).encode(),
+                refund_without_receiver_delay: REFUND_WITHOUT_RECEIVER_DELAY,
             },
         } satisfies RfqQuote;
     },


### PR DESCRIPTION
## Summary
- consume the solver-negotiated refund-without-receiver delay
- validate its BIP68 encoding and absolute refund coverage before returning a fundable lockup
- fail closed against pre-upgrade solver quotes missing the field

The same change is integrated into feat/v0.5 at e126e87f.

## Verification
- pnpm -r lint
- pnpm -r build
- pnpm -r test:unit
- swap tests: 40 files, 896 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Lightning send quotes now support a configurable refund delay.
  * Refund timing is validated against claim and locktime requirements before processing.
  * Legacy quote rebuilds retain a derived fallback delay.

* **Bug Fixes**
  * Prevented invalid or missing refund delays from being accepted during Lightning send requests.
  * Improved consistency by using a single captured timestamp for timing checks and funding gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->